### PR TITLE
Take into account change of license for Search 7.2.0.Alpha2

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -207,8 +207,10 @@ projects:
     blog_tag: Hibernate Search
     blog_tag_url: hibernate-search
     license:
-      name: LGPL v2.1
-      url: https://raw.github.com/hibernate/hibernate-search/main/lgpl.txt
+      name: ASL v2
+      url: https://raw.github.com/hibernate/hibernate-search/main/LICENSE.txt
+      # This data is also overridden in relevant series.yml and 7.2.0.Alpha1.yml to display correctly on releases pages
+      since: "7.2.0.Alpha2"
     jira:
       key: HSEARCH
     github:

--- a/_data/projects/search/releases/4.4/series.yml
+++ b/_data/projects/search/releases/4.4/series.yml
@@ -1,4 +1,7 @@
 summary: Dynamic index sharding, new Metadata API, Hibernate ORM 4.2.x compatible
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/4.4/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/4.5/series.yml
+++ b/_data/projects/search/releases/4.5/series.yml
@@ -1,4 +1,7 @@
 summary: Performance, WildFly 8 compatibility, JPA 2.1 / Hibernate ORM 4.3 compatibility
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/4.5/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.0/series.yml
+++ b/_data/projects/search/releases/5.0/series.yml
@@ -1,4 +1,7 @@
 summary: Upgrade to Lucene 4 and much much more ...
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.0/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.1/series.yml
+++ b/_data/projects/search/releases/5.1/series.yml
@@ -1,4 +1,7 @@
 summary: Upgrade to Lucene 4 and much much more ...
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.1/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.10/series.yml
+++ b/_data/projects/search/releases/5.10/series.yml
@@ -1,6 +1,9 @@
 summary: ORM 5.3 and JPA 2.2 compatibility, integration to DI frameworks through Hibernate ORM 5.3, upgrade to WildFly 17 and JGroups 4, JPMS automatic module names.
 status: limited-support
 displayed: false
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.10/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.11/series.yml
+++ b/_data/projects/search/releases/5.11/series.yml
@@ -1,4 +1,7 @@
 summary: ORM 5.4 compatibility.
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.11/lgpl.txt
 links:
   getting_started_guide:
     html: /search/documentation/getting-started/5.11

--- a/_data/projects/search/releases/5.2/series.yml
+++ b/_data/projects/search/releases/5.2/series.yml
@@ -1,4 +1,7 @@
 summary: Multi-tenancy, optimisations in criteria based loaders
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.2/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.3/series.yml
+++ b/_data/projects/search/releases/5.3/series.yml
@@ -1,4 +1,7 @@
 summary: Improved Faceting
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.3/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.4/series.yml
+++ b/_data/projects/search/releases/5.4/series.yml
@@ -1,4 +1,7 @@
 summary: Requires Hibernate ORM 5.0.0.Final; Last version compatible with Apache Lucene 4.x
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.4/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.5/series.yml
+++ b/_data/projects/search/releases/5.5/series.yml
@@ -1,4 +1,7 @@
 summary: Being maintained as it's included in WildFly. Supports Lucene only, requires Hibernate ORM 5.0.z or 5.1.z
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.5/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.6/series.yml
+++ b/_data/projects/search/releases/5.6/series.yml
@@ -1,4 +1,7 @@
 summary: Introduces experimental support for Elasticsearch, last release supporting Hibernate ORM 5.0.z or 5.1.z
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.6/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.7/series.yml
+++ b/_data/projects/search/releases/5.7/series.yml
@@ -1,4 +1,7 @@
 summary: Improved integration with Elasticsearch 2.x, compatible with Hibernate ORM 5.2.x
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.7/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.8/series.yml
+++ b/_data/projects/search/releases/5.8/series.yml
@@ -1,4 +1,7 @@
 summary: Experimental integration with Elasticsearch 5.x, AWS integration, improvements and deprecations paving the road to Search 6
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.8/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/5.9/series.yml
+++ b/_data/projects/search/releases/5.9/series.yml
@@ -1,4 +1,7 @@
 summary: JSR 352 (Batch for Java) mass indexing job, WildFly feature packs, improvements and deprecations paving the road to Search 6
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/5.9/lgpl.txt
 links:
   getting_started_guide:
     displayed: false

--- a/_data/projects/search/releases/6.0/series.yml
+++ b/_data/projects/search/releases/6.0/series.yml
@@ -2,6 +2,9 @@ summary: >-
   API overhaul.
   Safer and more concise Search DSL, more powerful bridges, smarter automatic indexing, nested documents.
   Upgrades to Lucene 8 and Elasticsearch 7.
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/6.0/lgpl.txt
 links:
   getting_started_guide:
     html: https://docs.jboss.org/hibernate/search/{series.version}/reference/en-US/html_single/#getting-started

--- a/_data/projects/search/releases/6.1/series.yml
+++ b/_data/projects/search/releases/6.1/series.yml
@@ -2,6 +2,9 @@ summary: >-
   Asynchronous, distributed automatic indexing, OpenSearch compatibility, search DSL improvements, conditional mass indexing,
   ORM 5.6, Lucene 8.11, Elasticsearch 7.16,
   Jakarta EE artifacts, ORM 6 artifacts.
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/6.1/lgpl.txt
 links:
   getting_started_guide:
     html: https://docs.jboss.org/hibernate/search/{series.version}/reference/en-US/html_single/#getting-started

--- a/_data/projects/search/releases/6.2/series.yml
+++ b/_data/projects/search/releases/6.2/series.yml
@@ -8,6 +8,9 @@ summary: >-
   compatibility with Elasticsearch 8.9 and OpenSearch 2.9,
   upgrade of `-orm6` artifacts to Hibernate ORM 6.2.
 status: limited-support
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/6.2/lgpl.txt
 maven:
   artifacts:
     - artifact_id: hibernate-search-mapper-orm-orm6

--- a/_data/projects/search/releases/7.0/series.yml
+++ b/_data/projects/search/releases/7.0/series.yml
@@ -8,6 +8,9 @@ summary: >-
   dropped compatibility with EOL'd Elasticsearch versions 5.x, 6.x, 7.0-7.9 and OpenSearch versions 1.0-1.2,
   other bugfixes and improvements
 status: limited-support
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/7.0/lgpl.txt
 maven:
   artifacts:
     - artifact_id: hibernate-search-bom

--- a/_data/projects/search/releases/7.1/series.yml
+++ b/_data/projects/search/releases/7.1/series.yml
@@ -6,6 +6,9 @@ summary: >-
   compatibility with Elasticsearch 8.12/8.13 and OpenSearch 2.12/2.13,
   upgrade to Lucene 9.9,
   other bugfixes, improvements and upgrades
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/7.1/lgpl.txt
 maven:
   artifacts:
     - artifact_id: hibernate-search-bom

--- a/_data/projects/search/releases/7.2/7.2.0.Alpha1.yml
+++ b/_data/projects/search/releases/7.2/7.2.0.Alpha1.yml
@@ -9,3 +9,6 @@ summary: >-
   upgrade to Lucene 9.10,
   upgrade to Hibernate ORM 6.5,
   other bugfixes, improvements and upgrades
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-search/7.2.0.Alpha1/lgpl.txt

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -121,6 +121,11 @@ module Awestruct
         if ( series[:version] == nil )
           series[:version] = File.basename( series_dir )
         end
+
+        if ( series[:license] == nil )
+          series[:license] = project.license
+        end
+
         series[:releases] = Array.new
         return series
       end
@@ -156,6 +161,10 @@ module Awestruct
           else
             release[:scm_tag] = release.version =~ /^(.*).Final$/ ? $1 : release.version
           end
+        end
+
+        if ( release[:license] == nil )
+          release[:license] = series.license
         end
         
         return release

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -395,6 +395,9 @@ project_hero_partial: project/hero-series.html.haml
                 = version
           %p
             %small.ui.label= release.date
+          %p
+            %small.ui.label
+              %a{:href => "#{release.license.url}"}= release.license.name
         .thirteen.wide.column
           - if release[:summary]
             %p

--- a/_partials/menu/desktop-left-project.html.haml
+++ b/_partials/menu/desktop-left-project.html.haml
@@ -55,3 +55,7 @@
 .license
   Released under the
   %a{:href => "#{project_description.license.url}"}= project_description.license.name
+  - if project_description.license.since
+    since version
+    #{project_description.license.since}
+    (check release descriptions for earlier versions)

--- a/community/license.adoc
+++ b/community/license.adoc
@@ -45,8 +45,5 @@ In a native image that includes LGPL-licensed code from Hibernate, the Hibernate
 
 == ASL 2.0
 
-Some Hibernate projects are released under link:https://opensource.org/licenses/Apache-2.0[ASL 2.0].
-
-This is mostly due to our work with the Java Community Process: implementing a reference implementation in practice requires such a liberal license (or a fully proprietary one strangely enough).
-
-
+Some Hibernate projects are released under link:https://opensource.org/licenses/Apache-2.0[ASL 2.0],
+and the Hibernate team is link:https://in.relation.to/2023/11/18/license/[trying to move more projects to that license].


### PR DESCRIPTION
See staging.

Result:

![image](https://github.com/hibernate/hibernate.org/assets/412878/421e2f7b-16fe-48dd-b93f-34b66b62bf94)


And when we'll have a 7.2.0.Alpha2, we'll get something like this (license names are links to the license):

![image](https://github.com/hibernate/hibernate.org/assets/412878/81bb3bf4-d3de-4333-8b65-95ba580a1310)


@marko-bekhta be careful when releasing 7.2.0.Alpha2, you must not copy `7.2.0.Alpha1.yml` blindly, as there is now a license override in that file!