### PR TITLE
Add lists of main artifacts for Hibernate Reactive

### DIFF
--- a/_data/projects/reactive/releases/1.0/series.yml
+++ b/_data/projects/reactive/releases/1.0/series.yml
@@ -1,4 +1,8 @@
 summary: Initial release using Hibernate ORM 5.6 and Vert.x 4.1
+maven:
+  artifacts:
+    - artifact_id: hibernate-reactive-core
+      summary: Core implementation
 integration_constraints:
   java:
     version: 11, 16 or 17

--- a/_data/projects/reactive/releases/1.1/series.yml
+++ b/_data/projects/reactive/releases/1.1/series.yml
@@ -1,4 +1,8 @@
 summary: Release with Vert.x 4.2 and integration with Oracle
+maven:
+  artifacts:
+    - artifact_id: hibernate-reactive-core
+      summary: Core implementation
 integration_constraints:
   java:
     version: 11, 16 or 17


### PR DESCRIPTION
That way, we display direct links to those artifacts and it's not such a big deal that the list of artifacts on the Maven Central WebUI is buggy.

cc @DavideD 