### PR TITLE
Fix compatibility with Ruby 3.2

### DIFF
--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -335,7 +335,7 @@ module Awestruct
         pom_name = get_pom_name(group_id, artifact_id, version)
         # to avoid net access cache the downloaded POMs into the _tmp directory
         cached_pom = File.join(tmp_dir, pom_name)
-        if File.exists?(cached_pom)
+        if File.exist?(cached_pom)
           $LOG.info "Cache hit: #{gav}" if $LOG.info?
           f = File.open(cached_pom)
           doc = Nokogiri::XML(f)


### PR DESCRIPTION
See https://stackoverflow.com/questions/14351272/undefined-method-exists-for-fileclass-nomethoderror

From what I read, the old method was deprecated since Ruby 2.1 so we should be safe.