### PR TITLE
Add information about project governance and team

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -391,6 +391,10 @@ projects:
     license:
       name: LGPL v2.1
       url: https://github.com/hibernate/hibernate-tools/blob/master/lgpl.txt
+    jira:
+      key: HBX
+    github:
+      project: hibernate-tools
     menu:
       intern:
         - name: About

--- a/_data/governance.yml
+++ b/_data/governance.yml
@@ -1,0 +1,11 @@
+leaders:
+  # Order is consistent with the order of projects in the top menu.
+  sebersole:
+    - orm
+  marko-bekhta:
+    - search
+    - validator
+  DavideD:
+    - reactive
+  koentsje:
+    - tools

--- a/_data/governance.yml
+++ b/_data/governance.yml
@@ -9,3 +9,6 @@ leaders:
     - reactive
   koentsje:
     - tools
+roles:
+  gavinking:
+    - '<a href="https://github.com/orgs/commonhaus/teams/cf-egc">Project Representative to the CommonHaus Foundation for Hibernate</a>'

--- a/_layouts/community/community-contributors.html.haml
+++ b/_layouts/community/community-contributors.html.haml
@@ -17,10 +17,10 @@ layout: community-standard
 
 %p &nbsp;
 
-.text-center#contributor-loader
+.text-center#list-loader
   %i.notched.circle.loading.icon.massive
 
-#contributor-list(style="display:none")
+#list.contributor-list(style="display:none")
 
 :javascript
   $(document).ready(function() {
@@ -38,8 +38,8 @@ layout: community-standard
         );
       });
 
-      $( '#contributor-list' ).append( items );
-      $( '#contributor-loader' ).hide();
-      $( '#contributor-list' ).fadeIn();
+      $( '#list' ).append( items );
+      $( '#list-loader' ).hide();
+      $( '#list' ).fadeIn();
     });
   });

--- a/_partials/menu/desktop-left-community.html.haml
+++ b/_partials/menu/desktop-left-community.html.haml
@@ -63,6 +63,12 @@
       - href = "/community/contributors/reactive/"
       %a.item{:href => href, :class => "#{(current_path.start_with?( href ) ? "selected" : "")}"}
         Hibernate Reactive
+      - href = "/community/contributors/tools/"
+      %a.item{:href => href, :class => "#{(current_path.start_with?( href ) ? "selected" : "")}"}
+        Hibernate Tools
+      - href = "/community/contributors/ogm/"
+      %a.item{:href => href, :class => "#{(current_path.start_with?( href ) ? "selected" : "")}"}
+        Hibernate OGM
 
   - href = "/community/corporate-contributors/"
   - active = (href == current_path)

--- a/_partials/menu/desktop-left-community.html.haml
+++ b/_partials/menu/desktop-left-community.html.haml
@@ -7,6 +7,12 @@
     %i.grid.icon.users
     Community
 
+  - href = "/community/governance/"
+  - active = (href == current_path)
+  %a.item{:href => href, :class => "#{(active ? "active" : "")}"}
+    %i.grid.icon.university
+    Governance
+
   .ui.dropdown.link.item{:class => "#{(current_path.start_with?( '/community/commonhaus/' ) ? "selected" : "")}"}
     Commonhaus
     %i.icon.dropdown
@@ -34,6 +40,12 @@
       - href = "/community/contribute/build-hibernate-orm/"
       %a.item{:href => href, :class => "#{(current_path.start_with?( href ) ? "selected" : "")}"}
         Build Hibernate ORM
+
+  - href = "/community/team/"
+  - active = (href == current_path)
+  %a.item{:href => href, :class => "#{(active ? "active" : "")}"}
+    %i.grid.icon.id.badge
+    Team
 
   .ui.dropdown.link.item{:class => "#{(current_path.start_with?( '/community/contributors/' ) ? "selected" : "")}"}
     Contributors

--- a/_partials/menu/mobile-section-community.html.haml
+++ b/_partials/menu/mobile-section-community.html.haml
@@ -12,6 +12,10 @@
       %a.item(href="/community/"){:class => "#{(item_active ? "active" : "")}"}
         %i.grid.icon.users
         Community
+      - href = "/community/governance/"
+      %a.item{:href => href, :class => "#{(current_path == href ? "active" : "")}"}
+        %i.grid.icon.university
+        Governance
       - href = "/community/commonhaus/"
       %a.item{:href => href, :class => "#{(current_path == href ? "active" : "")}"}
         Commonhaus - Membership
@@ -30,6 +34,10 @@
       - href = "/community/contribute/build-hibernate-orm/"
       %a.item{:href => href, :class => "#{(current_path.start_with?( href ) ? "active" : "")}"}
         Contribute - Build Hibernate ORM
+      - href = "/community/team/"
+      %a.item{:href => href, :class => "#{(current_path == href ? "active" : "")}"}
+        %i.grid.icon.id.badge
+        Team
       - item_active = (current_path == '/community/contributors/orm/')
       %a.item(href="/community/contributors/orm/"){:class => "#{(item_active ? "active" : "")}"}
         %i.grid.icon.database

--- a/_partials/menu/mobile-section-community.html.haml
+++ b/_partials/menu/mobile-section-community.html.haml
@@ -50,6 +50,14 @@
       %a.item(href="/community/contributors/validator/"){:class => "#{(item_active ? "active" : "")}"}
         %i.grid.icon.checkmark.box
         Contributors to Validator
+      - item_active = (current_path == '/community/contributors/reactive/')
+      %a.item(href="/community/contributors/reactive/"){:class => "#{(item_active ? "active" : "")}"}
+        %i.grid.icon.sitemap
+        Contributors to Reactive
+      - item_active = (current_path == '/community/contributors/tools/')
+      %a.item(href="/community/contributors/tools/"){:class => "#{(item_active ? "active" : "")}"}
+        %i.grid.icon.sitemap
+        Contributors to Tools
       - item_active = (current_path == '/community/contributors/ogm/')
       %a.item(href="/community/contributors/ogm/"){:class => "#{(item_active ? "active" : "")}"}
         %i.grid.icon.sitemap

--- a/community/contributors/tools.html.haml
+++ b/community/contributors/tools.html.haml
@@ -1,0 +1,5 @@
+---
+layout: community-contributors
+title: Contributors to Hibernate Tools
+project: tools
+---

--- a/community/governance.adoc
+++ b/community/governance.adoc
@@ -11,7 +11,7 @@ This governance model is designed to uphold the principles of transparency, open
 - **Contributors:** Anyone who contributes to Hibernate projects in any form.
 - **Members:** Contributors eligible for write access to a Hibernate code repository.
   Responsible for reviewing and merging contributions in their area of expertise.
-- **Project Leaders:** Elected members (at most one per code repository) with higher decision power whenever the project they lead is directly affected.
+- **Project Leaders:** Members (at most one per code repository) with higher decision power whenever the project they lead is affected.
   Responsible for steering project direction, and for enforcing compliance with requirements of the Commonhaus Foundation.
 
 Small or inactive projects may not have a leader,
@@ -20,20 +20,30 @@ in which case Members interested in the project will steer the project direction
 [[decision-making]]
 == Decision-Making
 
-Hibernate projects follow the https://www.commonhaus.org/bylaws/decision-making.html[Commonhaus decision-making process], with one additional provision.
+Hibernate projects follow a common decision-making process.
 
 Consensus-seeking (lazy consensus)::
-Projects primarily aim for a consensus-based decision-making process, where Members and active contributors discuss and come to an agreement.
-Voting::
-In situations where consensus cannot be reached, decisions may be made through a simple majority vote among Members.
+Hibernate projects primarily aim for a consensus-based decision-making process,
+where Members and active contributors discuss and come to an agreement.
++
+In practice, this involves:
++
+* Discussing matters openly, to facilitate others joining the discussions and expressing concerns.
+* Taking into account every contributor's opinion, regardless of their role.
+
++
+Actual implementation of consensus decision-making is up to Members and can vary based on the audience and criticality of the discussion.
+Inspiration may be found in
+the https://community.apache.org/committers/decisionMaking.html[Lazy Consensus model as defined by the Apache Foundation],
+and in https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1825&context=sociologyfacpub[Martha's Rules].
 Conflict Resolution::
-If conflicts arise, Members are responsible for facilitating a resolution. The https://www.commonhaus.org/bylaws/cf-council.html[Commonhaus Foundation Council] (CFC) can be asked to mediate the discussion, if necessary.
-Overruling _(Hibernate-specific)_::
-Project Leaders hold the power to overrule any decision directly affecting the project they lead.
-This allows for swift decisions on urgent or critical matters.
-Appeal to such overruling follows conflict resolution rules described above.
-// This is intended to balance the very extensive power of project leaders.
-In extreme cases, abuse of this power may result in the role of Project Leader being revoked (see below).
+If conflicts arise, Members are responsible for facilitating a resolution.
++
+Project Leaders hold the power to make the final decision, be it individually for the project they lead,
+or collectively for cross-project matters.
++
+As a last resort, in particular in case of disagreement about the decision-making process,
+the https://www.commonhaus.org/bylaws/cf-council.html[Commonhaus Foundation Council] (CFC) can be asked to mediate the discussion.
 
 [[role-granting-revoking]]
 == Role granting/revoking
@@ -42,14 +52,11 @@ The role of Member or Project Leader is granted or revoked through the <<decisio
 with additional restrictions:
 
 1. The discussion must happen on the Hibernate development mailing list, as listed in the link:/community[Community page on this website].
-// This prevents a Project Leader overruling their own revocation, or arbitrarily instating/revoking others.
-2. Project Leaders may not use their overruling power.
-// This is consistent with Commonhaus' own processes, which use supermajority for critical decisions.
-3. If consensus cannot be reached,
-   the ensuing vote requires supermajority approval by two-thirds of voting Members, instead of simple majority.
+// This prevents a Project Leader overruling their own revocation, in particular.
+2. The opinion of the Members or Project Leader whose role is being discussed does not factor into the decision.
 // This is long on purpose, to eliminates the risk of a decision being taken "in absentia" during e.g. holidays.
 // The assumption is that decisions around the project can be taken collectively, or by the previous leader, in the interim.
-4. Discussions regarding the role of Project Leader may not last less than 30 days.
+3. Discussions regarding the role of Project Leader may not last less than 30 days.
 
 Eligible candidates are:
 

--- a/community/governance.adoc
+++ b/community/governance.adoc
@@ -64,8 +64,7 @@ For the role of Member::
 Any contributor.
 For the role of Project Leader::
 Any contributor to the project they will lead, provided the candidate is a Commonhaus Foundation member,
-// TODO update link upon the PR getting merged.
-and agrees to become a Signatory of the https://github.com/commonhaus/foundation/pull/219/files#diff-64f58a8e70e16b011f35a30256797c538e6a951da4e9985943b55f4abe6e94b1[Commonhaus Fiscal Sponsorship Agreement] before taking on their new role.
+and agrees to become a Signatory of the https://www.commonhaus.org/policies/fiscal-sponsorship/[Commonhaus Fiscal Sponsorship Agreement] before taking on their new role.
 
 Members and Project Leaders keep their role indefinitely, unless they resign or a new decision revokes their role.
 

--- a/community/governance.adoc
+++ b/community/governance.adoc
@@ -10,12 +10,15 @@ This governance model is designed to uphold the principles of transparency, open
 
 - **Contributors:** Anyone who contributes to Hibernate projects in any form.
 - **Members:** Contributors eligible for write access to a Hibernate code repository.
-  Responsible for reviewing and merging contributions in their area of expertise.
++
+Responsible for driving initiatives and reviewing/merging contributions in their area of expertise.
 - **Project Leaders:** Members (at most one per code repository) with higher decision power whenever the project they lead is affected.
-  Responsible for steering project direction, and for enforcing compliance with requirements of the Commonhaus Foundation.
++
+Responsible for keeping the project's technical direction consistent, safe and sustainable.
+This involves in particular enforcing compliance with requirements of the Commonhaus Foundation.
 
 Small or inactive projects may not have a leader,
-in which case Members interested in the project will steer the project direction.
+in which case other project leaders will assume that responsibility collectively.
 
 [[decision-making]]
 == Decision-Making

--- a/community/governance.adoc
+++ b/community/governance.adoc
@@ -1,0 +1,80 @@
+= Governance
+:toc:
+:awestruct-layout: community-standard
+
+This document outlines the governance model for Hibernate projects.
+This governance model is designed to uphold the principles of transparency, open collaboration, and community involvement.
+
+[[roles]]
+== Roles and Responsibilities
+
+- **Contributors:** Anyone who contributes to Hibernate projects in any form.
+- **Members:** Contributors eligible for write access to a Hibernate code repository.
+  Responsible for reviewing and merging contributions in their area of expertise.
+- **Project Leaders:** Elected members (at most one per code repository) with higher decision power whenever the project they lead is directly affected.
+  Responsible for steering project direction, and for enforcing compliance with requirements of the Commonhaus Foundation.
+
+Small or inactive projects may not have a leader,
+in which case Members interested in the project will steer the project direction.
+
+[[decision-making]]
+== Decision-Making
+
+Hibernate projects follow the https://www.commonhaus.org/bylaws/decision-making.html[Commonhaus decision-making process], with one additional provision.
+
+Consensus-seeking (lazy consensus)::
+Projects primarily aim for a consensus-based decision-making process, where Members and active contributors discuss and come to an agreement.
+Voting::
+In situations where consensus cannot be reached, decisions may be made through a simple majority vote among Members.
+Conflict Resolution::
+If conflicts arise, Members are responsible for facilitating a resolution. The https://www.commonhaus.org/bylaws/cf-council.html[Commonhaus Foundation Council] (CFC) can be asked to mediate the discussion, if necessary.
+Overruling _(Hibernate-specific)_::
+Project Leaders hold the power to overrule any decision directly affecting the project they lead.
+This allows for swift decisions on urgent or critical matters.
+Appeal to such overruling follows conflict resolution rules described above.
+// This is intended to balance the very extensive power of project leaders.
+In extreme cases, abuse of this power may result in the role of Project Leader being revoked (see below).
+
+[[role-granting-revoking]]
+== Role granting/revoking
+
+The role of Member or Project Leader is granted or revoked through the <<decision-making,decision-making process>>,
+with additional restrictions:
+
+1. The discussion must happen on the Hibernate development mailing list, as listed in the link:/community[Community page on this website].
+// This prevents a Project Leader overruling their own revocation, or arbitrarily instating/revoking others.
+2. Project Leaders may not use their overruling power.
+// This is consistent with Commonhaus' own processes, which use supermajority for critical decisions.
+3. If consensus cannot be reached,
+   the ensuing vote requires supermajority approval by two-thirds of voting Members, instead of simple majority.
+// This is long on purpose, to eliminates the risk of a decision being taken "in absentia" during e.g. holidays.
+// The assumption is that decisions around the project can be taken collectively, or by the previous leader, in the interim.
+4. Discussions regarding the role of Project Leader may not last less than 30 days.
+
+Eligible candidates are:
+
+For the role of Member::
+Any contributor.
+For the role of Project Leader::
+Any contributor to the project they will lead, provided the candidate is a Commonhaus Foundation member,
+// TODO update link upon the PR getting merged.
+and agrees to become a Signatory of the https://github.com/commonhaus/foundation/pull/219/files#diff-64f58a8e70e16b011f35a30256797c538e6a951da4e9985943b55f4abe6e94b1[Commonhaus Fiscal Sponsorship Agreement] before taking on their new role.
+
+Members and Project Leaders keep their role indefinitely, unless they resign or a new decision revokes their role.
+
+The list of Members and Project Leaders is kept up-to-date on the link:/community/team["Team" page] of this website.
+
+[[code-of-conduct]]
+== Code of Conduct
+
+All participants in Hibernate projects are expected to adhere to the https://www.commonhaus.org/policies/code-of-conduct/[Commonhaus Foundation Code of Conduct]. Please ensure you are familiar with its guidelines and expectations, as it's essential for maintaining a positive and collaborative environment.
+
+[[trademark-policy]]
+== Trademark Policy
+
+The Hibernate logos, icons, and domain names are protected by trademark rights. Usage of these trademarks must adhere to the https://www.commonhaus.org/policies/trademark-policy/[Commonhaus Foundation Trademark Policy].
+
+[[contributing]]
+== Contributing
+
+We welcome all forms of contribution, from code improvements to documentation and design. For details on how to contribute and the process your contributions will follow, please read our link:/community/contribute/[Contributing Guidelines].

--- a/community/team.html.haml
+++ b/community/team.html.haml
@@ -45,7 +45,8 @@ title: Hibernate Team
   $(document).ready(function() {
     var contributorsNameMapping = #{site.data_json['contributors-name-mapping']}
     var governance = #{site.data_json['governance']}
-    $.getJSON( "https://api.github.com/orgs/hibernate/public_members", function( data ) {
+    // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#list-public-organization-members
+    $.getJSON( "https://api.github.com/orgs/hibernate/public_members?per_page=100", function( data ) {
       var items = [];
       data.forEach( function( member ) {
         var memberName = contributorsNameMapping[member.login] ? contributorsNameMapping[member.login] : member.login;

--- a/community/team.html.haml
+++ b/community/team.html.haml
@@ -86,3 +86,27 @@ title: Hibernate Team
       $( '#list' ).fadeIn();
     });
   });
+
+%h2{:id => "contributors"} Contributors
+
+.ui.icon.message
+  %i.icon.users
+  .content
+    Hibernate projects are not made just by members,
+    they're the result of the work of hundreds of contributors!
+    <br>
+    Follow the links below to find them all.
+
+.ui.labels.blue
+  %a.ui.label(href="/community/contributors/orm/")
+    Hibernate ORM
+  %a.ui.label(href="/community/contributors/search/")
+    Hibernate Search
+  %a.ui.label(href="/community/contributors/validator/")
+    Hibernate Validator
+  %a.ui.label(href="/community/contributors/reactive/")
+    Hibernate Reactive
+  %a.ui.label(href="/community/contributors/tools/")
+    Hibernate Tools
+  %a.ui.label(href="/community/contributors/ogm/")
+    Hibernate OGM

--- a/community/team.html.haml
+++ b/community/team.html.haml
@@ -32,7 +32,19 @@ title: Hibernate Team
     This is a list of all
     %a(href="/community/governance/#roles")
       Hibernate Members
-    who decided to make their membership public on GitHub.
+    extracted from public GitHub metadata.
+    %p
+    %em
+      Don't see your name?
+    If you're already a member, check that
+    %a(href="https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership")
+      your membership is public.
+    If you want to join us, reach out to a member to start
+    %a(href="/community/contribute")
+      contributing
+    or to start the
+    %a(href="/community/governance#role-granting-revoking")
+      joining process.
 
 %p &nbsp;
 

--- a/community/team.html.haml
+++ b/community/team.html.haml
@@ -1,0 +1,69 @@
+---
+layout: community-standard
+title: Hibernate Team
+---
+
+%h2{:id => "leaders"} Project Leaders
+
+.ui.icon.message
+  %i.icon.id.badge
+  .content
+    This is a list of all
+    %a(href="/community/governance/#roles")
+      Hibernate Project Leaders
+    \.
+
+.contributor-list.leader-list
+  - site.governance.leaders.each do |login, project_names|
+    - project_names_joined = project_names.map { |key| site.projects[key].name } .join( ', ' )
+    .ui.card.contributor{:"data-github-login" => login, :"data-project-names" => project_names_joined}
+      .content
+        .header
+          %a{:href => "https://github.com/#{login}"}
+            #{login}
+      .extra.content
+        Leader of #{project_names_joined}.
+
+%h2{:id => "members"} Members
+
+.ui.icon.message
+  %i.icon.id.badge
+  .content
+    This is a list of all
+    %a(href="/community/governance/#roles")
+      Hibernate Members
+    who decided to make their membership public on GitHub.
+
+%p &nbsp;
+
+.text-center#list-loader
+  %i.notched.circle.loading.icon.massive
+
+#list.contributor-list(style="display:none")
+
+:javascript
+  $(document).ready(function() {
+    var contributorsNameMapping = #{site.data_json['contributors-name-mapping']}
+    $.getJSON( "https://api.github.com/orgs/hibernate/public_members", function( data ) {
+      var items = [];
+      data.forEach( function( member ) {
+        var memberName = contributorsNameMapping[member.login] ? contributorsNameMapping[member.login] : member.login;
+
+        var item = $( '<div class="ui card contributor"/>' )
+          .append( $( '<div class="image"/>' ).append( $('<img src="' + member.avatar_url + '" />' ) ) )
+          .append( $( '<div class="content" />' ).append( $( '<div class="header" />' ).append( $( '<a href="' + member.html_url + '" />' ).text( memberName ) ) ) )
+
+        var leaderItem = $( '.leader-list [data-github-login=' + member.login + ']' )
+        if ( leaderItem.length ) {
+          item.append( $( '<div class="extra content" />' ).text( 'Leader of ' + leaderItem.data( 'project-names' ) + '.' ) );
+          leaderItem.replaceWith( item.clone() );
+        }
+
+        items.push(item);
+      });
+
+      $( '#list' ).append( items );
+      $( '#list-loader' ).hide();
+      $( '#list' ).fadeIn();
+    });
+  });

--- a/community/team.html.haml
+++ b/community/team.html.haml
@@ -44,6 +44,7 @@ title: Hibernate Team
 :javascript
   $(document).ready(function() {
     var contributorsNameMapping = #{site.data_json['contributors-name-mapping']}
+    var governance = #{site.data_json['governance']}
     $.getJSON( "https://api.github.com/orgs/hibernate/public_members", function( data ) {
       var items = [];
       data.forEach( function( member ) {
@@ -52,6 +53,11 @@ title: Hibernate Team
         var item = $( '<div class="ui card contributor"/>' )
           .append( $( '<div class="image"/>' ).append( $('<img src="' + member.avatar_url + '" />' ) ) )
           .append( $( '<div class="content" />' ).append( $( '<div class="header" />' ).append( $( '<a href="' + member.html_url + '" />' ).text( memberName ) ) ) )
+
+        var roles = governance.roles[member.login]
+        if ( roles ) {
+          item.append( $( '<div class="extra content" />' ).html( roles.join(', ') + '.' ) );
+        }
 
         var leaderItem = $( '.leader-list [data-github-login=' + member.login + ']' )
         if ( leaderItem.length ) {

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -729,7 +729,7 @@ pre .comment .conum {
 	}
 }
 
-#contributor-list {
+.contributor-list {
 	display: grid;
 	grid-auto-rows: 1fr;
 	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));


### PR DESCRIPTION
I semt an email about this to hibernate-dev, it warrants a discussion among all members: https://lists.jboss.org/archives/list/hibernate-dev@lists.jboss.org/thread/WMNJHAWAVAAJVWFWNBIJV2GNRMUHOIW2/

The important changes are:

* A new "Governance" page (see [on staging](https://staging.hibernate.org/community/governance/)) describing the structure and decision-making of the Hibernate organization. This establishes a sort of "bylaws" that we were missing until now. It's important for openness: with it, people can know what to expect if they dedicate time to the projects. The intent is to link to this page from a `GOVERNANCE.md` file in all repositories (or at least the main ones).
* A new "Team" page (see [on staging](https://staging.hibernate.org/community/team/)) listing project leaders and members who chose to make their membership public. It completes the governance information by clearly showing who contributors will have to work/argue with.

~~IMPORTANT: This is a first attempt. I worked on this by myself, so it needs reviews, comments, and adjustments. The final document must be something we all agree with, and commit to complying with.~~ => See discussions below, it looks like consensus was reached for those who had a look so far. Waiting for a few more...