### PR TITLE
Fixed typos in ORM section

### DIFF
--- a/_partials/project/orm/hero-text.html.haml
+++ b/_partials/project/orm/hero-text.html.haml
@@ -1,2 +1,2 @@
 %p
-  Idomatic persistence for Java and relational databases.
+  Idiomatic persistence for Java and relational databases.

--- a/_partials/project/search/hero-text.html.haml
+++ b/_partials/project/search/hero-text.html.haml
@@ -1,4 +1,4 @@
 %p
   Hibernate Search transparently indexes your objects
-  and offer fast regular, full-text and geolocation search.
+  and offers fast regular, full-text and geolocation search.
   Ease of use and easy clustering are core.

--- a/orm/index.html.haml
+++ b/orm/index.html.haml
@@ -13,14 +13,14 @@ title_partial: project/title-about.html.haml
         :asciidoc
           === Object/Relational Mapping
 
-          Hibernate enables developers to more esily write applications whose data outlives the application process.  As an Object/Relational Mapping (ORM) framework, Hibernate is concerned with data persistence as it applies to relational databases (via JDBC).
+          Hibernate enables developers to more easily write applications whose data outlives the application process.  As an Object/Relational Mapping (ORM) framework, Hibernate is concerned with data persistence as it applies to relational databases (via JDBC).
 
     .row-fluid
       .span12.feature-block
         :asciidoc
           === JPA Provider
           
-          In addition to its own "native" API, Hibernate is also an implementation of the Java Persistence API (JPA) specification.  As such, it can be esily used in any environment supporting JPA includng Java SE aplications, Java EE aplication servers, Enterprise OSGi containers, etc.
+          In addition to its own "native" API, Hibernate is also an implementation of the Java Persistence API (JPA) specification.  As such, it can be easily used in any environment supporting JPA including Java SE applications, Java EE application servers, Enterprise OSGi containers, etc.
 
     .row-fluid
       .span12.feature-block
@@ -34,9 +34,9 @@ title_partial: project/title-about.html.haml
         :asciidoc
           === High Performance
 
-          Hibernate supports lazy initialization, numerous fetching strategies and optimistic locking with automatic versioning and time stamping. Hibernate requires no special database tables or fields and generates much of the SQL at system initialization time instead of runtime. 
+          Hibernate supports lazy initialization, numerous fetching strategies and optimistic locking with automatic versioning and time stamping. Hibernate requires no special database tables or fields and generates much of the SQL at system initialization time instead of at runtime. 
 
-          Hibernate consistently offers superior performance over straight JDBC coding both in terms of developer productivity and runtime performance.
+          Hibernate consistently offers superior performance over straight JDBC code, both in terms of developer productivity and runtime performance.
 
     .row-fluid
       .span12.feature-block


### PR DESCRIPTION
This just fixes a few minor typos in the ORM section.
