### PR TITLE
Update navigation menu

### DIFF
--- a/_partials/menu/desktop-top.html.haml
+++ b/_partials/menu/desktop-top.html.haml
@@ -9,6 +9,8 @@
     %a.item{:href => "/ogm/", :class=>"#{'active' if current_path.start_with?('/ogm')}"} OGM
   %a.item{:href => "/reactive/", :class=>"#{'active' if current_path.start_with?('/reactive')}"} Reactive
   %a.item{:href => "/repositories/", :class=>"#{'active' if current_path.start_with?('/repositories')}"} Repositories
+  - if current_path.start_with?('/tools')
+    %a.item{:href => "/tools/", :class=>"#{'active' if current_path.start_with?('/tools')}"} Tools
   %a.item{:href => "/others/", :class=>"#{'active' if current_path.start_with?('/others')}"} Others
   .right.menu
     %a.item(href="#{site.in_relation_to.base_url}") Blog

--- a/_partials/menu/mobile.html.haml
+++ b/_partials/menu/mobile.html.haml
@@ -10,7 +10,8 @@
       = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'OGM', 'project_key' => 'ogm', 'project_icon' => 'sitemap'})
     = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'Reactive', 'project_key' => 'reactive', 'project_icon' => 'flask'})
     = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'Repositories', 'project_key' => 'repositories', 'project_icon' => 'university'})
-    = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'Tools', 'project_key' => 'tools', 'project_icon' => 'wrench'})
+    - if current_path.start_with?('/tools')
+      = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'Tools', 'project_key' => 'tools', 'project_icon' => 'wrench'})
     %a.item(href="/others/")
       Others
     = partial( 'menu/mobile-section-community.html.haml', {'real_page' => real_page})

--- a/index.html.haml
+++ b/index.html.haml
@@ -81,7 +81,7 @@ title: Hibernate. Everything data.
             %a{:href => relative("/others/")} Others
           %p
             %i.big.icon.pause
-            Less-active projects (Hibernate OGM, Hibernate Shards).
+            Less-active projects (Hibernate Tools, Hibernate OGM, Hibernate Shards).
           .ui.right.aligned.basic.segment
             %a.ui.button.right.labeled.icon.a.primary{:href => relative("/others/")}
               %i.right.arrow.icon

--- a/others/index.adoc
+++ b/others/index.adoc
@@ -5,6 +5,15 @@ Emmanuel Bernard
 We always have new ideas to solve data related problems.
 You will find some of these experiments here.
 
+== Hibernate Tools
+
+++++
+<a class="ui button right labeled icon a primary" href="/tools/">
+  <i class="right arrow icon"></i>
+  More about Hibernate Tools
+</a>
+++++
+
 == Hibernate OGM
 
 [role="ui message warning"]

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -264,15 +264,20 @@
 		color: #666;
 		font-size: 1.5em;
 		margin-bottom: 15px;
-		border-bottom: 2px dotted #bcae79;
-		padding-bottom: 2px;
-		display: inline-block;
 	}
 
 	h4 {
 		margin-top: 15px !important;
 		color: #888;
 		font-size: 1.3em;
+	}
+
+	.sectionbody {
+		h3 {
+			border-bottom: 2px dotted #bcae79;
+			padding-bottom: 2px;
+			display: inline-block;
+		}
 	}
 
 	.sect1:not(:last-child) {


### PR DESCRIPTION
- add tools as a "hidden" menu option, otherwise it looks a bit awkward when you are on the /tools page 
- adjust the mobile menu (to match what we do for the descktop one)
- add tools to the "Others" so it is not completely "invisible" on the site, but I'm not sure if that's the place for it and what the text we can add there ... 