### PR TITLE
Update the Hibernate Search roadmap

### DIFF
--- a/search/roadmap.adoc
+++ b/search/roadmap.adoc
@@ -26,34 +26,46 @@ Analyzers::
 A new DSL will be introduced to allow people to define Analyzers programmatically at boostrap, as an alternative to the current `@Analyzer` and `@AnalyzerDef` annotations.
 We might want to automatically register a set of commonly used Analyzers - let us know what you think of this as the choice is hard!
 
-WildFly Swarm::
-WildFly Swarm is the new fine-grained modular version of WildFly aiming at microservices.
-We should make sure Hibernate Search is integrated properly and the usage is documented.
-
 Java 9 compatibibility::
-We're aiming at regularly testing compatibility with Java 8 and now 9 too.
-Hibernate Search should test its modularity within project Jigsaw, within reason as we can't depent on Java9 release schedules.
+We're aiming at regularly testing compatibility with Java 9 on top of the regular tests on Java 8.
+Testing will be limited to having Hibernate Search on the regular classpath: running as a module is an additional step we deferred to version 5.9.
+
+
+== Hibernate Search 5.9
+
+Elasticsearch performance::
+We applied some interesting performance improvements in version 5.8 but there are some more interesting ideas which could provide
+a radical boost. Moved these to 5.9 as they are quite complex and need fleshing out.
+
+WildFly Swarm::
+http://wildfly-swarm.io/[WildFly Swarm] is the new fine-grained modular version of http://wildfly.org/[WildFly] aiming at microservices.
+We should make sure Hibernate Search is integrated properly and the usage is documented.
 
 Removal of class definitions from master nodes::
 The integration of a "master node" needs to be simplified, both in terms of user configuration and implementation.
 We plan to not need user classes (entities) on such a node, so that in future it could be a separate download
 which works out of the box with minimal configuration.
 
+Modularity related enhancements::
+Some code needs to be moved to different jars to improve the experience with OSGi, JBoss Modules and eventually Java 9 (Jigsaw) users.
+For example the integration with Apache Tika should be moved to allow loading additional extensions which haven't been originally bundled with Hibernate Search.
+
 
 == Hibernate Search 6.x
 
-Compatible with Hibernate ORM 6, Apache Lucene 6 (maybe 7).
+Compatible with Hibernate ORM 6, Apache Lucene 7.
 
 API Refresh::
 A significant API refresh is planned to better abstract from the Lucene API so that alternative backends such as Elasticsearch can be used without having Lucene on your classpath.
 This will also benefit Lucene users, as the abstraction should allow us to automatically apply more optimisations without the user needing to be a Lucene expert.
 
-Upgrade to Apache Lucene 6 (7)::
-To provide the full power of some of the new features in Apache Lucene 6, some API changes are needed.
-This includes some API improvements which could have been useful since the upgrade to Lucene 5, but we only apply breaking API changes in major releases.
+Upgrade to Apache Lucene 7::
+To provide the full power of some of the new features in Apache Lucene 7, some API changes are needed.
+This includes some API improvements which could have been useful since the upgrade to Lucene 5; since we only apply breaking API changes in major releases these had to wait.
 
 Free-form indexing::
-We're planning to decouple the metadata definition from annotated java classes, to allow better indexing of other more flexible sources.
+We're planning to decouple the metadata definition from annotated java classes, to allow better indexing of other more flexible sources;
+for example to make it easier to index data structured in the JSON format, or other formats whose schema is not known at compile time.
 
 Join operations::
 Expose Lucene's index-time and query-time join capabilities.

--- a/search/roadmap.adoc
+++ b/search/roadmap.adoc
@@ -50,6 +50,13 @@ Modularity related enhancements::
 Some code needs to be moved to different jars to improve the experience with OSGi, JBoss Modules and eventually Java 9 (Jigsaw) users.
 For example the integration with Apache Tika should be moved to allow loading additional extensions which haven't been originally bundled with Hibernate Search.
 
+Modularity related enhancements::
+Some code needs to be moved to different jars to improve the experience with OSGi, JBoss Modules and eventually Java 9 (Jigsaw) users.
+For example the integration with Apache Tika should be moved to allow loading additional extensions which haven't been originally bundled with Hibernate Search.
+
+JSR-352 (Batch Applications for the Java Platform) integration::
+Since last year, Mincong Huang worked on a JSR-352 job for Hibernate Search mass indexing.
+We plan to do some performance testing (and optimization if necessary), then merge this work as a new module.
 
 == Hibernate Search 6.x
 


### PR DESCRIPTION
Sending as a PR as this essentially is a proposal for creating a 5.9 branch.. should we?

It seems natural to me but there were concerns at our meeting along the lines of "not wasting time" on anything distracting from Search 6.0

Also: should we mention the JBatch integration for 5.9 ?