### PR TITLE
[ORM] Add a page to list all migration guides

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -128,7 +128,7 @@ projects:
           css_class: 'folder open'
           documentation_submenu: true
         - name: Migration guides
-          href: 'https://github.com/hibernate/hibernate-orm/wiki/Migration-Guides'
+          href: '/orm/documentation/migrate/'
           css_class: 'share'
         - name: Books
           href: '/orm/books/'

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -85,7 +85,7 @@ projects:
       getting_started_guide:
         html: https://docs.jboss.org/hibernate/orm/{series.version}/quickstart/html_single/
       migration_guide:
-        html: https://github.com/hibernate/hibernate-orm/wiki/Migration-Guides
+        html: https://github.com/hibernate/hibernate-orm/blob/{series.latest_scm_ref}/migration-guide.adoc
       dist:
         # No longer distributing dists on sourceforge, starting with ORM 6.0.
     maven:
@@ -215,6 +215,7 @@ projects:
       key: HSEARCH
     github:
       project: hibernate-search
+      final_suffix_in_tags: true
     integrations:
       java:
         name: Java
@@ -385,6 +386,7 @@ projects:
       key: HV
     github:
       project: hibernate-validator
+      final_suffix_in_tags: true
     integrations:
       java:
         name: Java
@@ -492,6 +494,7 @@ projects:
       key: OGM
     github:
       project: hibernate-ogm
+      final_suffix_in_tags: true
     integrations:
       java:
         name: Java

--- a/_data/projects/orm/releases/4.2/series.yml
+++ b/_data/projects/orm/releases/4.2/series.yml
@@ -7,6 +7,8 @@ links:
   dist:
     sourceforge:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
+  migration_guide:
+    html:
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/4.3/series.yml
+++ b/_data/projects/orm/releases/4.3/series.yml
@@ -7,6 +7,8 @@ links:
   dist:
     sourceforge:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
+  migration_guide:
+    html:
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/5.1/series.yml
+++ b/_data/projects/orm/releases/5.1/series.yml
@@ -3,6 +3,8 @@ links:
   dist:
     sourceforge:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
+  migration_guide:
+    html: https://hibernate.org/orm/documentation/5.1/migration/
 maven:
   coord:
     group_id: org.hibernate

--- a/_ext/links.rb
+++ b/_ext/links.rb
@@ -62,6 +62,7 @@ module Awestruct
           return nil
         end
         return pattern.gsub('{series.version}', series&.version || '')
+            .gsub('{series.latest_scm_ref}', series&.latest_scm_ref || '')
             .gsub('{release.version}', release&.version || '')
             .gsub('{series.version.dashes}', series&.version&.gsub('.', '-') || '')
       end

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -149,6 +149,14 @@ module Awestruct
         else
           raise StandardError, "Unsupported version scheme for #{release_file}: #{release.version}"
         end
+
+        if release[:scm_tag] == nil
+          if project.github['final_suffix_in_tags']
+            release[:scm_tag] = release.version
+          else
+            release[:scm_tag] = release.version =~ /^(.*).Final$/ ? $1 : release.version
+          end
+        end
         
         return release
       end
@@ -220,6 +228,13 @@ module Awestruct
               end
             end
             series[:endoflife] = series[:status] == 'end-of-life'
+
+            # The latest series might have its own branch, or might still be on main.
+            # We don't know so we won't try to guess.
+            if series[:scm_branch] == nil && !series.latest
+              series[:scm_branch] = series.version
+            end
+            series.latest_scm_ref = series[:scm_branch] || series.releases&.first&.scm_tag
           end
         end
         project[:active_release_series] = project[:release_series].nil? ? nil

--- a/orm/documentation/migrate/index.adoc
+++ b/orm/documentation/migrate/index.adoc
@@ -1,0 +1,20 @@
+= Migration guides
+:awestruct-layout: project-migrate
+:awestruct-project: orm
+:page-interpolate: true
+
+== Older Hibernate ORM versions
+
+Please note these versions have not been maintained for a long time, so migrating to a more recent version is a very good idea.
+
+* _4.3 missing_
+* _4.2 missing_
+* _4.1 missing_
+* https://developer.jboss.org/docs/DOC-16473[4.0]
+* https://developer.jboss.org/docs/DOC-15659[3.6]
+* https://developer.jboss.org/docs/DOC-16370[3.5]
+* _3.4 was skipped_
+* https://developer.jboss.org/docs/DOC-15066[3.3]
+* https://developer.jboss.org/docs/DOC-15065[3.2]
+* https://developer.jboss.org/docs/DOC-15063[3.1]
+* https://developer.jboss.org/docs/DOC-15062[3.0]


### PR DESCRIPTION
See http://staging.hibernate.org/orm/documentation/migrate

The only drawback compared to the current solution of manually editing a wiki is that the link to the migration guide of the latest series always points to a tag, as opposed to a branch. That's because I can't be sure whether the latest series has its own branch already (e.g. `6.5`) or is still on the `main` branch. Getting more certainty would require annoying manual configuration, so I considered this an acceptable trade-off.