### PR TITLE
Releasing Hibernate Search 5.6.0.CR1 and 5.7.0.Beta2

### DIFF
--- a/_data/projects/search/releases/5.6.0.Beta4.yml
+++ b/_data/projects/search/releases/5.6.0.Beta4.yml
@@ -4,5 +4,5 @@ date: 2016-11-29
 stable: false
 announcement_url: http://in.relation.to/2016/11/29/hibernate-search-5-6-0-Beta4-and-5-7-0-Beta1/
 summary: Experimental Elasticsearch integration
-displayed: true
+displayed: false
 

--- a/_data/projects/search/releases/5.6.0.CR1.yml
+++ b/_data/projects/search/releases/5.6.0.CR1.yml
@@ -1,0 +1,8 @@
+version: 5.6.0.CR1
+version_family: 5.6
+date: 2016-12-20
+stable: false
+announcement_url: http://in.relation.to/2016/12/20/hibernate-search-5-6-0-CR1-and-5-7-0-Beta2/
+summary: Experimental Elasticsearch integration
+displayed: true
+

--- a/_data/projects/search/releases/5.7.0.Beta1.yml
+++ b/_data/projects/search/releases/5.7.0.Beta1.yml
@@ -4,5 +4,5 @@ date: 2016-11-29
 stable: false
 announcement_url: http://in.relation.to/2016/11/29/hibernate-search-5-6-0-Beta4-and-5-7-0-Beta1/
 summary: Experimental Elasticsearch integration, compatibility with Hibernate ORM 5.2.x
-displayed: true
+displayed: false
 

--- a/_data/projects/search/releases/5.7.0.Beta2.yml
+++ b/_data/projects/search/releases/5.7.0.Beta2.yml
@@ -1,0 +1,8 @@
+version: 5.7.0.Beta2
+version_family: 5.7
+date: 2016-12-20
+stable: false
+announcement_url: http://in.relation.to/2016/12/20/hibernate-search-5-6-0-CR1-and-5-7-0-Beta2/
+summary: Experimental Elasticsearch integration, compatibility with Hibernate ORM 5.2.x
+displayed: true
+

--- a/search/documentation/migrate/5.6.adoc
+++ b/search/documentation/migrate/5.6.adoc
@@ -7,7 +7,7 @@ Sanne Grinovero, Gunnar Morling
 :toc-title: Content
 :to_version_short: 5.6
 :from_version_short: 5.5
-:reference_version_full: 5.6.0.Alpha3
+:reference_version_full: 5.6.0.CR1
 
 Here we are helping you migrate your existing Search application to the latest and greatest.
 
@@ -21,23 +21,101 @@ It refers to Hibernate Search version `{reference_version_full}`. If you think s
 
 === Requirements
 
-This version of Hibernate Search now requires using *Apache Lucene 5.5.0*.
+This version of Hibernate Search now requires using *Apache Lucene 5.5.x*.
 
 === API changes
 
-A new method `getShardIdentifiersForDeletion()` has been added to `org.hibernate.search.store.ShardIdentifierProvider` (https://hibernate.atlassian.net/browse/HSEARCH-2075[HSEARCH-2075]).
-Existing implementations which are not derived from `ShardIdentifierProviderTemplate` need to be adapted.
+This release of Hibernate Search upgrades the dependency to Lucene from 5.3.1 to 5.5.2.
+In case you are working with Lucene types directly, check out the Apache Lucene 5 http://lucene.apache.org/core/5_5_0/MIGRATE.html[migration guide] as well as the Apache Lucene http://lucene.apache.org/core/5_4_0/changes/Changes.html[5.4] and http://lucene.apache.org/core/5_5_0/changes/Changes.html[5.5] change logs.
 
-This release of Hibernate Search upgrades the dependency to Lucene from 5.3.1 to 5.5.0.
-In case you are working with Lucene types directly, thus also check out the Apache Lucene 5 http://lucene.apache.org/core/5_5_0/MIGRATE.html[migration guide] as well as the Apache Lucene http://lucene.apache.org/core/5_4_0/changes/Changes.html[5.4] and http://lucene.apache.org/core/5_5_0/changes/Changes.html[5.5] change logs.
+Below are the changes on application programming interfaces that require changes on the existing implementations or clients.
+Please refer to the javadoc for the expected behavior of changed/added methods.
+
+`org.hibernate.search.store.ShardIdentifierProvider`:
+
+ * a new method `getShardIdentifiersForDeletion()` has been added (https://hibernate.atlassian.net/browse/HSEARCH-2075[HSEARCH-2075]).
+
+`org.hibernate.search.jpa.FullTextQuery` and `org.hibernate.search.FullTextQuery`:
+
+ * `setFilter(Filter filter);` has been deprecated. See the javadoc for how to avoid using it.
+ 
+`org.hibernate.search.annotations.ProvidedId`:
+
+ * this annotation has been deprecated and will ultimately be removed with no replacement.
+
+Please also note those new features that may help when writing new code, but don't require any change to existing code:
+
+ * the https://docs.jboss.org/hibernate/search/5.6/reference/en-US/html_single/#query-sorting[sort DSL]
+ * the experimental `org.hibernate.search.bridge.MetadataProvidingFieldBridge` interface,
+   that allows custom bridges implementing it to define both the exact type of their custom (additional) fields
+   (for proper querying support on numeric fields, in particular)
+   and whether those fields should be sortable (for better performance when sorting). 
 
 === SPI changes
 
-A new method `flushAndReleaseResources()` has been added `org.hibernate.search.indexes.spi.IndexManager`.
-Existing implementations need to be adjusted.
+Below are the changes on service provider interfaces that require changes on the existing implementations or clients.
+Please refer to the javadoc for the expected behavior of changed/added methods.
 
-A new method `flushAndReleaseResources()` has been added to `org.hibernate.search.backend.spi.BackendQueueProcessor`.
-Existing implementations need to be adjusted, but we don't expect many such implementations in the wild.
+`org.hibernate.search.indexes.spi.IndexManager`:
 
-The method `org.hibernate.search.backend.spi.BackendQueueProcessor#initialize()` has been changed to accept any kind of `IndexManager` now instead of `DirectoryBasedIndexManager`.
-Existing implementations need to be adjusted, but we don't expect many such implementations in the wild.
+ * a new method `flushAndReleaseResources()` has been added.
+ * `getSerializer()` has been deprecated and is not used anymore:
+   implementations may make this a no-op and safely return null.
+ * a new method `awaitAsyncProcessingCompletion()` has been added.
+ 
+The changes below are unlikely to impact anyone, but are mentioned here for the sake of completeness.
+
+`org.hibernate.search.backend.spi.BackendQueueProcessor`:
+
+ * a new method `flushAndReleaseResources()` has been added.
+ * `initialize()` has been changed to accept any kind of `IndexManager` now instead of `DirectoryBasedIndexManager`.
+ * `getExclusiveWriteLock()` has been removed.
+ * `indexMappingChanged()` has been removed.
+
+`org.hibernate.search.engine.spi.AbstractDocumentBuilder`:
+
+ * `getAnalyzer()` has been renamed to `getAnalyzerReference` and now returns an
+   `org.hibernate.search.analyzer.spi.AnalyzerReference`.
+
+`org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity`:
+
+ * `getIdentifierName()` has been renamed to `getIdPropertyName()`
+ * `getIdKeywordName()` has been renamed to `getIdFieldName()`
+
+`org.hibernate.search.engine.service.spi.ServiceManager`:
+
+ * a new method `ClassLoaderService getClassLoaderService()` has been added.
+ * a new method `<S extends Service> ServiceReference<S> requestReference(Class<S> serviceRole)`
+   has been added.
+ 
+`org.hibernate.search.backend.spi.DeletionQuery`:
+
+ * `toLuceneQuery(ScopedAnalyzer)` has been changed to accept a `DocumentBuilderIndexedEntity`
+   instead of a `ScopedAnalyzer`.
+
+`org.hibernate.search.backend.spi.BatchBackend`:
+
+ * a new method `awaitAsyncProcessingCompletion()` has been added.
+
+`org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer`:
+
+ * this interface now extends `org.hibernate.search.engine.service.spi.Service`.
+
+`org.hibernate.search.spi.SearchIntegrator`:
+
+ * a new method `LuceneWorkSerializer getWorkSerializer()` has been added.
+ * a new method `HSQuery createHSQuery(Query luceneQuery, Class<?>... entities)`
+   has been added.
+ * `createHSQuery()` has been deprecated. It should not be used anymore:
+   `createHSQuery(Query, Class<?>...)` should be used instead.
+
+`org.hibernate.search.cfg.spi.SearchConfiguration`:
+
+ * a new method `boolean isMultitenancyEnabled()` has been added.
+ * we kindly remind you that implementing classes should not implement `SearchConfiguration` directly
+   but rather extend `org.hibernate.search.cfg.spi.SearchConfigurationBase`, so as to shield
+   them from additions to `SearchConfiguration`.
+
+`org.hibernate.search.query.engine.spi.HSQuery`:
+
+ * a new method `String getQueryString()` has been added.

--- a/search/documentation/migrate/5.7.adoc
+++ b/search/documentation/migrate/5.7.adoc
@@ -1,0 +1,28 @@
+= Migration Guide from Hibernate Search {from_version_short} to {to_version_short}
+Sanne Grinovero, Gunnar Morling
+:awestruct-layout: project-frame
+:awestruct-project: search
+:toc:
+:toc-placement: preamble
+:toc-title: Content
+:to_version_short: 5.7
+:from_version_short: 5.6
+:reference_version_full: 5.7.0.Beta2
+
+Here we are helping you migrate your existing Search application to the latest and greatest.
+
+== Upgrade to Search {to_version_short}.x from {from_version_short}.x
+
+The aim of this guide is to assist you migrating an existing application using any version `{from_version_short}.x` of Hibernate Search to the latest of the `{to_version_short}.x` series.
+If you're looking to migrate different versions see link:/search/documentation/migrate[Hibernate Search migration guides].
+
+NOTE: This document provides pointers for a migration.
+It refers to Hibernate Search version `{reference_version_full}`. If you think something is missing or something does not work, please link:/community[contact us].
+
+=== Requirements
+
+This version of Hibernate Search now requires using Hibernate ORM version `5.2.x`.
+
+=== API changes
+
+There were no relevant API changes within Hibernate Search itself; consider though that the required Hibernate ORM version change may change some Hibernate ORM APIs.

--- a/search/documentation/migrate/index.adoc
+++ b/search/documentation/migrate/index.adoc
@@ -7,6 +7,9 @@
 The following guides are meant to help you upgrading an existing application using Hibernate Search to a more recent version.
 This content is not automatically generated, but structured to give you the high level overview.
 
+link:/search/documentation/migrate/5.7[Migration guide to Hibernate Search 5.7]::
+Notes and relevant changes you should keep in mind when upgrading from versions _5.6_ to _5.7_.
+
 link:/search/documentation/migrate/5.6[Migration guide to Hibernate Search 5.6]::
 Notes and relevant changes you should keep in mind when upgrading from versions _5.5_ to _5.6_.
 


### PR DESCRIPTION
This is mainly about the migration guides; I found several changes that were not mentioned until now and would like to confirm they should be mentioned.

The changes should be up on staging soon:

 * http://staging.hibernate.org/search/documentation/migrate/5.6/
 * http://staging.hibernate.org/search/documentation/migrate/5.7/