### PR TITLE
WEBSITE-640 Link to new Maven Central WebUI where possible

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -13,7 +13,8 @@ maven:
   repo:
     central:
       repo_url: 'https://repo.maven.apache.org/maven2/'
-      web_ui_url: 'https://search.maven.org'
+      web_ui_url: 'https://central.sonatype.com'
+      old_web_ui_url: 'https://search.maven.org'
     jboss:
       repo_url: 'https://repository.jboss.org/nexus/content/repositories/public/'
       web_ui_url: 'https://repository.jboss.org/nexus/index.html'

--- a/_ext/links.rb
+++ b/_ext/links.rb
@@ -26,16 +26,17 @@ module Awestruct
 
       def maven_central_search_url(coord, version)
         if coord.artifact_id_pattern?
+          # The new Maven Central WebUI doesn't support artifact ID patterns, so we fall back to the old WebUI.
           search_string = ERB::Util.url_encode("g:#{coord.group_id} AND a:#{coord.artifact_id_pattern} AND v:#{version}")
-          return "#{@site.maven.repo.central.web_ui_url}/search?q=#{search_string}"
+          return "#{@site.maven.repo.central.old_web_ui_url}/search?q=#{search_string}"
         else
-          search_string = ERB::Util.url_encode("g:#{coord.group_id} AND v:#{version}")
-          return "#{@site.maven.repo.central.web_ui_url}/search?q=#{search_string}"
+          search_string = ERB::Util.url_encode("g:#{coord.group_id} v:#{version}")
+          return "#{@site.maven.repo.central.web_ui_url}/search?q=#{search_string}&sort=name"
         end
       end
 
       def maven_central_artifact_url(group_id, artifact_id, version)
-        return "#{@site.maven.repo.central.web_ui_url}/artifact/#{group_id}/#{artifact_id}/#{version}/jar"
+        return "#{@site.maven.repo.central.web_ui_url}/artifact/#{group_id}/#{artifact_id}/#{version}"
       end
 
       def github_issues_url(project)


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/WEBSITE-640

I already pushed various cleanups that were necessary to get there, but this is the actual switch to the new WebUI (https://central.sonatype.com/) instead of the old one (https://search.maven.org/) for all our links from hibernate.org to Maven Central.

@gsmet @DavideD @sebersole Could you please have a look at the end result for your projects (I pushed it to [staging](https://staging.hibernate.org/))? Basically just try the various links to Maven artifacts on the release pages. I checked myself, but I'd feel better if someone else double-checked. Be sure to check both newer versions (project-specific group IDs) and older versions (same old `org.hibernate` group ID everywhere), because they will behave differently.

We need to switch because the old WebUI no longer works correctly: it redirects to the new one automatically, but drops the search query in the process, so our links basically all point to the main landing page, which is pointless. Even if it preserved the search query, the syntax is different on the new WebUI (`AND` is implicit, and an explicit `AND` will prevent any match), so it still wouldn't work.

There is one case where our current links could work, but it's far-fetched: if users, upon being redirected, click "go back to the old UI", they be redirected to the main landing page of the old UI (so, that still won't work). BUT... they will get a cookie that will prevent redirection, and the next time they click our link, it will work correctly.

Still, I think redirection is unlikely to work in most cases, so I think we need to link to the new one where possible.

Note:

1. There is a bug on the new WebUI that leads it to sometimes ignore the search query... I reported it: [MVNCENTRAL-7972](https://issues.sonatype.org/browse/MVNCENTRAL-7972)
2. The new WebUI doesn't support prefix queries at the moment (e.g. `a:hibernate-search-*`, see [MVNCENTRAL-7973](https://issues.sonatype.org/browse/MVNCENTRAL-7973)), so for now I'm still using links to the old web UI when we need prefix queries. Which, as I explained above, will only work the second time a user clicks such link, and only if they opted out of the new WebUI...