### PR TITLE
[HSEARCH] What's new in 5.5, 5.6, 5.7

### DIFF
--- a/search/releases/5.5/index.adoc
+++ b/search/releases/5.5/index.adoc
@@ -1,3 +1,59 @@
 :awestruct-layout: project-releases-series
 :awestruct-project: search
 :awestruct-series_version: "5.5"
+
+
+=== Lucene upgrade
+
+Hibernate Search 5.5 adds compatibility with Lucene 5,
+and requires Lucene 5.2, 5.3 or 5.4 to work correctly.
+
+=== Hibernate ORM upgrade
+
+Hibernate Search now requires Hibernate ORM 5.0 or 5.1 to work correctly.
+
+=== Out of the box indexing of java.time types
+
+Hibernate Search is now able to automatically provide a sensible mapping for
+`java.time.Year`, `java.time.Duration` `java.time.Instant`, `java.time.LocalDate`,
+`java.time.LocalTime`, `java.time.LocalDateTime`, `java.time.LocalTime`, `java.time.MonthDay`,
+`java.time.OffsetDateTime`, `java.time.OffsetTime`, `java.time.Period`, `java.time.YearMonth`,
+`java.time.ZoneDateTime`, `java.time.ZoneId`, `java.time.ZoneOffset`.
+
+That means that it includes an out of the box `FieldBridge` for each of these types,
+and allows transparent indexing and querying of properties of these types.
+You can of course customize the indexing by providing your own `FieldBridge`, as usual.
+
+This feature is only available if you are running on a Java 8 runtime,
+although all other features of Hibernate Search are still backwards compatible with Java 7.
+
+=== Sorting improvements
+
+Since Apache Lucene 5.0 (and including 5.3 as we currently require)
+we can provide a significant performance improvement if you let us know in advance which fields you intend to use for sorting.
+
+For this purpose a new annotation http://docs.jboss.org/hibernate/search/5.5/api/org/hibernate/search/annotations/SortableField.html[`org.hibernate.search.annotations.SortableField`] is available.
+If you start using this annotation in your projects you'll benefit from improved performance, but for those who don't want to update their mapping yet we will fallback to the older strategy.
+
+This subject is discussed in detail in this {base_url}2015/09/14/sorting-in-hibernate-search-55/[follow-up post].
+
+=== Encoding null tokens in your index
+
+When using http://docs.jboss.org/hibernate/search/5.5/api/org/hibernate/search/annotations/Field.html#indexNullAs--[`@Field(indexNullAs=)`]
+to encode some marker value in the index,
+the type of the marker is now required to be of a compatible field type
+as all other values which are indexed in that same field.
+
+This was problematic for `NumericField`s, the ones optimised for range queries on numbers,
+as we would previously allow you to encode a string keyword like '_null_':
+this is no longer allowed, you will have to pick a number to be used to represent the null value.
+
+As an example for an "age" property you might want to use:
+
+====
+[source, Java]
+----
+@Field(indexNullAs = "-1")
+Integer nullableAge;
+----
+====

--- a/search/releases/5.6/index.adoc
+++ b/search/releases/5.6/index.adoc
@@ -1,3 +1,68 @@
 :awestruct-layout: project-releases-series
 :awestruct-project: search
 :awestruct-series_version: "5.6"
+
+=== Experimental Elasticsearch integration
+
+A new, experimental Elasticsearch integration was introduced in this series.
+
+With the Elasticsearch integration, rather than indexing your entities directly by managing the Lucene resources,
+Hibernate Search will be sending RPCs to an Elasticsearch cluster to achieve a very similar purpose:
+after all it is also Lucene based, so the feature match is extremely close!
+
+Since Hibernate Search will transparently map all the current features to this new alternative backend,
+you will be able to switch to a new architecture with only minimal changes in your applications.
+For most users the differences will be mostly in configuration details.
+
+When using Elasticsearch, Hibernate Search will need to send RPCs over the network
+to run queries and index updates,
+but on the other hand you benefit from _Microservices_ - style decoupling and all the nice features
+that Elasticsearch can provide in terms of running and managing an horizontally scalable cluster.
+
+To know more about this integration, check out the
+http://docs.jboss.org/hibernate/search/5.6/reference/en-US/html_single/#elasticsearch-integration[Elasticsearch chapter]
+in the documentation.
+
+=== Sort DSL
+
+The QueryBuilder interface now has an additional `sort()` method,
+allowing to easily build sort definitions regardless of the underlying technology
+(raw Lucene or Elasticsearch),
+and without worrying about numeric field types:
+
+[source, JAVA]
+----
+QueryBuilder builder = fullTextSession.getSearchFactory()
+  .buildQueryBuilder().forEntity(Book.class).get();
+Query luceneQuery = builder.all().createQuery();
+FullTextQuery query = fullTextSession.createFullTextQuery( luceneQuery, Book.class );
+Sort sort = builder
+  .sort()
+    .byField("author").desc() // Descending order
+    .andByField("title") // Default order (ascending)
+  .createSort();
+query.setSort(sort);
+List results = query.list();
+----
+
+You can find more information in
+http://in.relation.to/2016/10/10/introducing-hibernate-search-sort-dsl/[this blog post]
+and in
+http://docs.jboss.org/hibernate/search/5.6/reference/en-US/html_single/#query-sorting[the documentation]
+
+=== Lucene upgrade
+
+The Lucene dependency was upgraded to 5.5.
+
+Also, do not think Lucene was forgotten in this series,
+since there were several bug fixes and performance improvements.
+See the release notes for details.
+
+=== Async reader strategy
+
+A new `async` reader strategy has been added for the Lucene integration,
+bringing performance boosts when you are okay with your queries being run
+on an out-of-date index (how much out-of-date is configurable).
+
+Refer to http://docs.jboss.org/hibernate/search/5.6/reference/en-US/html_single/#search-architecture-readerstrategy[the documentation]
+for more information.

--- a/search/releases/5.7/index.adoc
+++ b/search/releases/5.7/index.adoc
@@ -1,3 +1,18 @@
 :awestruct-layout: project-releases-series
 :awestruct-project: search
 :awestruct-series_version: "5.7"
+
+=== Hibernate ORM 5.2 upgrade
+
+Hibernate Search 5.7 adds compatibility with Hibernate ORM 5.2,
+and is no longer compatible with Hibernate ORM 5.1 and below.
+
+[WARNING]
+====
+Hibernate Search 5.7 is only compatible with Hibernate ORM 5.2.3 and later.
+There isn't any version of Hibernate Search compatible with Hibernate ORM 5.2.0 to 5.2.2.
+====
+
+=== Java 8 upgrade
+
+Hibernate Search now requires Java 8.


### PR DESCRIPTION
 * http://staging.hibernate.org/search/releases/5.5/#whats-new
 * http://staging.hibernate.org/search/releases/5.6/#whats-new
 * http://staging.hibernate.org/search/releases/5.7/#whats-new

Sources:

 * For 5.5: http://in.relation.to/2015/09/09/Hibernate-Search-5/
 * For 5.6: http://in.relation.to/2016/02/29/HibernateSearchAlpha-Elasticsearch/ , http://in.relation.to/2016/10/10/introducing-hibernate-search-sort-dsl/ , http://in.relation.to/2016/11/29/hibernate-search-5-6-0-Beta4-and-5-7-0-Beta1/
 * For 5.7: my own memory