### PR TITLE
Update Java compatibility information

### DIFF
--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -17,6 +17,6 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 11, 17 or 21
+    version: 11, 17, 21, 22 or 23
   jakarta_jpa:
     version: 3.1

--- a/_data/projects/orm/releases/7.0/series.yml
+++ b/_data/projects/orm/releases/7.0/series.yml
@@ -19,6 +19,6 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 17 or 21
+    version: 17, 21 or 23
   jakarta_jpa:
     version: 3.2

--- a/_data/projects/reactive/releases/2.4/series.yml
+++ b/_data/projects/reactive/releases/2.4/series.yml
@@ -5,7 +5,7 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 11, 17, 20, 21, and 22
+    version: 11, 17, 20, 21, 22 or 23
   orm:
     version: 6.6
   vertx:

--- a/_data/projects/search/releases/7.2/series.yml
+++ b/_data/projects/search/releases/7.2/series.yml
@@ -33,7 +33,7 @@ maven:
       summary: Helper for migrating from Hibernate Search 5 to Hibernate Search 6/7 (Hibernate ORM mapper + Lucene backend)
 integration_constraints:
   java:
-    version: 11, 17, 21 or 22
+    version: 11, 17, 21, 22 or 23
   orm:
     version: 6.6
   elasticsearch:

--- a/_data/projects/validator/releases/8.0/series.yml
+++ b/_data/projects/validator/releases/8.0/series.yml
@@ -9,7 +9,7 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 11, 17 or 21
+    version: 11, 17, 21, 22 or 23
   jbv:
     version: 3.0
   jee:

--- a/_data/projects/validator/releases/9.0/series.yml
+++ b/_data/projects/validator/releases/9.0/series.yml
@@ -20,7 +20,7 @@ maven:
       summary: Set of test utilities that can help testing custom constraints.
 integration_constraints:
   java:
-    version: 17, 21 or 22
+    version: 17, 21, 22 or 23
   jbv:
     version: 3.1
   jee:


### PR DESCRIPTION
... to match what actually gets tested on our CI.

@sebersole I noticed ORM only mentioned LTS releases, so I added missing STS releases (22/23) as well. Hope that's okay?