### PR TITLE
Maintenance policy: Colored labels, internal links and minor tweaks

### DIFF
--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -66,6 +66,8 @@ project_hero_partial: project/hero-series.html.haml
     * bug reproducers using this version will be given lower priority.
 
     We recommend that you upgrade to a newer series if possible.
+
+    See also the link:/community/maintenance-policy[Maintenance policy].
     ====
 - elsif series.status == 'limited-support'
   :asciidoc
@@ -81,6 +83,8 @@ project_hero_partial: project/hero-series.html.haml
     * bug reproducers using this version will be given lower priority.
 
     We recommend that you upgrade to a newer series if possible or look for link:../../support[paid support].
+
+    See also the link:/community/maintenance-policy[Maintenance policy].
     ====
 
 - unless series.integration_constraints.nil? || series.integration_constraints.empty?
@@ -103,7 +107,10 @@ project_hero_partial: project/hero-series.html.haml
   %p
     See also the
     %a{:href => "/community/compatibility-policy"}
-      Compatibility policy.
+      Compatibility policy
+    and
+    %a{:href => "/community/maintenance-policy"}
+      Maintenance policy.
 
 %h2{:id => "documentation"} Documentation
 %p
@@ -135,6 +142,8 @@ project_hero_partial: project/hero-series.html.haml
     [WARNING]
     ====
     {projectName} {version} has reached its end-of-life: we recommend that you upgrade to a newer series if possible.
+
+    See also the link:/community/maintenance-policy[Maintenance policy].
     ====
 - elsif series.status == 'limited-support'
   :asciidoc
@@ -143,6 +152,8 @@ project_hero_partial: project/hero-series.html.haml
     [WARNING]
     ====
     {projectName} {version} is in limited maintenance mode: we recommend that you upgrade to a newer series if possible or look for link:../../support[paid support].
+
+    See also the link:/community/maintenance-policy[Maintenance policy].
     ====
 .ui.grid.equal.height.stackable.download-options
   .row
@@ -235,6 +246,8 @@ project_hero_partial: project/hero-series.html.haml
       [WARNING]
       ====
       {projectName} {version} has reached its end-of-life: we recommend that you upgrade to a newer series if possible.
+
+      See also the link:/community/maintenance-policy[Maintenance policy].
       ====
   - elsif series.status == 'limited-support'
     :asciidoc
@@ -243,6 +256,8 @@ project_hero_partial: project/hero-series.html.haml
       [WARNING]
       ====
       {projectName} {version} is in limited maintenance mode: we recommend that you upgrade to a newer series if possible or look for link:../../support[paid support].
+
+      See also the link:/community/maintenance-policy[Maintenance policy].
       ====
   %p
     If you want to start using #{project_description.name} #{series.version}, please refer to the getting started guide:
@@ -341,6 +356,8 @@ project_hero_partial: project/hero-series.html.haml
     [WARNING]
     ====
     {projectName} {version} has reached its end-of-life: we recommend that you upgrade to a newer series if possible.
+
+    See also the link:/community/maintenance-policy[Maintenance policy].
     ====
 - elsif series.status == 'limited-support'
   :asciidoc
@@ -349,6 +366,8 @@ project_hero_partial: project/hero-series.html.haml
     [WARNING]
     ====
     {projectName} {version} is in limited maintenance mode: we recommend that you upgrade to a newer series if possible or look for link:../../support[paid support].
+
+    See also the link:/community/maintenance-policy[Maintenance policy].
     ====
 - unless series.nil?
   .ui.stackable.grid.series-versions

--- a/_layouts/project/project-releases.html.haml
+++ b/_layouts/project/project-releases.html.haml
@@ -112,7 +112,10 @@ project_buttons_partial: project/releases-buttons.html.haml
   %p
     See also the
     %a{:href => "/community/compatibility-policy"}
-      Compatibility policy.
+      Compatibility policy
+    and
+    %a{:href => "/community/maintenance-policy"}
+      Maintenance policy.
 
 ~ content
 

--- a/_partials/menu/desktop-left-community.html.haml
+++ b/_partials/menu/desktop-left-community.html.haml
@@ -36,6 +36,12 @@
     %i.grid.icon.history
     Compatibility policy
 
+  - href = "/community/maintenance-policy/"
+  - active = (href == current_path)
+  %a.item{:href => href, :class => "#{(active ? "active" : "")}"}
+    %i.grid.icon.wrench
+    Maintenance policy
+
   - href = "/community/license/"
   - active = (href == current_path)
   %a.item{:href => href, :class => "#{(active ? "active" : "")}"}

--- a/_partials/menu/mobile-section-community.html.haml
+++ b/_partials/menu/mobile-section-community.html.haml
@@ -37,6 +37,11 @@
       %a.item{:href => href, :class => "#{(current_path.start_with?( href ) ? "active" : "")}"}
         %i.grid.icon.history
         Compatibility policy
+      - href = "/community/maintenance-policy/"
+      - active = (href == current_path)
+      %a.item{:href => href, :class => "#{(current_path.start_with?( href ) ? "active" : "")}"}
+        %i.grid.icon.wrench
+        Maintenance policy
       - item_active = (current_path == '/community/license/')
       %a.item(href="/community/license/"){:class => "#{(item_active ? "active" : "")}"}
         %i.grid.icon.legal

--- a/community/maintenance-policy/index.adoc
+++ b/community/maintenance-policy/index.adoc
@@ -13,7 +13,7 @@ Hibernate is a series of large projects, and yet its core development team is am
 
 One of the lowest-hanging fruits for us in this regard is to maintain just the most recent release series. It is just not practical for us to support more than 1 or 2 branches simultaneously.
 
-Discussions about maintenance invariably depend on discussions about https://hibernate.org/community/compatibility-policy/#versioning-scheme[versioning].  For the purposes of this
+Discussions about maintenance invariably depend on discussions about link:/community/compatibility-policy/#versioning-scheme[versioning].  For the purposes of this
 discussion, there are a few important considerations -
 
 * Pre-Final releases (Alpha, Beta and CR) are actively in-development and subject to justifiable API and SPI changes.
@@ -23,7 +23,7 @@ discussion, there are a few important considerations -
 
 [NOTE]
 ====
-https://hibernate.org/community/compatibility-policy/#compatibility-api-spi[Compatibility] affects maintainability as well.
+link:/community/compatibility-policy/#compatibility-api-spi[Compatibility] affects maintainability as well.
 ====
 
 Therefore, "maintain" here means -
@@ -41,7 +41,7 @@ Therefore, "maintain" here means -
 {latest-stable}/{stable}::
   Series which are fully maintained.  Most Hibernate projects limit full maintainability to just the latest series; Hibernate Validator maintains multiple series.
 {limited-support}::
-  A level of maintainability between {latest-stable}/{stable} and {end-of-life} - backports to these series are highly restricted and releases are not guarenteed.  We recommend that you upgrade to a newer
+  A level of maintainability between {latest-stable}/{stable} and {end-of-life} - backports to these series are highly restricted and releases are not guaranteed.  We recommend that you upgrade to a newer
   series if possible or look for paid support - downstream frameworks or commercial offerings (e.g. Red Hat's) may provide stronger guarantees.
 {end-of-life}::
   The version has reached the end of its maintenance and support lifecycle.  We recommend that you upgrade to a newer series, if possible, because we are unlikely to fix bugs or provide

--- a/community/maintenance-policy/index.adoc
+++ b/community/maintenance-policy/index.adoc
@@ -1,5 +1,10 @@
 = Maintenance Policy
 :awestruct-layout: community-standard
+:development: pass:[<span class="ui small label orange">development</span>]
+:latest-stable: pass:[<span class="ui small label green">latest-stable</span>]
+:stable: pass:[<span class="ui small label green">stable</span>]
+:limited-support: pass:[<span class="ui small label yellow">limited-support</span>]
+:end-of-life: pass:[<span class="ui small label red">end-of-life</span>]
 
 [[background]]
 == Background
@@ -31,20 +36,20 @@ Therefore, "maintain" here means -
 [[levels]]
 == Maintenance Levels
 
-development::
-  Series which are still in pre-Final development are generally maintained at the same level as `(latest-)stable` releases, except that we reserve the right to make changes in new API and SPI.
-(latest-)stable::
+{development}::
+  Series which are still in pre-Final development are generally maintained at the same level as {latest-stable}/{stable} releases, except that we reserve the right to make changes in new API and SPI.
+{latest-stable}/{stable}::
   Series which are fully maintained.  Most Hibernate projects limit full maintainability to just the latest series; Hibernate Validator maintains multiple series.
-limited-support::
-  A level of maintainability between `stable` and `end-of-life` - backports to these series are highly restricted and releases are not guarenteed.  We recommend that you upgrade to a newer
+{limited-support}::
+  A level of maintainability between {latest-stable}/{stable} and {end-of-life} - backports to these series are highly restricted and releases are not guarenteed.  We recommend that you upgrade to a newer
   series if possible or look for paid support - downstream frameworks or commercial offerings (e.g. Red Hat's) may provide stronger guarantees.
-end-of-life::
+{end-of-life}::
   The version has reached the end of its maintenance and support lifecycle.  We recommend that you upgrade to a newer series, if possible, because we are unlikely to fix bugs or provide
   new releases for this series.
 
 [[take-aways]]
 == Take-aways
 
-* Only bug-reports verified against the `(latest-)stable` and `development` series are accepted.
-* Bug-fixes and improvements are only applied to `(latest-)stable` and `development` (and sometimes to `limited-support`) series.
-* Only `development` and `(latest-)stable` series are actively released.  Occasional releases of `limited-support` series may happen, but should not be expected. 
+* Only bug-reports verified against the {latest-stable}/{stable} and {development} series are accepted.
+* Bug-fixes and improvements are only applied to {latest-stable}/{stable} and {development} (and sometimes to {limited-support}) series.
+* Only {development} and {latest-stable}/{stable} series are actively released.  Occasional releases of {limited-support} series may happen, but should not be expected.

--- a/community/maintenance-policy/index.adoc
+++ b/community/maintenance-policy/index.adoc
@@ -14,7 +14,7 @@ Hibernate is a series of large projects, and yet its core development team is am
 One of the lowest-hanging fruits for us in this regard is to maintain just the most recent release series. It is just not practical for us to support more than 1 or 2 branches simultaneously.
 
 Discussions about maintenance invariably depend on discussions about link:/community/compatibility-policy/#versioning-scheme[versioning].  For the purposes of this
-discussion, there are a few important considerations -
+discussion, there are a few important considerations:
 
 * Pre-Final releases (Alpha, Beta and CR) are actively in-development and subject to justifiable API and SPI changes.
 * Final releases are considered stable - aside from changes necessary for bugfixes, the code is considered stable.
@@ -26,26 +26,34 @@ discussion, there are a few important considerations -
 link:/community/compatibility-policy/#compatibility-api-spi[Compatibility] affects maintainability as well.
 ====
 
-Therefore, "maintain" here means -
+Therefore, "maintain" here means:
 
-* series against which we accept bug reports (consider them valid)
-* series to which we apply changes 
-* series for which we actively produce releases
+* series against which we accept bug reports (consider them valid);
+* series to which we apply changes;
+* series for which we actively produce releases.
 
 
 [[levels]]
 == Maintenance Levels
 
-{development}::
-  Series which are still in pre-Final development are generally maintained at the same level as {latest-stable}/{stable} releases, except that we reserve the right to make changes in new API and SPI.
 {latest-stable}/{stable}::
-  Series which are fully maintained.  Most Hibernate projects limit full maintainability to just the latest series; Hibernate Validator maintains multiple series.
+Series which are fully maintained.
++
+Most Hibernate projects limit full maintainability to just the latest series; Hibernate Validator maintains multiple series.
+{development}::
+Series which are still in pre-Final development are generally maintained at the same level as {latest-stable}/{stable} releases,
+except that we reserve the right to make changes in new API and SPI.
 {limited-support}::
-  A level of maintainability between {latest-stable}/{stable} and {end-of-life} - backports to these series are highly restricted and releases are not guaranteed.  We recommend that you upgrade to a newer
-  series if possible or look for paid support - downstream frameworks or commercial offerings (e.g. Red Hat's) may provide stronger guarantees.
+A level of maintainability between {latest-stable}/{stable} and {end-of-life}.
++
+Backports to these series are highly restricted and releases are not guaranteed.
++
+We recommend that you upgrade to a newer series if possible or look for paid support:
+downstream frameworks or commercial offerings (e.g. Red Hat's) may provide stronger guarantees.
 {end-of-life}::
-  The version has reached the end of its maintenance and support lifecycle.  We recommend that you upgrade to a newer series, if possible, because we are unlikely to fix bugs or provide
-  new releases for this series.
+The version has reached the end of its maintenance and support lifecycle.
++
+We recommend that you upgrade to a newer series, if possible, because we are unlikely to fix bugs or provide new releases for this series.
 
 [[take-aways]]
 == Take-aways

--- a/community/maintenance-policy/index.adoc
+++ b/community/maintenance-policy/index.adoc
@@ -19,11 +19,11 @@ discussion, there are a few important considerations:
 * Pre-Final releases (Alpha, Beta and CR) are actively in-development and subject to justifiable API and SPI changes.
 * Final releases are considered stable - aside from changes necessary for bugfixes, the code is considered stable.
 * A `{major}.{minor}` combination (6.0, 6.1, 6.2, e.g.) is called a series.
-* Branches and maintainability are based on series.
+* Branches and maintenance are based on series.
 
 [NOTE]
 ====
-link:/community/compatibility-policy/#compatibility-api-spi[Compatibility] affects maintainability as well.
+link:/community/compatibility-policy/#compatibility-api-spi[Compatibility] affects maintenance as well.
 ====
 
 Therefore, "maintain" here means:
@@ -39,12 +39,12 @@ Therefore, "maintain" here means:
 {latest-stable}/{stable}::
 Series which are fully maintained.
 +
-Most Hibernate projects limit full maintainability to just the latest series; Hibernate Validator maintains multiple series.
+Most Hibernate projects limit full maintenance to just the latest series; Hibernate Validator maintains multiple series.
 {development}::
 Series which are still in pre-Final development are generally maintained at the same level as {latest-stable}/{stable} releases,
 except that we reserve the right to make changes in new API and SPI.
 {limited-support}::
-A level of maintainability between {latest-stable}/{stable} and {end-of-life}.
+A level of maintenance between {latest-stable}/{stable} and {end-of-life}.
 +
 Backports to these series are highly restricted and releases are not guaranteed.
 +


### PR DESCRIPTION
For the maintenance policy itself, I actually didn't change much of the content, but the few formatting changes mess up the diff; sorry about that. It's probably easier to compare visually between production and staging:

* Production (before): https://hibernate.org/community/maintenance-policy/
* Staging (after): https://staging.hibernate.org/community/maintenance-policy/

Here are some screenshots.

Before | After
:-------------------------:|:-------------------------:
![image](https://github.com/hibernate/hibernate.org/assets/412878/ec26f718-b6ac-4458-9fb0-489c83d0fa0c) | ![image](https://github.com/hibernate/hibernate.org/assets/412878/772e0250-4b88-4ffc-b0b1-7e427b5c7d4d)


Regarding the colored labels, I'm on the fence. Maybe I should only have used them for the heading of each entry in the "maintenance level" list. I don't know.
