### PR TITLE
Fix Zulip chat link

### DIFF
--- a/community/index.adoc
+++ b/community/index.adoc
@@ -104,7 +104,7 @@ https://lists.jboss.org/mailman/listinfo/hibernate-dev[Development mailing list]
 Discussion list for developers to brainstorm ideas. Between JIRA and this mailing, you will not miss 
 any discussion.
 
-https://hibernate.zulipchat.com/chat[Zulip]::
+https://hibernate.zulipchat.com[Zulip]::
 The Hibernate team maintains multiple development-oriented https://zulip.com/[Zulip] channels (called "streams"), one per project.
 +++<br />
 <div class="ui labels blue">


### PR DESCRIPTION
The current Zulip chat link leads to a 404 error. The new goes straight to the Hibernate chat.

Please, let me know if this PR makes sense.