### PR TITLE
[HSEARCH] Mark Hibernate Search 7.1 series as compatible with Hibernate ORM 6.5

### DIFF
--- a/_data/projects/search/releases/7.1/series.yml
+++ b/_data/projects/search/releases/7.1/series.yml
@@ -35,7 +35,7 @@ integration_constraints:
   java:
     version: 11, 17 or 21
   orm:
-    version: 6.4
+    version: 6.4/6.5
   elasticsearch:
     version: 7.10 - 8.13
   opensearch:


### PR DESCRIPTION
related to https://github.com/hibernate/hibernate-search/pull/4199