### PR TITLE
Remove multipage HTML link from the documentation page.

### DIFF
--- a/_layouts/project/project-documentation.html.haml
+++ b/_layouts/project/project-documentation.html.haml
@@ -57,11 +57,8 @@ layout: project-frame
               %ul
                 %li
                   English reference documentation:
-                  %a{:href => "#{doc_root_url}#{project_description.reference_doc_type}/en-US/html/"}
-                    HTML
-                  |
                   %a{:href => "#{doc_root_url}#{project_description.reference_doc_type}/en-US/html_single/"}
-                    HTML (single page)
+                    HTML
                   - if not project_description.reference_pdf.nil?
                     |
                     %a{:href => "#{doc_root_url}#{project_description.reference_doc_type}/en-US/pdf/#{project_description.reference_pdf}"}


### PR DESCRIPTION
Our reference documentation is the single page one and with the switch
to Asciidoctor, we won't be generating a multipage documentation
anymore.

I don't think it's worth it introducing a per project test as our goal will be to migrate all projects to the new AsciiDoc output.

Note: it only concerns NoORM projects, ORM has its own documentation page.