### PR TITLE
WEBSITE-180 Add default landing page for lost content

### DIFF
--- a/community/we-lost-that-content.adoc
+++ b/community/we-lost-that-content.adoc
@@ -1,0 +1,20 @@
+= Looks like we lost the content you are looking for
+Emmanuel Bernard
+:awestruct-layout: community-frame
+
+== What?
+
+You are clicking on an old, very old URL.
+Most likely older than 2006.
+You know before iPhones even existed. 
+Unfortunately, we lost its content
+and we no longer have any decent replacement to point to.
+
+== Where can I go now?
+
+Your best bet is to start from the link:/[home page].
+We did put a lot of effort to this new website and its navigation.
+And of course a well crafted Google query is your friend.
+
+And we highly encourage you to migrate to a more recent version of our software.
+We did improve it a lot since 2006 :)


### PR DESCRIPTION
A lost content is an _identified_ content / URL we know we no longer
have any replacement or redirection for. It is generally from the old
cwiki website. Use it to identify URLs that should not be reported
as missing (404).
