### PR TITLE
Add instructions for how to download artifacts directly from Maven Central

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -12,11 +12,11 @@ html_minifier: disabled
 maven:
   repo:
     central:
-      repo_url: 'https://repo.maven.apache.org/maven2/'
+      repo_url: 'https://repo.maven.apache.org/maven2'
       web_ui_url: 'https://central.sonatype.com'
       old_web_ui_url: 'https://search.maven.org'
     jboss:
-      repo_url: 'https://repository.jboss.org/nexus/content/repositories/public/'
+      repo_url: 'https://repository.jboss.org/nexus/content/repositories/public'
       web_ui_url: 'https://repository.jboss.org/nexus/index.html'
 
 jira:

--- a/_ext/links.rb
+++ b/_ext/links.rb
@@ -39,6 +39,11 @@ module Awestruct
         return "#{@site.maven.repo.central.web_ui_url}/artifact/#{group_id}/#{artifact_id}/#{version}"
       end
 
+      def maven_central_direct_download_url(coord)
+        group_id_path = coord.group_id.gsub('.', '/')
+        return "#{@site.maven.repo.central.repo_url}/#{group_id_path}/"
+      end
+
       def github_issues_url(project)
         return "https://github.com/hibernate/#{project.github['project']}/issues?q=is%3Aissue+is%3Aclosed+"
       end

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -380,7 +380,7 @@ module Awestruct
       end
 
       def get_uri(base_url, group_id, artifact, version)
-        base_url + group_id.gsub(/\./, "/") + '/' + artifact + '/' + version + '/' + get_pom_name(group_id, artifact, version)
+        base_url + '/' + group_id.gsub(/\./, "/") + '/' + artifact + '/' + version + '/' + get_pom_name(group_id, artifact, version)
       end
 
       def get_pom_name(group_id, artifact, version)

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -174,6 +174,24 @@ project_hero_partial: project/hero-series.html.haml
           %a.ui.right.labeled.button.primary.icon{:href => dist_sourceforge.zip_url, :title => "Download"}
             %i.icon.cloud.download
             Download Zip archive
+    - elsif maven_coord
+      .five.wide.column.divided
+        %h3 Direct download
+        %p
+          Direct download is available from Maven Central:
+          %a.ui.right.labeled.button.primary.icon{:href => maven_central_direct_download_url(maven_coord)}
+            %i.icon.cloud.download
+            Maven Central subdirectory
+        %p
+          See
+          %a{:href => "https://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-project-dependencies.html"}
+            here
+          for how to download all dependencies of your Maven project to a local directory on your filesystem.
+        %p
+          See
+          %a{:href => "https://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-artifacts.html"}
+            here
+          for how to download an explicitly listed set of artifacts to a local directory on your filesystem.
 
 %p
   More information about specific releases (announcements, download links) can be found


### PR DESCRIPTION
This should help people who used to download from SourceForge.

cc @beikov , now you'll be able to simply point people to our website in cases like [this](https://discourse.hibernate.org/t/download-links-not-working/7448/2?u=yrodiere).

I pushed this to staging, see for example https://staging.hibernate.org/orm/releases/6.2/#get-it