### PR TITLE
Don't list hibernate-validator-osgi in HV artifacts for recent versions

### DIFF
--- a/_data/projects/validator/releases/6.2/series.yml
+++ b/_data/projects/validator/releases/6.2/series.yml
@@ -5,8 +5,6 @@ maven:
       summary: Core implementation
     - artifact_id: hibernate-validator-cdi
       summary: CDI integration
-    - artifact_id: hibernate-validator-osgi
-      summary: OSGi integration
     - artifact_id: hibernate-validator-annotation-processor
       summary: Annotation processor
 integration_constraints:

--- a/_data/projects/validator/releases/7.0/series.yml
+++ b/_data/projects/validator/releases/7.0/series.yml
@@ -5,8 +5,6 @@ maven:
       summary: Core implementation
     - artifact_id: hibernate-validator-cdi
       summary: CDI integration
-    - artifact_id: hibernate-validator-osgi
-      summary: OSGi integration
     - artifact_id: hibernate-validator-annotation-processor
       summary: Annotation processor
 integration_constraints:

--- a/_data/projects/validator/releases/8.0/series.yml
+++ b/_data/projects/validator/releases/8.0/series.yml
@@ -5,8 +5,6 @@ maven:
       summary: Core implementation
     - artifact_id: hibernate-validator-cdi
       summary: CDI integration
-    - artifact_id: hibernate-validator-osgi
-      summary: OSGi integration
     - artifact_id: hibernate-validator-annotation-processor
       summary: Annotation processor
 integration_constraints:


### PR DESCRIPTION
This artifact no longer exists.

cc @gsmet 