### PR TITLE
[HSEARCH] Updates after 5.6.1.Final and 5.7.0.Final

### DIFF
--- a/_data/projects/search/releases/5.4.0.Final.yml
+++ b/_data/projects/search/releases/5.4.0.Final.yml
@@ -4,5 +4,5 @@ date: 2015-9-03
 stable: true
 announcement_url: http://in.relation.to/2015/09/03/HS-5/
 summary: Requires Hibernate ORM 5.0.0.Final; Last version compatible with Apache Lucene 4.x
-displayed: true
+displayed: false
 

--- a/_data/projects/search/releases/5.5.6.Final.yml
+++ b/_data/projects/search/releases/5.5.6.Final.yml
@@ -4,5 +4,5 @@ date: 2017-01-09
 stable: true
 announcement_url: http://in.relation.to/2017/01/09/hibernate-search-5-5-6-Final/
 summary: Minor adjustments
-displayed: true
+displayed: false
 

--- a/_data/projects/search/releases/5.6.0.Final.yml
+++ b/_data/projects/search/releases/5.6.0.Final.yml
@@ -4,4 +4,4 @@ date: 2017-01-30
 stable: true
 announcement_url: http://in.relation.to/2017/01/30/hibernate-search-5-6-0-Final-and-5-7-0-CR1/
 summary: Experimental Elasticsearch integration
-displayed: true
+displayed: false

--- a/_data/projects/search/releases/5.6.1.Final.yml
+++ b/_data/projects/search/releases/5.6.1.Final.yml
@@ -1,0 +1,7 @@
+version: 5.6.1.Final
+version_family: 5.6
+date: 2017-02-22
+stable: true
+announcement_url: http://in.relation.to/2017/02/22/hibernate-search-5-7-0-Final/
+summary: Experimental Elasticsearch integration
+displayed: true

--- a/_data/projects/search/releases/5.7.0.CR1.yml
+++ b/_data/projects/search/releases/5.7.0.CR1.yml
@@ -4,4 +4,4 @@ date: 2017-01-30
 stable: false
 announcement_url: http://in.relation.to/2017/01/30/hibernate-search-5-6-0-Final-and-5-7-0-CR1/
 summary: Experimental Elasticsearch integration, compatibility with Hibernate ORM 5.2.x
-displayed: true
+displayed: false

--- a/_data/projects/search/releases/5.7.0.Final.yml
+++ b/_data/projects/search/releases/5.7.0.Final.yml
@@ -1,0 +1,7 @@
+version: 5.7.0.Final
+version_family: 5.7
+date: 2017-02-22
+stable: true
+announcement_url: http://in.relation.to/2017/02/22/hibernate-search-5-7-0-Final/
+summary: Experimental Elasticsearch integration, compatibility with Hibernate ORM 5.2.x
+displayed: true


### PR DESCRIPTION
I added the new versions, and removed two older ones (5.4 and 5.5):

 - http://staging.hibernate.org/search/documentation/
 - http://staging.hibernate.org/search/downloads/


Also, I updated the roadmap: http://staging.hibernate.org/search/roadmap/
I basically removed 5.6 and 5.7 from the roadmap and pushed most 5.7 goals that we didn't reach to 5.8 (but maybe we should just drop them? Some of them seem to fit 6.0 better)