### PR TITLE
[HSEARCH] Update roadmap to push static metamodel to the next major

### DIFF
--- a/search/roadmap.adoc
+++ b/search/roadmap.adoc
@@ -18,13 +18,22 @@ Dates are generally omitted: milestones are released regularly, the Final releas
 For a full list of issues currently planned for this series,
 see https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HSEARCH%20AND%20fixVersion%20%3D%207.2-backlog%20ORDER%20BY%20created%20DESC[here].
 
-* link:{hsearch-jira-url-prefix}/HSEARCH-4951[HSEARCH-4951] Static metamodel for Hibernate Search
 * link:{hsearch-jira-url-prefix}/HSEARCH-4962[HSEARCH-4962] APIs to support Hibernate Search Tools
+* link:{hsearch-jira-url-prefix}/HSEARCH-5133[HSEARCH-5133] Add metrics aggregations
 
-== Hibernate Search 7.3
+== Hibernate Search 8.0
 
 For a full list of issues currently planned for this series,
-see https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HSEARCH%20AND%20fixVersion%20%3D%207.3-backlog%20ORDER%20BY%20created%20DESC[here].
+see https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HSEARCH%20AND%20fixVersion%20%3D%208.0-backlog%20ORDER%20BY%20created%20DESC[here].
+
+* link:{hsearch-jira-url-prefix}/HSEARCH-4951[HSEARCH-4951] Static metamodel for Hibernate Search
+* link:{hsearch-jira-url-prefix}/HSEARCH-5082[HSEARCH-5082] Upgrade to Hibernate ORM 7.0
+
+
+== Hibernate Search 8.1
+
+For a full list of issues currently planned for this series,
+see https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HSEARCH%20AND%20fixVersion%20%3D%208.1-backlog%20ORDER%20BY%20created%20DESC[here].
 
 * link:{hsearch-jira-url-prefix}/HSEARCH-4974[HSEARCH-4970] Better observability in Hibernate Search
 * link:{hsearch-jira-url-prefix}/HSEARCH-4977[HSEARCH-4977] Better highlighting/projections in nested fields


### PR DESCRIPTION
if this makes sense, I'll rename/add versions in JIRA to match 