### PR TITLE
Support marking series as end-of-life'd

### DIFF
--- a/_data/projects/ogm/releases/4.0/series.yml
+++ b/_data/projects/ogm/releases/4.0/series.yml
@@ -1,5 +1,5 @@
 summary: Last release using Hibernate ORM 4.2 and JPA 2.1. Initial Neo4j integration; support for store-specific native queries.
-displayed: false
+endoflife: true
 artifacts:
   - artifact_id: hibernate-search-infinispan
     summary: Infinispan integration (embedded)

--- a/_data/projects/ogm/releases/4.1/series.yml
+++ b/_data/projects/ogm/releases/4.1/series.yml
@@ -1,5 +1,5 @@
 summary: JPA object mapper for NoSQL
-displayed: false
+endoflife: true
 artifacts:
   - artifact_id: hibernate-search-infinispan
     summary: Infinispan integration (embedded)

--- a/_data/projects/ogm/releases/4.2/series.yml
+++ b/_data/projects/ogm/releases/4.2/series.yml
@@ -1,5 +1,5 @@
 summary: Queries on embedded id properties for Neo4j and MongoDB, Bugfixes
-displayed: false
+endoflife: true
 artifacts:
   - artifact_id: hibernate-search-infinispan
     summary: Infinispan integration (embedded)

--- a/_data/projects/ogm/releases/5.0/series.yml
+++ b/_data/projects/ogm/releases/5.0/series.yml
@@ -1,5 +1,5 @@
 summary: Upgrade to Hibernate ORM 5 and Hibernate Search 5
-displayed: false
+endoflife: true
 artifacts:
   - artifact_id: hibernate-search-infinispan
     summary: Infinispan integration (embedded)

--- a/_data/projects/ogm/releases/5.1/series.yml
+++ b/_data/projects/ogm/releases/5.1/series.yml
@@ -1,5 +1,5 @@
 summary: Hibernate ORM 5.1, Neo4j and Infinispan remote, Aggregation in MongoDB native queries, Operations grouping
-displayed: false
+endoflife: true
 artifacts:
   - artifact_id: hibernate-search-infinispan
     summary: Infinispan integration (embedded)

--- a/_data/projects/ogm/releases/5.2/series.yml
+++ b/_data/projects/ogm/releases/5.2/series.yml
@@ -1,4 +1,5 @@
 summary: Grouping for Infinispan remote, move dialects in separate repositories, support map-reduce in MongoDB native queries
+endoflife: true
 artifacts:
   - artifact_id: hibernate-ogm-infinispan-embedded
     summary: Infinispan integration (embedded)

--- a/_data/projects/ogm/releases/5.3/series.yml
+++ b/_data/projects/ogm/releases/5.3/series.yml
@@ -1,4 +1,5 @@
 summary: Upgrade to Hibernate ORM 5.2 and Hibernate Search 5.9
+endoflife: true
 artifacts:
   - artifact_id: hibernate-ogm-infinispan-embedded
     summary: Infinispan integration (embedded)

--- a/_data/projects/ogm/releases/5.4/series.yml
+++ b/_data/projects/ogm/releases/5.4/series.yml
@@ -1,4 +1,5 @@
 summary: WildFly 13 Feature Pack - JPA 2.2 - Hibernate ORM 5.3 - Infinispan 9.4
+endoflife: true
 artifacts:
   - artifact_id: hibernate-ogm-infinispan-embedded
     summary: Infinispan integration (embedded)

--- a/_data/projects/orm/releases/4.2/series.yml
+++ b/_data/projects/orm/releases/4.2/series.yml
@@ -1,5 +1,5 @@
 summary: JPA 2.0
-displayed: false
+endoflife: true
 maven:
   group_id: org.hibernate
   main_artifact_id: hibernate-core

--- a/_data/projects/orm/releases/4.3/series.yml
+++ b/_data/projects/orm/releases/4.3/series.yml
@@ -1,5 +1,5 @@
 summary: JPA 2.1 support
-displayed: false
+endoflife: true
 maven:
   group_id: org.hibernate
   main_artifact_id: hibernate-core

--- a/_data/projects/orm/releases/5.0/series.yml
+++ b/_data/projects/orm/releases/5.0/series.yml
@@ -1,6 +1,5 @@
 summary: Improved bootstrapping, hibernate-java8, hibernate-spatial, Karaf support
 endoflife: true
-displayed: true
 maven:
   group_id: org.hibernate
   main_artifact_id: hibernate-core

--- a/_data/projects/orm/releases/5.0/series.yml
+++ b/_data/projects/orm/releases/5.0/series.yml
@@ -1,4 +1,6 @@
 summary: Improved bootstrapping, hibernate-java8, hibernate-spatial, Karaf support
+endoflife: true
+displayed: true
 maven:
   group_id: org.hibernate
   main_artifact_id: hibernate-core

--- a/_data/projects/orm/releases/5.1/series.yml
+++ b/_data/projects/orm/releases/5.1/series.yml
@@ -1,6 +1,5 @@
 summary: Entity joins, load-by-multiple-ids, association traversal in AuditQuery
 endoflife: true
-displayed: true
 maven:
   group_id: org.hibernate
   main_artifact_id: hibernate-core

--- a/_data/projects/orm/releases/5.1/series.yml
+++ b/_data/projects/orm/releases/5.1/series.yml
@@ -1,4 +1,6 @@
 summary: Entity joins, load-by-multiple-ids, association traversal in AuditQuery
+endoflife: true
+displayed: true
 maven:
   group_id: org.hibernate
   main_artifact_id: hibernate-core

--- a/_data/projects/orm/releases/5.2/series.yml
+++ b/_data/projects/orm/releases/5.2/series.yml
@@ -1,4 +1,6 @@
 summary: Java 8, JCache support, hibernate-entitymanager consolidation
+endoflife: true
+displayed: true
 maven:
   group_id: org.hibernate
   main_artifact_id: hibernate-core

--- a/_data/projects/orm/releases/5.2/series.yml
+++ b/_data/projects/orm/releases/5.2/series.yml
@@ -1,6 +1,5 @@
 summary: Java 8, JCache support, hibernate-entitymanager consolidation
 endoflife: true
-displayed: true
 maven:
   group_id: org.hibernate
   main_artifact_id: hibernate-core

--- a/_data/projects/orm/releases/5.3/series.yml
+++ b/_data/projects/orm/releases/5.3/series.yml
@@ -1,4 +1,5 @@
 summary: JPA 2.2, inheritance caching
+displayed: false
 maven:
   group_id: org.hibernate
 links:

--- a/_data/projects/orm/releases/5.4/series.yml
+++ b/_data/projects/orm/releases/5.4/series.yml
@@ -1,6 +1,5 @@
 summary: EntityGraph improvements, JDK 11 support
 endoflife: true
-displayed: true
 maven:
   group_id: org.hibernate
 links:

--- a/_data/projects/orm/releases/5.4/series.yml
+++ b/_data/projects/orm/releases/5.4/series.yml
@@ -1,4 +1,6 @@
 summary: EntityGraph improvements, JDK 11 support
+endoflife: true
+displayed: true
 maven:
   group_id: org.hibernate
 links:

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -1,4 +1,6 @@
 summary: Introducing support for Jakarta JPA
+endoflife: true
+displayed: true
 maven:
   group_id: org.hibernate
 links:

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -1,6 +1,5 @@
 summary: Introducing support for Jakarta JPA
 endoflife: true
-displayed: true
 maven:
   group_id: org.hibernate
 links:

--- a/_data/projects/search/releases/4.4/series.yml
+++ b/_data/projects/search/releases/4.4/series.yml
@@ -1,5 +1,5 @@
 summary: Dynamic index sharding, new Metadata API, Hibernate ORM 4.2.x compatible
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/4.5/series.yml
+++ b/_data/projects/search/releases/4.5/series.yml
@@ -1,5 +1,5 @@
 summary: Performance, WildFly 8 compatibility, JPA 2.1 / Hibernate ORM 4.3 compatibility
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.0/series.yml
+++ b/_data/projects/search/releases/5.0/series.yml
@@ -1,5 +1,5 @@
 summary: Upgrade to Lucene 4 and much much more ...
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.1/series.yml
+++ b/_data/projects/search/releases/5.1/series.yml
@@ -1,5 +1,5 @@
 summary: Upgrade to Lucene 4 and much much more ...
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.10/series.yml
+++ b/_data/projects/search/releases/5.10/series.yml
@@ -1,4 +1,5 @@
 summary: ORM 5.3 and JPA 2.2 compatibility, integration to DI frameworks through Hibernate ORM 5.3, upgrade to WildFly 17 and JGroups 4, JPMS automatic module names.
+displayed: false
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.2/series.yml
+++ b/_data/projects/search/releases/5.2/series.yml
@@ -1,5 +1,5 @@
 summary: Multi-tenancy, optimisations in criteria based loaders
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.3/series.yml
+++ b/_data/projects/search/releases/5.3/series.yml
@@ -1,5 +1,5 @@
 summary: Improved Faceting
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.4/series.yml
+++ b/_data/projects/search/releases/5.4/series.yml
@@ -1,5 +1,5 @@
 summary: Requires Hibernate ORM 5.0.0.Final; Last version compatible with Apache Lucene 4.x
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.5/series.yml
+++ b/_data/projects/search/releases/5.5/series.yml
@@ -1,5 +1,5 @@
 summary: Being maintained as it's included in WildFly. Supports Lucene only, requires Hibernate ORM 5.0.z or 5.1.z
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.6/series.yml
+++ b/_data/projects/search/releases/5.6/series.yml
@@ -1,5 +1,5 @@
 summary: Introduces experimental support for Elasticsearch, last release supporting Hibernate ORM 5.0.z or 5.1.z
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.7/series.yml
+++ b/_data/projects/search/releases/5.7/series.yml
@@ -1,5 +1,5 @@
 summary: Improved integration with Elasticsearch 2.x, compatible with Hibernate ORM 5.2.x
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.8/series.yml
+++ b/_data/projects/search/releases/5.8/series.yml
@@ -1,5 +1,5 @@
 summary: Experimental integration with Elasticsearch 5.x, AWS integration, improvements and deprecations paving the road to Search 6
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.9/series.yml
+++ b/_data/projects/search/releases/5.9/series.yml
@@ -1,5 +1,5 @@
 summary: JSR 352 (Batch for Java) mass indexing job, WildFly feature packs, improvements and deprecations paving the road to Search 6
-displayed: false
+endoflife: true
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/6.0/series.yml
+++ b/_data/projects/search/releases/6.0/series.yml
@@ -3,7 +3,6 @@ summary: >-
   Safer and more concise Search DSL, more powerful bridges, smarter automatic indexing, nested documents.
   Upgrades to Lucene 8 and Elasticsearch 7.
 endoflife: true
-displayed: true
 artifacts:
   - artifact_id: hibernate-search-mapper-orm
     summary: Hibernate ORM mapper

--- a/_data/projects/search/releases/6.0/series.yml
+++ b/_data/projects/search/releases/6.0/series.yml
@@ -2,6 +2,8 @@ summary: >-
   API overhaul.
   Safer and more concise Search DSL, more powerful bridges, smarter automatic indexing, nested documents.
   Upgrades to Lucene 8 and Elasticsearch 7.
+endoflife: true
+displayed: true
 artifacts:
   - artifact_id: hibernate-search-mapper-orm
     summary: Hibernate ORM mapper

--- a/_data/projects/validator/releases/4.3/series.yml
+++ b/_data/projects/validator/releases/4.3/series.yml
@@ -1,5 +1,5 @@
 summary: Last Bean Validation 1.0 compatible version
-displayed: false
+endoflife: true
 maven:
   group_id: org.hibernate
   repo:

--- a/_data/projects/validator/releases/5.0/series.yml
+++ b/_data/projects/validator/releases/5.0/series.yml
@@ -1,5 +1,5 @@
 summary: Reference implementation for Bean Validation 1.1
-displayed: false
+endoflife: true
 maven:
   group_id: org.hibernate
   repo:

--- a/_data/projects/validator/releases/5.1/series.yml
+++ b/_data/projects/validator/releases/5.1/series.yml
@@ -1,5 +1,5 @@
 summary: Performances and memory footprint improvements
-displayed: false
+endoflife: true
 maven:
   group_id: org.hibernate
   repo:

--- a/_data/projects/validator/releases/5.2/series.yml
+++ b/_data/projects/validator/releases/5.2/series.yml
@@ -1,5 +1,5 @@
 summary: Java 8 support and more
-displayed: false
+endoflife: true
 maven:
   group_id: org.hibernate
   repo:

--- a/_data/projects/validator/releases/5.3/series.yml
+++ b/_data/projects/validator/releases/5.3/series.yml
@@ -1,5 +1,5 @@
 summary: Dynamic constraint payload, parameter relaxation, new api for programmatic constraint definition, new translations.
-displayed: false
+endoflife: true
 maven:
   group_id: org.hibernate
   repo:

--- a/_data/projects/validator/releases/5.4/series.yml
+++ b/_data/projects/validator/releases/5.4/series.yml
@@ -1,5 +1,5 @@
 summary: JavaMoney support, annotation processor improvements.
-displayed: false
+endoflife: true
 maven:
   group_id: org.hibernate
   repo:

--- a/_data/projects/validator/releases/6.0/series.yml
+++ b/_data/projects/validator/releases/6.0/series.yml
@@ -1,4 +1,5 @@
 summary: Bean Validation 2.0 support, performance improvements.
+displayed: false
 artifacts:
   - artifact_id: hibernate-validator
     summary: Core implementation

--- a/_data/projects/validator/releases/6.1/series.yml
+++ b/_data/projects/validator/releases/6.1/series.yml
@@ -1,5 +1,5 @@
 summary: Jakarta Bean Validation, new Quarkus-tailored bootstrap
-displayed: false
+endoflife: true
 artifacts:
   - artifact_id: hibernate-validator
     summary: Core implementation

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -123,6 +123,9 @@ module Awestruct
           series[:version] = File.basename( series_dir )
         end
         series[:releases] = Array.new
+        if ( series[:endoflife] == nil )
+          series[:endoflife] = false
+        end
         return series
       end
 
@@ -206,6 +209,10 @@ module Awestruct
             end
           end
         end
+        project[:active_release_series] = project[:release_series].nil? ? nil
+            : project[:release_series].values.select{|s| !s[:displayed].nil? ? s.displayed : !s.endoflife}
+        project[:older_release_series] = project[:release_series].nil? ? nil
+            : project[:release_series].values.select{|s| !s[:displayed].nil? ? !s.displayed : s.endoflife}
       end
 
       def downloadDependencies(project, series)

--- a/_layouts/project/project-documentation.html.haml
+++ b/_layouts/project/project-documentation.html.haml
@@ -14,7 +14,7 @@ project_buttons_partial: project/documentation-buttons.html.haml
 
 %h2 Documentation per Series
 
-- active_series = project_description.release_series.nil? ? nil : project_description.release_series.values.select{|s| s.displayed}
+- active_series = project_description.active_release_series
 - if not active_series.nil?
   .ui.grid.documentation-versions
     - active_series.each do |series|
@@ -27,7 +27,7 @@ project_buttons_partial: project/documentation-buttons.html.haml
             %span.ui.label.large
               %strong= release.version
               %span.detail= release.date
-            %span.ui.tag.label{:class => "#{release.stable ? 'green' : 'orange'}"} #{release.stable ? 'stable'   : 'development'}
+            = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "tag" } )
           %p
             = series.summary
           %p
@@ -74,7 +74,7 @@ project_buttons_partial: project/documentation-buttons.html.haml
 - else
   %p There is no reference documentation configured for this project.
 
-- older_series = project_description.release_series.nil? ? nil : project_description.release_series.values.select{|s| !s.displayed}
+- older_series = project_description.older_release_series
 - unless older_series.nil? || older_series.empty?
   %p
     %a.ui.button.right.labeled.icon#older-series-button(href="javascript: void(0)")
@@ -104,7 +104,7 @@ project_buttons_partial: project/documentation-buttons.html.haml
               %span.ui.label.large
                 %strong= release.version
                 %span.detail= release.date
-              %span.ui.tag.label{:class => "#{release.stable ? 'green' : 'orange'}"} #{release.stable ? 'stable'   : 'development'}
+              = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "tag" } )
             %p
               = series.summary
             %p

--- a/_layouts/project/project-frame.html.haml
+++ b/_layouts/project/project-frame.html.haml
@@ -9,8 +9,7 @@ layout: base
 %script
   var displayed_series = [];
   - unless project_description.release_series.nil?
-    - project_description.release_series.values.each do |series|
-      - unless series.displayed then next end
+    - project_description.active_release_series.each do |series|
       displayed_series.push('#{series.version}');
 
 = partial( page.project_banner_partial.nil? ? 'project/banner.html.haml' : page.project_banner_partial, { "real_page" => page } )

--- a/_layouts/project/project-getting-started.html.haml
+++ b/_layouts/project/project-getting-started.html.haml
@@ -28,7 +28,7 @@ layout: project-standard
             %span.ui.label.large
               %strong= release.version
               %span.detail= release.date
-            %span.ui.tag.label{:class => "#{release.stable ? 'green' : 'orange'}"} #{release.stable ? 'stable' : 'development'}
+            = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "tag" } )
             %p
               %span.ui.button.disabled
                 Getting started guide

--- a/_layouts/project/project-migrate.html.haml
+++ b/_layouts/project/project-migrate.html.haml
@@ -29,7 +29,7 @@ layout: project-standard
             %span.ui.label.large
               %strong= release.version
               %span.detail= release.date
-            %span.ui.tag.label{:class => "#{release.stable ? 'green' : 'orange'}"} #{release.stable ? 'stable' : 'development'}
+            = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "tag" } )
             %p
               %span.ui.button.disabled
                 Migration guide

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -115,92 +115,101 @@ project_hero_partial: project/hero-series.html.haml
     documentation page.
 
 %h2{:id => "get-it"} How to get it
+- if series.endoflife
+  :asciidoc
+    :projectName: #{project_description.name}
+    :version: #{series.version}
+    [WARNING]
+    ====
+    {projectName} {version} has reached its end-of-life: we recommend you use a newer series if possible.
+    ====
 .ui.grid.equal.height.stackable.download-options
-  - if maven_repo
-    .eleven.wide.column
-      %h3 Maven, Gradle...
-      - if maven_repo[:bintray]
-        %p
-          Maven artifacts of #{project_description.name} are published to
-          %a{:href => site.maven.repo.central.web_ui_url}
-            Maven Central
-          and to
-          %a{:href => site.maven.repo.bintray.web_ui_url}
-            Bintray.
-      - elsif maven_repo[:jboss]
-        %p
-          Maven artifacts of #{project_description.name} are published to
-          %a{:href => site.maven.repo.central.web_ui_url}
-            Maven Central
-          and to the
-          %a{:href => site.maven.repo.jboss.web_ui_url}
-            JBoss Maven repository.
-          Refer to the
-          %a{:href => "http://community.maven.jboss.org/wiki/MavenGettingStarted-Users"} Maven Getting Started guide
-          on the JBoss Wiki for more information on how to configure the JBoss Maven repository.
-      - else
-        %p
-          Maven artifacts of #{project_description.name} are published to
-          %a{:href => site.maven.repo.central.web_ui_url}
-            Maven Central.
-      - if maven_repo[:bintray]
-        %p
-          You can find the Maven coordinates of all artifacts through the link below:
+  .row
+    - if maven_repo
+      .eleven.wide.column
+        %h3 Maven, Gradle...
+        - if maven_repo[:bintray]
           %p
-            %a.ui.right.labeled.button.primary.icon{:href => maven_bintray_url(maven_repo.bintray.package)}
-              %i.icon.cloud.cubes
-              Maven artifacts
-      - elsif maven_repo[:central]
-        %p
-          You can find the Maven coordinates of all artifacts through the link below:
+            Maven artifacts of #{project_description.name} are published to
+            %a{:href => site.maven.repo.central.web_ui_url}
+              Maven Central
+            and to
+            %a{:href => site.maven.repo.bintray.web_ui_url}
+              Bintray.
+        - elsif maven_repo[:jboss]
           %p
-            %a.ui.right.labeled.button.primary.icon{:href => maven_central_search_url(latest_release_group_id, maven_repo.central.artifact_id_pattern, latest_release.version)}
-              %i.icon.cloud.cubes
-              Maven artifacts
-      - if series[:artifacts]
+            Maven artifacts of #{project_description.name} are published to
+            %a{:href => site.maven.repo.central.web_ui_url}
+              Maven Central
+            and to the
+            %a{:href => site.maven.repo.jboss.web_ui_url}
+              JBoss Maven repository.
+            Refer to the
+            %a{:href => "http://community.maven.jboss.org/wiki/MavenGettingStarted-Users"} Maven Getting Started guide
+            on the JBoss Wiki for more information on how to configure the JBoss Maven repository.
+        - else
+          %p
+            Maven artifacts of #{project_description.name} are published to
+            %a{:href => site.maven.repo.central.web_ui_url}
+              Maven Central.
+        - if maven_repo[:bintray]
+          %p
+            You can find the Maven coordinates of all artifacts through the link below:
+            %p
+              %a.ui.right.labeled.button.primary.icon{:href => maven_bintray_url(maven_repo.bintray.package)}
+                %i.icon.cloud.cubes
+                Maven artifacts
+        - elsif maven_repo[:central]
+          %p
+            You can find the Maven coordinates of all artifacts through the link below:
+            %p
+              %a.ui.right.labeled.button.primary.icon{:href => maven_central_search_url(latest_release_group_id, maven_repo.central.artifact_id_pattern, latest_release.version)}
+                %i.icon.cloud.cubes
+                Maven artifacts
+        - if series[:artifacts]
+          %p
+            Below are the Maven coordinates of the main artifacts.
+          %dl.sparse
+            - series.artifacts.each do |artifact|
+              - group_id = latest_release_group_id
+              - artifact_id = artifact.artifact_id
+              - version = latest_release.version
+              - summary = artifact[:summary]
+              - summary ||= artifact.artifact_id
+              %dt
+                %a.ui.label.large.blue{:href => maven_central_artifact_url(group_id, artifact_id, version)}
+                  #{group_id}:#{artifact_id}:#{version}
+              %dd= summary
+              - if false # disabled for now, takes too much vertical space
+                :asciidoc
+                  :groupId: #{group_id}
+                  :artifactId: #{artifact_id}
+                  :version: #{version}
+                  [source,xml]
+                  [subs="verbatim,attributes"]
+                  ----
+                  <dependency>
+                      <groupId>{groupId}</groupId>
+                      <artifactId>{artifactId}</artifactId>
+                      <version>{version}</version>
+                  </dependency>
+                  ----
+        - if project_maven.signing&.since
+          %p
+            All Maven artifacts of this project released after #{project_maven.signing?.since} are signed.
+          %p
+            To verify signed Maven artifacts, head to
+            %a{:href => "/community/keys/"}
+              this page.
+    - if dist_sourceforge
+      .five.wide.column.divided
+        %h3 Zip archive
         %p
-          Below are the Maven coordinates of the main artifacts.
-        %dl.sparse
-          - series.artifacts.each do |artifact|
-            - group_id = latest_release_group_id
-            - artifact_id = artifact.artifact_id
-            - version = latest_release.version
-            - summary = artifact[:summary]
-            - summary ||= artifact.artifact_id
-            %dt
-              %a.ui.label.large.blue{:href => maven_central_artifact_url(group_id, artifact_id, version)}
-                #{group_id}:#{artifact_id}:#{version}
-            %dd= summary
-            - if false # disabled for now, takes too much vertical space
-              :asciidoc
-                :groupId: #{group_id}
-                :artifactId: #{artifact_id}
-                :version: #{version}
-                [source,xml]
-                [subs="verbatim,attributes"]
-                ----
-                <dependency>
-                    <groupId>{groupId}</groupId>
-                    <artifactId>{artifactId}</artifactId>
-                    <version>{version}</version>
-                </dependency>
-                ----
-      - if project_maven.signing&.since
+          Direct download is available from SourceForge:
         %p
-          All Maven artifacts of this project released after #{project_maven.signing?.since} are signed.
-        %p
-          To verify signed Maven artifacts, head to
-          %a{:href => "/community/keys/"}
-            this page.
-  - if dist_sourceforge
-    .five.wide.column.divided
-      %h3 Zip archive
-      %p
-        Direct download is available from SourceForge:
-      %p
-        %a.ui.right.labeled.button.primary.icon{:href => dist_sourceforge.zip_url, :title => "Download"}
-          %i.icon.cloud.download
-          Download Zip archive
+          %a.ui.right.labeled.button.primary.icon{:href => dist_sourceforge.zip_url, :title => "Download"}
+            %i.icon.cloud.download
+            Download Zip archive
 
 %p
   More information about specific releases (announcements, download links) can be found
@@ -209,6 +218,14 @@ project_hero_partial: project/hero-series.html.haml
 
 - if not getting_started_guide.nil?
   %h2{:id => "getting_started"} Getting started
+  - if series.endoflife
+    :asciidoc
+      :projectName: #{project_description.name}
+      :version: #{series.version}
+      [WARNING]
+      ====
+      {projectName} {version} has reached its end-of-life: we recommend you use a newer series if possible.
+      ====
   %p
     If you want to start using #{project_description.name}, please refer to the getting started guide:
   %p
@@ -270,6 +287,14 @@ project_hero_partial: project/hero-series.html.haml
 ~ content
 
 %h2{:id => "releases"} Releases in this series
+- if series.endoflife
+  :asciidoc
+    :projectName: #{project_description.name}
+    :version: #{series.version}
+    [WARNING]
+    ====
+    {projectName} {version} has reached its end-of-life: we recommend you use a newer series if possible.
+    ====
 - unless series.nil?
   .ui.stackable.grid.series-versions
     - series.releases.each do |release|

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -314,8 +314,17 @@ project_hero_partial: project/hero-series.html.haml
       .ui.row
         .three.wide.column
           %p
-            %span.ui.label.version{:class => "#{series.endoflife ? 'red' : (release.stable ? 'green' : 'orange')}"}
-              = version
+            - if series.endoflife
+              %span.ui.label.version.red
+                %span{:data => {:tooltip => "#{project_description.name} #{series.version} has reached its end-of-life: \n we recommend that you use a newer series if possible.", :position => "right center"}}
+                  = version
+            - elsif release.stable
+              %span.ui.label.version.green
+                = version
+            - else
+              %span.ui.label.version.orange
+                %span{:data => {:tooltip => "This is a development release: be prepared for changes.", :position => "right center"}}
+                  = version
           %p
             %small.ui.label= release.date
         .thirteen.wide.column

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -56,6 +56,22 @@ project_hero_partial: project/hero-series.html.haml
       %a.item{:href => "#releases"}
         Releases in this series
 
+- if series.endoflife
+  :asciidoc
+    :projectName: #{project_description.name}
+    :version: #{series.version}
+    [WARNING]
+    ====
+    {projectName} {version} has reached its end-of-life:
+
+    * it is unlikely to see another release;
+    * bugs are unlikely to get fixed in this version, even security vulnerabilities;
+    * pull requests against this version will be rejected;
+    * bug reproducers using this version will be given lower priority.
+
+    We encourage you to upgrade to a newer series if possible.
+    ====
+
 - unless series.integration_constraints.nil? || series.integration_constraints.empty?
   %h2{:id => "compatibility"} Compatibility
   %table.ui.collapsing.table.striped.celled.unstackable
@@ -273,7 +289,7 @@ project_hero_partial: project/hero-series.html.haml
       .ui.row
         .three.wide.column
           %p
-            %span.ui.label.version{:class => "#{release.stable ? 'green' : 'orange'}"}
+            %span.ui.label.version{:class => "#{series.endoflife ? 'red' : (release.stable ? 'green' : 'orange')}"}
               = version
           %p
             %small.ui.label= release.date

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -94,7 +94,7 @@ project_hero_partial: project/hero-series.html.haml
 
 %h2{:id => "documentation"} Documentation
 %p
-  Documentation for this specific series can be accessed through the links below:
+  Documentation for #{project_description.name} #{series.version} can be accessed through the links below:
 %p
   - reference_doc = reference_doc(project_description, series)
   %a.ui.right.labeled.icon.button(href="#{reference_doc.html_url}")
@@ -227,7 +227,7 @@ project_hero_partial: project/hero-series.html.haml
       {projectName} {version} has reached its end-of-life: we recommend you use a newer series if possible.
       ====
   %p
-    If you want to start using #{project_description.name}, please refer to the getting started guide:
+    If you want to start using #{project_description.name} #{series.version}, please refer to the getting started guide:
   %p
     - if not getting_started_guide.html_url.nil?
       %a.ui.right.labeled.icon.button(href="#{getting_started_guide.html_url}")

--- a/_layouts/project/project-releases.html.haml
+++ b/_layouts/project/project-releases.html.haml
@@ -22,15 +22,14 @@ project_buttons_partial: project/releases-buttons.html.haml
       \.
 
 %h2 Series
-- active_series = project_description.release_series.nil? ? nil : project_description.release_series.values.select{|s| s.displayed}
+- active_series = project_description.active_release_series
 - unless active_series.nil? || active_series.empty?
   .ui.three.column.doubling.grid.series.active-series.stackable
     - active_series.each do |series|
       - release = series.releases[0]
       .column
         .ui.raised.segment.version
-          %span{:class => "ui right ribbon label #{release.stable ? 'green' : 'orange'}"}
-            #{release.stable ? 'stable' : 'development'}
+          = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "right ribbon" } )
           %h3.ui.header
             = series.version
             %small
@@ -41,9 +40,9 @@ project_buttons_partial: project/releases-buttons.html.haml
               %i.right.arrow.icon
               More info
 - else
-  %p There are no releases configured for this project.
+  %p There are no active series for this project.
 
-- older_series = project_description.release_series.nil? ? nil : project_description.release_series.values.select{|s| !s.displayed}
+- older_series = project_description.older_release_series
 - unless older_series.nil? || older_series.empty?
   %p
     %a.ui.button.right.labeled.icon#older-series-button(href="javascript: void(0)")
@@ -68,8 +67,7 @@ project_buttons_partial: project/releases-buttons.html.haml
         - release = series.releases[0]
         .column
           .ui.raised.segment.version
-            %span{:class => "ui right ribbon label #{release.stable ? 'green' : 'orange'}"}
-              #{release.stable ? 'stable' : 'development'}
+            = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "right ribbon" } )
             %h3.ui.header
               = series.version
               %small
@@ -87,8 +85,7 @@ project_buttons_partial: project/releases-buttons.html.haml
       %tr
         %th
           = project_description.name
-        - project_description.release_series.values.each do |series|
-          - unless series.displayed then next end
+        - project_description.active_release_series.each do |series|
           %th
             = series.version
     %tbody
@@ -97,8 +94,7 @@ project_buttons_partial: project/releases-buttons.html.haml
           %td
             %a{:href => "#{integration['url']}"}
               = integration["name"]
-          - project_description.release_series.values.each do |series|
-            - unless series.displayed then next end
+          - project_description.active_release_series.each do |series|
             - constraint = series.integration_constraints[integration_id]
             %td
               - if constraint == nil

--- a/_layouts/project/project-releases.html.haml
+++ b/_layouts/project/project-releases.html.haml
@@ -29,7 +29,7 @@ project_buttons_partial: project/releases-buttons.html.haml
       - release = series.releases[0]
       .column
         .ui.raised.segment.version
-          = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "right ribbon" } )
+          = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "right ribbon", "tooltipPosition" => "left center" } )
           %h3.ui.header
             = series.version
             %small
@@ -67,7 +67,7 @@ project_buttons_partial: project/releases-buttons.html.haml
         - release = series.releases[0]
         .column
           .ui.raised.segment.version
-            = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "right ribbon" } )
+            = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "right ribbon", "tooltipPosition" => "left center" } )
             %h3.ui.header
               = series.version
               %small

--- a/_partials/menu/desktop-left-project.html.haml
+++ b/_partials/menu/desktop-left-project.html.haml
@@ -1,7 +1,7 @@
 - real_page = page['real_page']
 - current_path = page['real_page'].output_path.sub(/index\.html$/, "").sub(/\.html$/,"/")
 - project_description = page['project_description']
-- displayed_series = project_description.release_series.nil? ? nil : project_description.release_series.values.select{|s| s.displayed}
+- displayed_series = project_description.active_release_series
 - stable_series = project_description.latest_stable_series
 
 .ui.fluid.vertical.menu

--- a/_partials/project/banner-series.html.haml
+++ b/_partials/project/banner-series.html.haml
@@ -3,7 +3,6 @@
 - project_name = real_page.project ? project_description.name : ''
 - series = project_description.release_series[real_page.series_version]
 - real_page.title = "#{series.version} series"
-- latest_release = series.releases.first
 .jumbotron.small
   .ui.container
     .ui.grid.stackable
@@ -15,7 +14,7 @@
           %h2
             %span
               = real_page.title
-            %span.ui.label.tag{:class => "#{latest_release.stable ? 'green' : 'orange'}"} #{latest_release.stable ? 'stable' : 'development'}
+            = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "tag" } )
         .column.four.wide.middle.aligned
           = partial( real_page.project_buttons_partial.nil? ? 'project/empty-buttons.html.haml' : real_page.project_buttons_partial, { "real_page" => real_page } )
 

--- a/_partials/project/series-status-label.html.haml
+++ b/_partials/project/series-status-label.html.haml
@@ -1,12 +1,15 @@
 - series = page["series"]
 - classes = page["classes"]
+- tooltipPosition = page["tooltipPosition"] || "bottom center"
 
 - if series.endoflife
   %span.ui.label.red{:class => "#{classes}"}
-    end-of-life
+    %span{:data => {:tooltip => "#{series.project.name} #{series.version} has reached its end-of-life: \n we recommend that you use a newer series if possible.", :position => tooltipPosition}}
+      end-of-life
 - elsif series.stable
   %span.ui.label.green{:class => "#{classes}"}
     stable
 - else
   %span.ui.label.orange{:class => "#{classes}"}
-    development
+    %span{:data => {:tooltip => "#{series.project.name} #{series.version} is still in development: \n we encourage you to try it, but be prepared for changes.", :position => tooltipPosition}}
+      development

--- a/_partials/project/series-status-label.html.haml
+++ b/_partials/project/series-status-label.html.haml
@@ -1,0 +1,12 @@
+- series = page["series"]
+- classes = page["classes"]
+
+- if series.endoflife
+  %span.ui.label.red{:class => "#{classes}"}
+    end-of-life
+- elsif series.stable
+  %span.ui.label.green{:class => "#{classes}"}
+    stable
+- else
+  %span.ui.label.orange{:class => "#{classes}"}
+    development

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -42,7 +42,7 @@ div.logo img {
 		font-size: 4rem;
 		letter-spacing: 2px;
 
-		span {
+		> span {
 			background-color: #7d8a90;
 			padding: 3px;
 			padding-left: 10px;
@@ -54,7 +54,7 @@ div.logo img {
 		font-size: 2rem;
 		color: white;
 
-		span {
+		> span {
 			background-color: #7d8a90;
 			padding: 3px;
 			padding-left: 10px;
@@ -719,6 +719,11 @@ pre .comment .conum {
 
 .ui.items > .item > .content > a.header {
     color: #4183C4;
+}
+
+// Make sure newlines are properly rendered in tooltips (popups)
+[data-tooltip]:after {
+  white-space: pre;
 }
 
 // Semantic UI has these classes, however they're only applicable to

--- a/survival-guide.adoc
+++ b/survival-guide.adoc
@@ -203,10 +203,20 @@ in the `_data/<project ID>/releases/<series version>` directory.
 
 For information about the content of each file, see <<data_directory,here>>.
 
-=== Hide an older series
+=== Older/end-of-life'd series
 
-To hide an older series, edit the `_data/<project ID>/releases/<series version>/series.yml` file
-to set the `displayed` attribute to `false` (just add the attribute if it is missing).
+To mark a series as end-of-life (no longer maintained) and display the corresponding warnings,
+edit the `_data/<project ID>/releases/<series version>/series.yml` file
+to set the `endoflife` attribute to `true` (just add the attribute if it is missing).
+
+By default, an end-of-life'd series is considered "older" and not displayed with the other series:
+it is not displayed in the drop-down "Releases" submenu,
+it is moved to its own "Older series" section in the page listing all series,
+and it is not displayed in the project's compatibility matrix.
+
+You can override this behavior, to hide a non-EOL'd series or display an EOL'd series,
+by editing the `_data/<project ID>/releases/<series version>/series.yml` file
+and setting the `displayed` attribute to `true` or `false` (just add the attribute if it is missing).
 
 === Hide a specific release
 


### PR DESCRIPTION
See https://hibernate.zulipchat.com/#narrow/stream/132094-hibernate-orm-dev/topic/Unsupported.20versions

See on staging:

* List of series: https://staging.hibernate.org/orm/releases/
  * EOL'd series are not displayed by default (you must click "See older series")
  * EOL'd series have an explicit red label
  * EOL'd series are not displayed in the compatibility matrix
* Same for documentation, migration guides:
  * https://staging.hibernate.org/validator/documentation/
  * https://staging.hibernate.org/search/documentation/migrate/
* The page for an end-of-life'd series: https://staging.hibernate.org/orm/releases/5.2/
  * The tag in the banner is red and mentions the series is EOL'd
  * There is an explicit warning at the top of the page
  * There are several shorter, but still explicit warnings in other sections ("How to get it", "Getting started", "Releases in this series")
  * "stable" releases (bottom of the page) are red instead of green/orange

Also, tags/labels for development/end-of-life now have a tooltip to explain (shortly) what that means exactly. Let's not argue about the tooltip position though: I can't do much better because of how stacking and z-index works in HTML (other positions result in tooltip being hidden behind other components in the same page).