### PR TITLE
Clarify JDK compatibility of Search and Validator

### DIFF
--- a/_data/projects/search/releases/4.4/series.yml
+++ b/_data/projects/search/releases/4.4/series.yml
@@ -14,7 +14,7 @@ artifacts:
     summary: Analyzer dependencies from Lucene/Solr
 integration_constraints:
   java:
-    version: 6 - 7 - 8
+    version: 6, 7 or 8
   orm:
     version: 4.2
   lucene:

--- a/_data/projects/search/releases/4.5/series.yml
+++ b/_data/projects/search/releases/4.5/series.yml
@@ -14,7 +14,7 @@ artifacts:
     summary: Analyzer dependencies from Lucene/Solr
 integration_constraints:
   java:
-    version: 6 - 7 - 8
+    version: 6, 7 or 8
   orm:
     version: 4.3
   lucene:

--- a/_data/projects/search/releases/5.0/series.yml
+++ b/_data/projects/search/releases/5.0/series.yml
@@ -12,7 +12,7 @@ artifacts:
     summary: JMS backend
 integration_constraints:
   java:
-    version: 7 - 8
+    version: 7 or 8
   orm:
     version: 4.3
   lucene:

--- a/_data/projects/search/releases/5.1/series.yml
+++ b/_data/projects/search/releases/5.1/series.yml
@@ -12,7 +12,7 @@ artifacts:
     summary: JMS backend
 integration_constraints:
   java:
-    version: 7 - 8
+    version: 7 or 8
   orm:
     version: 4.3
   lucene:

--- a/_data/projects/search/releases/5.10/series.yml
+++ b/_data/projects/search/releases/5.10/series.yml
@@ -30,7 +30,7 @@ artifacts:
     summary: WildFly feature pack - JGroups backend
 integration_constraints:
   java:
-    version: 8 - 9
+    version: 8
   orm:
     version: 5.3
   elasticsearch:

--- a/_data/projects/search/releases/5.11/series.yml
+++ b/_data/projects/search/releases/5.11/series.yml
@@ -30,7 +30,7 @@ artifacts:
     summary: WildFly feature pack - JGroups backend
 integration_constraints:
   java:
-    version: 8 - 11
+    version: 8 or 11
   orm:
     version: 5.4
   elasticsearch:

--- a/_data/projects/search/releases/5.2/series.yml
+++ b/_data/projects/search/releases/5.2/series.yml
@@ -12,7 +12,7 @@ artifacts:
     summary: JMS backend
 integration_constraints:
   java:
-    version: 7 - 8
+    version: 7 or 8
   orm:
     version: 4.3
   lucene:

--- a/_data/projects/search/releases/5.3/series.yml
+++ b/_data/projects/search/releases/5.3/series.yml
@@ -12,7 +12,7 @@ artifacts:
     summary: JMS backend
 integration_constraints:
   java:
-    version: 7 - 8
+    version: 7 or 8
   orm:
     version: 5.0
   lucene:

--- a/_data/projects/search/releases/5.4/series.yml
+++ b/_data/projects/search/releases/5.4/series.yml
@@ -12,7 +12,7 @@ artifacts:
     summary: JMS backend
 integration_constraints:
   java:
-    version: 7 - 8
+    version: 7 or 8
   orm:
     version: 5.0
   lucene:

--- a/_data/projects/search/releases/5.5/series.yml
+++ b/_data/projects/search/releases/5.5/series.yml
@@ -12,7 +12,7 @@ artifacts:
     summary: JMS backend
 integration_constraints:
   java:
-    version: 7 - 8
+    version: 7 or 8
   orm:
     version: 5.0 - 5.1
   lucene:

--- a/_data/projects/search/releases/5.6/series.yml
+++ b/_data/projects/search/releases/5.6/series.yml
@@ -14,7 +14,7 @@ artifacts:
     summary: JMS backend
 integration_constraints:
   java:
-    version: 7 - 8
+    version: 7 or 8
   orm:
     version: 5.0 - 5.1
   elasticsearch:

--- a/_data/projects/search/releases/6.0/series.yml
+++ b/_data/projects/search/releases/6.0/series.yml
@@ -9,7 +9,7 @@ artifacts:
     summary: Lucene backend
 integration_constraints:
   java:
-    version: 8 - 11
+    version: 8, 11 or 12
   orm:
     version: 5.4
   elasticsearch:

--- a/_data/projects/validator/releases/4.3/series.yml
+++ b/_data/projects/validator/releases/4.3/series.yml
@@ -14,6 +14,6 @@ artifacts:
     summary: Annotation processor
 integration_constraints:
   java:
-    version: 6+
+    version: 6
   bv:
     version: 1.0

--- a/_data/projects/validator/releases/5.0/series.yml
+++ b/_data/projects/validator/releases/5.0/series.yml
@@ -16,6 +16,6 @@ artifacts:
     summary: Annotation processor
 integration_constraints:
   java:
-    version: 6+
+    version: 6 or 7
   bv:
     version: 1.1

--- a/_data/projects/validator/releases/5.1/series.yml
+++ b/_data/projects/validator/releases/5.1/series.yml
@@ -16,6 +16,6 @@ artifacts:
     summary: Annotation processor
 integration_constraints:
   java:
-    version: 6+
+    version: 6 or 7
   bv:
     version: 1.1

--- a/_data/projects/validator/releases/5.2/series.yml
+++ b/_data/projects/validator/releases/5.2/series.yml
@@ -18,7 +18,7 @@ artifacts:
     summary: Annotation processor
 integration_constraints:
   java:
-    version: 6+
+    version: 6, 7 or 8
   bv:
     version: 1.1
 

--- a/_data/projects/validator/releases/5.3/series.yml
+++ b/_data/projects/validator/releases/5.3/series.yml
@@ -18,6 +18,6 @@ artifacts:
     summary: Annotation processor
 integration_constraints:
   java:
-    version: 6+
+    version: 6, 7 or 8
   bv:
     version: 1.1

--- a/_data/projects/validator/releases/5.4/series.yml
+++ b/_data/projects/validator/releases/5.4/series.yml
@@ -18,6 +18,6 @@ artifacts:
     summary: Annotation processor
 integration_constraints:
   java:
-    version: 6+
+    version: 6, 7 or 8
   bv:
     version: 1.1

--- a/_data/projects/validator/releases/6.0/series.yml
+++ b/_data/projects/validator/releases/6.0/series.yml
@@ -11,6 +11,6 @@ artifacts:
     summary: Annotation processor
 integration_constraints:
   java:
-    version: 8+
+    version: 8 or 11
   bv:
     version: 2.0


### PR DESCRIPTION
Since we're starting to take a more conservative approach to JDK support (only LTS + latest non-LTS), I think we need to be clearer on the website.

In particular, I would avoid confusing expressions such as "works with Java 8+": we don't know what will break in version above 8, so we can't make that kind of promise until we know what we are promising.

Similarly, we cannot say "works with Java 8 to 11" lightly, since 9 and 10 are non-LTS releases, they have some quirks, and we're likely to stop testing with these JDKs at some point.

For now I just updated the compatibility matrices to be very explicit about which versions are expected to work.

@gsmet could you please check the information for Validator?