### PR TITLE
Point the latest stable documentation to the /stable/ url.

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -21,7 +21,8 @@ projects:
     zip_file: hibernate-release-VERSION.zip
     group_id: org.hibernate
     artifact_id: hibernate-core
-    reference_doc_prefix_url: http://docs.jboss.org/hibernate/orm/
+    reference_doc_prefix_url: https://docs.jboss.org/hibernate/orm/
+    stable_reference_doc_prefix_url: https://docs.jboss.org/hibernate/stable/orm/
     reference_doc_type: manual
     reference_pdf:
     javadoc_path: javadocs
@@ -109,7 +110,8 @@ projects:
     zip_file: hibernate-search-VERSION-dist.zip
     group_id: org.hibernate
     artifact_id: hibernate-search-orm
-    reference_doc_prefix_url: http://docs.jboss.org/hibernate/search/
+    reference_doc_prefix_url: https://docs.jboss.org/hibernate/search/
+    stable_reference_doc_prefix_url: https://docs.jboss.org/hibernate/stable/search/
     reference_doc_type: reference
     reference_pdf: hibernate_search_reference.pdf
     javadoc_path: api
@@ -173,7 +175,8 @@ projects:
     #zip_file: hibernate-search-VERSION-dist.zip
     #group_id: org.hibernate
     #artifact_id: hibernate-search
-    #reference_doc_prefix_url: http://docs.jboss.org/hibernate/search/
+    #reference_doc_prefix_url: https://docs.jboss.org/hibernate/search/
+    #stable_reference_doc_prefix_url: https://docs.jboss.org/hibernate/stable/search/
     #reference_doc_type: reference
     #reference_pdf: hibernate_search_reference.pdf
     #javadoc_path: api
@@ -235,7 +238,8 @@ projects:
     zip_file: hibernate-validator-VERSION-dist.zip
     group_id: org.hibernate
     artifact_id: hibernate-validator
-    reference_doc_prefix_url: http://docs.jboss.org/hibernate/validator/
+    reference_doc_prefix_url: https://docs.jboss.org/hibernate/validator/
+    stable_reference_doc_prefix_url: https://docs.jboss.org/hibernate/stable/validator/
     reference_doc_type: reference
     reference_pdf: hibernate_validator_reference.pdf
     javadoc_path: api
@@ -301,7 +305,8 @@ projects:
     zip_file: hibernate-ogm-VERSION-dist.zip
     group_id: org.hibernate.ogm
     artifact_id: hibernate-ogm-*
-    reference_doc_prefix_url: http://docs.jboss.org/hibernate/ogm/
+    reference_doc_prefix_url: https://docs.jboss.org/hibernate/ogm/
+    stable_reference_doc_prefix_url: https://docs.jboss.org/hibernate/stable/ogm/
     reference_doc_type: reference
     reference_pdf: hibernate_ogm_reference.pdf
     javadoc_path: api

--- a/_layouts/project/project-documentation.html.haml
+++ b/_layouts/project/project-documentation.html.haml
@@ -8,6 +8,7 @@ layout: project-frame
 -# Metadata from site.yml for the project
 - project_description = site.projects[page.project]
 - get_started_url = site.projects[page.project].getting_started.nil? ? nil : relative("#{site.projects[page.project].getting_started}", page)
+- stable_documentation_url = "#{project_description.stable_reference_doc_prefix_url}#{project_description.reference_doc_type}/en-US/html_single/"
 
 -# Documentation buttons using the latest dev and latest stable releases
 .release-bottons.hidden-phone
@@ -17,7 +18,7 @@ layout: project-frame
       %a.btn.btn-large{:href => "#{get_started_url}"} Getting started guide
     - if not stable_release.nil?
       &nbsp;
-      %a.btn.btn-large.btn-success{:href => "#{project_description.reference_doc_prefix_url}#{stable_release.version_family}/#{project_description.reference_doc_type}/en-US/html/"} Get documentation for #{stable_release.version}
+      %a.btn.btn-large.btn-success{:href => "#{stable_documentation_url}"} Get documentation for #{stable_release.version}
 .release-bottons.visible-phone
   - stable_release = latest_stable_release(page)
   - if not get_started_url.nil?
@@ -27,19 +28,25 @@ layout: project-frame
     - if not stable_release.nil?
       .row-fluid.text-center
         #documentation-button
-          %a.btn.btn-success{:href => "#{project_description.reference_doc_prefix_url}#{stable_release.version_family}/#{project_description.reference_doc_type}/en-US/html/"} Get documentation for #{stable_release.version}
+          %a.btn.btn-success{:href => "#{stable_documentation_url}"} Get documentation for #{stable_release.version}
 .row-fluid
   .span12
-    -# Documentation table built form the metadata
+    -# Documentation table built from the metadata
     %h2 Reference documentation
     - if not site.projects[page.project].sorted_releases.nil?
+      - first_stable_release = true
       - site.projects[page.project].sorted_releases.each do |release|
         - if release.displayed
+          - if release.stable && first_stable_release
+            - doc_root_url = "#{project_description.stable_reference_doc_prefix_url}"
+            - first_stable_release = false
+          - else
+            - doc_root_url = "#{project_description.reference_doc_prefix_url}#{release.version_family}/"
           %dl.dl-horizontal
             %dt
               = release.version
               &nbsp;
-              %a.btn.btn-info{:href => "#{project_description.reference_doc_prefix_url}#{release.version_family}/#{  project_description.reference_doc_type}/en-US/html/"}
+              %a.btn.btn-info{:href => "#{doc_root_url}#{project_description.reference_doc_type}/en-US/html_single/"}
                 %i.icon-book
             %dd
               %small= release.date
@@ -50,18 +57,18 @@ layout: project-frame
               %ul
                 %li
                   English reference documentation:
-                  %a{:href => "#{project_description.reference_doc_prefix_url}#{release.version_family}/#{  project_description.reference_doc_type}/en-US/html/"}
+                  %a{:href => "#{doc_root_url}#{project_description.reference_doc_type}/en-US/html/"}
                     HTML
                   |
-                  %a{:href => "#{project_description.reference_doc_prefix_url}#{release.version_family}/#{  project_description.reference_doc_type}/en-US/html_single/"}
+                  %a{:href => "#{doc_root_url}#{project_description.reference_doc_type}/en-US/html_single/"}
                     HTML (single page)
                   - if not project_description.reference_pdf.nil?
                     |
-                    %a{:href => "#{project_description.reference_doc_prefix_url}#{release.version_family}/#{  project_description.reference_doc_type}/en-US/pdf/#{project_description.reference_pdf}"}
+                    %a{:href => "#{doc_root_url}#{project_description.reference_doc_type}/en-US/pdf/#{project_description.reference_pdf}"}
                       PDF
                 %li
                   API documentation:
-                  %a{:href => "#{project_description.reference_doc_prefix_url}#{release.version_family}/#{  project_description.javadoc_path}/"}
+                  %a{:href => "#{doc_root_url}#{project_description.javadoc_path}/"}
                     JavaDoc
 
     - else


### PR DESCRIPTION
The idea is to improve the ranking of the /stable/ url as it's now our
canonical URL for documentation.
