### PR TITLE
Consistently refer to Hibernate ORM 7.0+ as ASL 2

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -96,8 +96,10 @@ projects:
     blog_tag: Hibernate ORM
     blog_tag_url: hibernate-orm
     license:
-      name: LGPL V2.1
-      url: https://hibernate.org/license/
+      name: ASL v2
+      url: https://raw.github.com/hibernate/hibernate-orm/main/LICENSE.txt
+      # This data is also overridden in relevant series.yml and earlier 7.0.0.{Alpha,Beta}*.yml to display correctly on releases pages
+      since: "7.0.0.Beta5"
     jira:
       key: HHH
     github:
@@ -476,7 +478,7 @@ projects:
     blog_tag_url: hibernate-validator
     license:
       name: ASL v2
-      url: https://raw.github.com/hibernate/hibernate-validator/master/license.txt
+      url: https://raw.github.com/hibernate/hibernate-validator/main/LICENSE.txt
     jira:
       key: HV
     github:

--- a/_data/projects/orm/releases/4.2/series.yml
+++ b/_data/projects/orm/releases/4.2/series.yml
@@ -1,4 +1,7 @@
 summary: JPA 2.0
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/4.2/lgpl.txt
 links:
   getting_started_guide:
     html: https://docs.jboss.org/hibernate/orm/{series.version}/quickstart/en-US/html_single/

--- a/_data/projects/orm/releases/4.3/series.yml
+++ b/_data/projects/orm/releases/4.3/series.yml
@@ -1,4 +1,7 @@
 summary: JPA 2.1 support
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/4.3/lgpl.txt
 links:
   getting_started_guide:
     html: https://docs.jboss.org/hibernate/orm/{series.version}/quickstart/en-US/html_single/

--- a/_data/projects/orm/releases/5.0/series.yml
+++ b/_data/projects/orm/releases/5.0/series.yml
@@ -1,4 +1,7 @@
 summary: Improved bootstrapping, hibernate-java8, hibernate-spatial, Karaf support
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/5.0/lgpl.txt
 links:
   getting_started_guide:
     html: https://docs.jboss.org/hibernate/orm/{series.version}/quickstart/en-US/html_single/

--- a/_data/projects/orm/releases/5.1/series.yml
+++ b/_data/projects/orm/releases/5.1/series.yml
@@ -1,4 +1,7 @@
 summary: Entity joins, load-by-multiple-ids, association traversal in AuditQuery
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/5.1/lgpl.txt
 links:
   dist:
     sourceforge:

--- a/_data/projects/orm/releases/5.2/series.yml
+++ b/_data/projects/orm/releases/5.2/series.yml
@@ -1,4 +1,7 @@
 summary: Java 8, JCache support, hibernate-entitymanager consolidation
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/5.2/lgpl.txt
 links:
   dist:
     sourceforge:

--- a/_data/projects/orm/releases/5.3/series.yml
+++ b/_data/projects/orm/releases/5.3/series.yml
@@ -1,4 +1,7 @@
 summary: JPA 2.2, inheritance caching
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/5.3/lgpl.txt
 status: limited-support
 displayed: false
 maven:

--- a/_data/projects/orm/releases/5.4/series.yml
+++ b/_data/projects/orm/releases/5.4/series.yml
@@ -1,4 +1,7 @@
 summary: EntityGraph improvements, JDK 11 support
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/5.4/lgpl.txt
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -1,4 +1,7 @@
 summary: Introducing support for Jakarta JPA
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/5.5/lgpl.txt
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/5.6/series.yml
+++ b/_data/projects/orm/releases/5.6/series.yml
@@ -1,4 +1,7 @@
 summary: Dropped support for Javassist, Performance
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/5.6/lgpl.txt
 status: limited-support
 displayed: false
 links:

--- a/_data/projects/orm/releases/6.0/series.yml
+++ b/_data/projects/orm/releases/6.0/series.yml
@@ -1,4 +1,7 @@
 summary: Performance, HQL, Criteria, Type System
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/6.0/lgpl.txt
 maven:
   repo:
     snapshots: jboss

--- a/_data/projects/orm/releases/6.1/series.yml
+++ b/_data/projects/orm/releases/6.1/series.yml
@@ -1,4 +1,7 @@
 summary: Subquery in FROM clause, JDBC Array support, Unified Mapping XSD
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/6.1/lgpl.txt
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/6.2/series.yml
+++ b/_data/projects/orm/releases/6.2/series.yml
@@ -1,4 +1,7 @@
 summary: Jakarta Persistence 3.1, records, structs, value generation, partitioning, SQL `MERGE`
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/6.2/lgpl.txt
 status: limited-support
 displayed: false
 maven:

--- a/_data/projects/orm/releases/6.3/series.yml
+++ b/_data/projects/orm/releases/6.3/series.yml
@@ -1,4 +1,7 @@
 summary: Jakarta Persistence 3.1, query methods, finder methods
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/6.3/lgpl.txt
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/6.4/series.yml
+++ b/_data/projects/orm/releases/6.4/series.yml
@@ -1,4 +1,7 @@
 summary: soft-delete, array functions, non-String tenant-id
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/6.4/lgpl.txt
 status: limited-support
 maven:
   artifacts:

--- a/_data/projects/orm/releases/6.5/series.yml
+++ b/_data/projects/orm/releases/6.5/series.yml
@@ -1,4 +1,7 @@
 summary: Java Time Handling, Configurable Query Cache Layout, records as @IdClass, auto-enabled Filters, Key-based Pagination, Jakarta Data (tech preview)
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/6.5/lgpl.txt
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -1,4 +1,7 @@
 summary: Jakarta Data, @ConcreteProxy, Extended Array Support, Embeddable Inheritance
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/6.6/lgpl.txt
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/7.0/7.0.0.Alpha1.yml
+++ b/_data/projects/orm/releases/7.0/7.0.0.Alpha1.yml
@@ -2,3 +2,6 @@ date: 2024-04-16
 announcement_url: https://in.relation.to/2024/04/16/orm-70alpha1/
 
 summary: Jakarta Persistence 3.2, Java 17, Hibernate Models, mapping.xsd, hbm.xml transformation
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/7.0.0.Alpha1/lgpl.txt

--- a/_data/projects/orm/releases/7.0/7.0.0.Alpha2.yml
+++ b/_data/projects/orm/releases/7.0/7.0.0.Alpha2.yml
@@ -2,3 +2,6 @@ date: 2024-05-03
 announcement_url: https://in.relation.to/2024/05/03/orm-70alpha2/
 
 summary: Jakarta Persistence 3.2, Java 17, Hibernate Models, mapping.xsd, hbm.xml transformation
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/7.0.0.Alpha2/lgpl.txt

--- a/_data/projects/orm/releases/7.0/7.0.0.Alpha3.yml
+++ b/_data/projects/orm/releases/7.0/7.0.0.Alpha3.yml
@@ -2,3 +2,6 @@ date: 2024-06-14
 announcement_url: https://in.relation.to/2024/06/14/orm-70alpha3/
 
 summary: Jakarta Persistence 3.2, Java 17, Hibernate Models, mapping.xsd, hbm.xml transformation
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/7.0.0.Alpha3/lgpl.txt

--- a/_data/projects/orm/releases/7.0/7.0.0.Beta1.yml
+++ b/_data/projects/orm/releases/7.0/7.0.0.Beta1.yml
@@ -2,3 +2,6 @@ date: 2024-08-01
 announcement_url: https://in.relation.to/2024/08/01/orm-70-beta1/
 
 summary: Jakarta Persistence 3.2, Java 17, Hibernate Models, mapping.xsd, hbm.xml transformation
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/7.0.0.Beta1/lgpl.txt

--- a/_data/projects/orm/releases/7.0/7.0.0.Beta2.yml
+++ b/_data/projects/orm/releases/7.0/7.0.0.Beta2.yml
@@ -1,3 +1,6 @@
 date: 2024-11-13
 announcement_url: https://in.relation.to/2024/11/13/orm-70-beta2/
 summary: Jakarta Persistence 3.2, Java 17, Hibernate Models, mapping.xsd, hbm.xml transformation, Modern SQL Functions
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/7.0.0.Beta2/lgpl.txt

--- a/_data/projects/orm/releases/7.0/7.0.0.Beta3.yml
+++ b/_data/projects/orm/releases/7.0/7.0.0.Beta3.yml
@@ -1,3 +1,6 @@
 date: 2024-12-5
 announcement_url:
 summary: Jakarta Persistence 3.2, Java 17, Hibernate Models, mapping.xsd, hbm.xml transformation, Modern SQL Functions
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/7.0.0.Beta3/lgpl.txt

--- a/_data/projects/orm/releases/7.0/7.0.0.Beta4.yml
+++ b/_data/projects/orm/releases/7.0/7.0.0.Beta4.yml
@@ -1,3 +1,6 @@
 date: 2025-02-12
 
 summary: Jakarta Persistence 3.2, Java 17, Hibernate Models, mapping.xsd, hbm.xml transformation, Modern SQL Functions
+license:
+  name: LGPL v2.1
+  url: https://raw.github.com/hibernate/hibernate-orm/7.0.0.Beta4/lgpl.txt

--- a/_data/projects/orm/releases/7.0/7.0.0.Beta5.yml
+++ b/_data/projects/orm/releases/7.0/7.0.0.Beta5.yml
@@ -1,6 +1,3 @@
 date: 2025-03-21
 announcement_url:
 summary: API enhancements, bug fixes, Apache License
-license:
-  name: ASL v2.0
-  url: https://www.apache.org/licenses/LICENSE-2.0.txt

--- a/community/license.adoc
+++ b/community/license.adoc
@@ -4,21 +4,24 @@ Richard Fontana
 
 == Free as in Speech
 
-Hibernate projects are licensed under either the LGPL 2.1 or the ASL 2.0.
+Hibernate projects are licensed under either the ASL 2.0, or in some cases LGPL 2.1.
 Hibernate is Free Software.
 
 You can find under which a specific project is released below its menu or in the code source.
 
 == ASL 2.0
 
-Some Hibernate projects are released under link:https://opensource.org/licenses/Apache-2.0[ASL 2.0].
-This is the case for link:/validator[Hibernate Validator], link:/reactive[Hibernate Reactive], and (since version 7.2.0.Alpha2) link:/search[Hibernate Search].
+Most Hibernate projects, in their recent versions, are released under link:https://opensource.org/licenses/Apache-2.0[ASL 2.0]:
 
-The Hibernate team is link:https://in.relation.to/2023/11/18/license/[trying to move more projects to this license].
+* link:/orm[Hibernate ORM] since version 7.0.0.Beta5
+* link:/validator[Hibernate Validator] since its inception
+* link:/reactive[Hibernate Reactive] since its inception
+* link:/search[Hibernate Search] since version 7.2.0.Alpha2
 
 == LGPL 2.1
 
-Hibernate projects have historically been released, and in some cases still are, under link:https://opensource.org/licenses/LGPL-2.1[LGPL v2.1].
+Some Hibernate projects have historically been released under link:https://opensource.org/licenses/LGPL-2.1[LGPL v2.1],
+and link:/tools[Hibernate Tools] still is.
 
 The maintainers of Hibernate have consistently understood the LGPL to simply allow Hibernate to be used by both open source and proprietary code without any impact on the licensing or distribution of such independent code.
 This interpretation applies regardless of whether a binary that includes Hibernate code is designed to run on the JVM or is a native image generated through use of tools and frameworks like link:https://www.graalvm.org/[GraalVM] and link:https://quarkus.io/[Quarkus].


### PR DESCRIPTION
So that:

1. We don't need to provide the license in `*.yml` for future releases
2. We have this nice thing in the menu:
![image](https://github.com/user-attachments/assets/5f6d0455-dd08-44b0-bd6e-bb10dae6ee9c)

@sebersole FYI