### PR TITLE
[ORM] Update migration guide link for Hibernate ORM 6.0

### DIFF
--- a/orm/documentation/6.0/index.adoc
+++ b/orm/documentation/6.0/index.adoc
@@ -2,7 +2,7 @@
 :awestruct-layout: project-documentation-orm
 :awestruct-project: orm
 :awestruct-ormversion: 6.0
-:awestruct-ormbranch: main
+:awestruct-ormbranch: 6.0
 
 == Guides and such
 


### PR DESCRIPTION
With 6.0 being released and `main` being a home for 6.1 the current migration guide for 6.0 is pointing to a different page.