### PR TITLE
Add lists of main artifacts for recent versions of Hibernate ORM

### DIFF
--- a/_data/projects/orm/releases/5.3/series.yml
+++ b/_data/projects/orm/releases/5.3/series.yml
@@ -4,6 +4,25 @@ maven:
   coord:
     group_id: org.hibernate
     main_artifact_id: hibernate-core
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-osgi
+      summary: OSGi integration
+    - artifact_id: hibernate-spatial
+      summary: Spatial support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+    - artifact_id: hibernate-hikaricp
+      summary: HikariCP connection pooling
+    - artifact_id: hibernate-c3p0
+      summary: c3p0 connection pooling
+    - artifact_id: hibernate-proxool
+      summary: Proxool connection pooling
+    - artifact_id: hibernate-infinispan
+      summary: Infinispan second-level caching
+    - artifact_id: hibernate-ehcache
+      summary: Ehcache second-level caching
 links:
   dist:
     sourceforge:

--- a/_data/projects/orm/releases/5.4/series.yml
+++ b/_data/projects/orm/releases/5.4/series.yml
@@ -4,6 +4,27 @@ maven:
   coord:
     group_id: org.hibernate
     main_artifact_id: hibernate-core
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-osgi
+      summary: OSGi integration
+    - artifact_id: hibernate-spatial
+      summary: Spatial support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+    - artifact_id: hibernate-hikaricp
+      summary: HikariCP connection pooling
+    - artifact_id: hibernate-c3p0
+      summary: c3p0 connection pooling
+    - artifact_id: hibernate-proxool
+      summary: Proxool connection pooling
+    - artifact_id: hibernate-jcache
+      summary: JCache second-level caching
+    - artifact_id: hibernate-infinispan
+      summary: Infinispan second-level caching
+    - artifact_id: hibernate-ehcache
+      summary: Ehcache second-level caching
 links:
   dist:
     sourceforge:

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -4,6 +4,27 @@ maven:
   coord:
     group_id: org.hibernate
     main_artifact_id: hibernate-core
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-osgi
+      summary: OSGi integration
+    - artifact_id: hibernate-spatial
+      summary: Spatial support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+    - artifact_id: hibernate-hikaricp
+      summary: HikariCP connection pooling
+    - artifact_id: hibernate-c3p0
+      summary: c3p0 connection pooling
+    - artifact_id: hibernate-proxool
+      summary: Proxool connection pooling
+    - artifact_id: hibernate-jcache
+      summary: JCache second-level caching
+    - artifact_id: hibernate-infinispan
+      summary: Infinispan second-level caching
+    - artifact_id: hibernate-ehcache
+      summary: Ehcache second-level caching
 links:
   dist:
     sourceforge:

--- a/_data/projects/orm/releases/5.6/series.yml
+++ b/_data/projects/orm/releases/5.6/series.yml
@@ -3,6 +3,27 @@ maven:
   coord:
     group_id: org.hibernate
     main_artifact_id: hibernate-core
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-osgi
+      summary: OSGi integration
+    - artifact_id: hibernate-spatial
+      summary: Spatial support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+    - artifact_id: hibernate-hikaricp
+      summary: HikariCP connection pooling
+    - artifact_id: hibernate-c3p0
+      summary: c3p0 connection pooling
+    - artifact_id: hibernate-proxool
+      summary: Proxool connection pooling
+    - artifact_id: hibernate-jcache
+      summary: JCache second-level caching
+    - artifact_id: hibernate-infinispan
+      summary: Infinispan second-level caching
+    - artifact_id: hibernate-ehcache
+      summary: Ehcache second-level caching
 integration_constraints:
   java:
     version: 8, 11, 17 or 18

--- a/_data/projects/orm/releases/6.0/series.yml
+++ b/_data/projects/orm/releases/6.0/series.yml
@@ -1,5 +1,21 @@
 summary: Performance, HQL, Criteria, Type System
 endoflife: true
+maven:
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-spatial
+      summary: Spatial support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+    - artifact_id: hibernate-hikaricp
+      summary: HikariCP connection pooling
+    - artifact_id: hibernate-c3p0
+      summary: c3p0 connection pooling
+    - artifact_id: hibernate-proxool
+      summary: Proxool connection pooling
+    - artifact_id: hibernate-jcache
+      summary: JCache second-level caching
 integration_constraints:
   java:
     version: 11, 17 or 18

--- a/_data/projects/orm/releases/6.1/series.yml
+++ b/_data/projects/orm/releases/6.1/series.yml
@@ -1,4 +1,20 @@
 summary: Subquery in FROM clause, JDBC Array support, Unified Mapping XSD
+maven:
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-spatial
+      summary: Spatial support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+    - artifact_id: hibernate-hikaricp
+      summary: HikariCP connection pooling
+    - artifact_id: hibernate-c3p0
+      summary: c3p0 connection pooling
+    - artifact_id: hibernate-proxool
+      summary: Proxool connection pooling
+    - artifact_id: hibernate-jcache
+      summary: JCache second-level caching
 integration_constraints:
   java:
     version: 11, 17 or 18

--- a/_data/projects/orm/releases/6.2/series.yml
+++ b/_data/projects/orm/releases/6.2/series.yml
@@ -1,4 +1,20 @@
 summary: Jakarta Persistence 3.1, records, structs, value generation, partitioning, SQL `MERGE`
+maven:
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-spatial
+      summary: Spatial support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+    - artifact_id: hibernate-hikaricp
+      summary: HikariCP connection pooling
+    - artifact_id: hibernate-c3p0
+      summary: c3p0 connection pooling
+    - artifact_id: hibernate-proxool
+      summary: Proxool connection pooling
+    - artifact_id: hibernate-jcache
+      summary: JCache second-level caching
 integration_constraints:
   java:
     version: 11, 17 or 18


### PR DESCRIPTION
That way, we display direct links to those artifacts and it's not such a big deal that the list of artifacts on the Maven Central WebUI is buggy.

cc @sebersole 