### PR TITLE
Prepare for "What's new"/"Release highlights" published as part of project documentation

### DIFF
--- a/_data/projects/orm/releases/4.3/series.yml
+++ b/_data/projects/orm/releases/4.3/series.yml
@@ -3,10 +3,11 @@ license:
   name: LGPL v2.1
   url: https://raw.github.com/hibernate/hibernate-orm/4.3/lgpl.txt
 links:
-  getting_started_guide:
-    html: https://docs.jboss.org/hibernate/orm/{series.version}/quickstart/en-US/html_single/
-  reference_doc:
-    html: https://docs.jboss.org/hibernate/orm/{series.version}/manual/en-US/html_single/
+  documentation:
+    getting_started_guide:
+      html: https://docs.jboss.org/hibernate/orm/{series.version}/quickstart/en-US/html_single/
+    reference_doc:
+      html: https://docs.jboss.org/hibernate/orm/{series.version}/manual/en-US/html_single/
   dist:
     sourceforge:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download

--- a/_ext/links.rb
+++ b/_ext/links.rb
@@ -24,6 +24,10 @@ module Awestruct
         return DocumentRef.from_patterns(project, series, :migration_guide)
       end
 
+      def whats_new(project, series)
+        return DocumentRef.from_patterns(project, series, :whats_new)
+      end
+
       def maven(project, series, release)
         return MavenRef.from(@site, project, series, release)
       end

--- a/_layouts/project/project-documentation.html.haml
+++ b/_layouts/project/project-documentation.html.haml
@@ -32,48 +32,7 @@ project_buttons_partial: project/documentation-buttons.html.haml
             :asciidoc
               :doctype: inline
               #{series.summary.strip}
-          %p
-            - reference_doc = reference_doc(project_description, series)
-            %span.ui.label.basic.horizontal
-              Reference
-            %a.ui.right.labeled.icon.button.small(href="#{reference_doc.html_url}")
-              %i.icon.file.text.outline
-              HTML
-            - if not reference_doc.pdf_url.nil?
-              %a.ui.right.labeled.icon.button.small(href="#{reference_doc.pdf_url}")
-                %i.icon.file.pdf.outline
-                PDF
-            - javadoc = javadoc(project_description, series)
-            %a.ui.right.labeled.icon.button.small(href="#{javadoc.html_url}")
-              %i.icon.code.outline
-              API (Javadoc)
-          - getting_started_guides(project_description, series).each do |getting_started_guide|
-            %p
-              %span.ui.label.basic.horizontal
-                Getting started guide
-                - if getting_started_guide.name
-                  = "(#{getting_started_guide.name})"
-              - if not getting_started_guide.html_url.nil?
-                %a.ui.right.labeled.icon.button.small(href="#{getting_started_guide.html_url}")
-                  %i.icon.file.text.outline
-                  HTML
-              - if not getting_started_guide.pdf_url.nil?
-                %a.ui.right.labeled.icon.button.small(href="#{getting_started_guide.pdf_url}")
-                  %i.icon.file.pdf.outline
-                  PDF
-          - migration_guide = migration_guide(project_description, series)
-          - if not migration_guide.nil?
-            %p
-              %span.ui.label.basic.horizontal
-                Migration guide
-              - if not migration_guide.html_url.nil?
-                %a.ui.right.labeled.icon.button.small(href="#{migration_guide.html_url}")
-                  %i.icon.file.text.outline
-                  HTML
-              - if not migration_guide.pdf_url.nil?
-                %a.ui.right.labeled.icon.button.small(href="#{migration_guide.pdf_url}")
-                  %i.icon.file.pdf.outline
-                  PDF
+          = partial( 'project/series-documentation.html.haml', { "project" => project_description, "series" => series } )
 - else
   %p There is no reference documentation configured for this project.
 
@@ -110,47 +69,6 @@ project_buttons_partial: project/documentation-buttons.html.haml
               = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "tag" } )
             %p
               = series.summary
-            %p
-              - reference_doc = reference_doc(project_description, series)
-              %span.ui.label.basic.horizontal
-                Reference
-              %a.ui.right.labeled.icon.button.small(href="#{reference_doc.html_url}")
-                %i.icon.file.text.outline
-                HTML
-              - if not reference_doc.pdf_url.nil?
-                %a.ui.right.labeled.icon.button.small(href="#{reference_doc.pdf_url}")
-                  %i.icon.file.pdf.outline
-                  PDF
-              - javadoc = javadoc(project_description, series)
-              %a.ui.right.labeled.icon.button.small(href="#{javadoc.html_url}")
-                %i.icon.code.outline
-                API (Javadoc)
-            - getting_started_guides(project_description, series).each do |getting_started_guide|
-              %p
-                %span.ui.label.basic.horizontal
-                  Getting started guide
-                  - if getting_started_guide.name
-                    = "(#{getting_started_guide.name})"
-                - if not getting_started_guide.html_url.nil?
-                  %a.ui.right.labeled.icon.button.small(href="#{getting_started_guide.html_url}")
-                    %i.icon.file.text.outline
-                    HTML
-                - if not getting_started_guide.pdf_url.nil?
-                  %a.ui.right.labeled.icon.button.small(href="#{getting_started_guide.pdf_url}")
-                    %i.icon.file.pdf.outline
-                    PDF
-            - migration_guide = migration_guide(project_description, series)
-            - if not migration_guide.nil?
-              %p
-                %span.ui.label.basic.horizontal
-                  Migration guide
-                - if not migration_guide.html_url.nil?
-                  %a.ui.right.labeled.icon.button.small(href="#{migration_guide.html_url}")
-                    %i.icon.file.text.outline
-                    HTML
-                - if not migration_guide.pdf_url.nil?
-                  %a.ui.right.labeled.icon.button.small(href="#{migration_guide.pdf_url}")
-                    %i.icon.file.pdf.outline
-                    PDF
+            = partial( 'project/series-documentation.html.haml', { "project" => project_description, "series" => series } )
 
 ~ content

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -76,6 +76,20 @@ project_hero_partial: project/hero-series.html.haml
 
     See also the link:/community/maintenance-policy[Maintenance policy].
     ====
+- elsif series.status == 'development'
+  :asciidoc
+    :projectName: #{project_description.name}
+    :version: #{series.version}
+    [NOTE]
+    ====
+    {projectName} {version} is still in development:
+
+    * some features may be incomplete;
+    * newly introduced features may change in a backward-incompatible way before the stable release.
+
+    We encourage you to link:#get-it[give it a try] and to link:/community/[let us know]
+    of any bugs or problems you encounter.
+    ====
 
 - unless series.integration_constraints.nil? || series.integration_constraints.empty?
   %h2{:id => "compatibility"} Compatibility
@@ -103,26 +117,6 @@ project_hero_partial: project/hero-series.html.haml
       Maintenance policy.
 
 %h2{:id => "documentation"} Documentation
-- if series.status == 'end-of-life'
-  :asciidoc
-    :projectName: #{project_description.name}
-    :version: #{series.version}
-    [WARNING]
-    ====
-    {projectName} {version} has reached its end-of-life: we recommend that you upgrade to a newer series if possible.
-
-    See also the link:/community/maintenance-policy[Maintenance policy].
-    ====
-- elsif series.status == 'limited-support'
-  :asciidoc
-    :projectName: #{project_description.name}
-    :version: #{series.version}
-    [WARNING]
-    ====
-    {projectName} {version} is in limited maintenance mode: we recommend that you upgrade to a newer series if possible or look for link:../../support[paid support].
-
-    See also the link:/community/maintenance-policy[Maintenance policy].
-    ====
 %p
   Documentation for #{project_description.name} #{series.version} can be accessed through the links below:
 = partial( 'project/series-documentation.html.haml', { "project" => project_description, "series" => series, "anchors" => true } )
@@ -133,26 +127,11 @@ project_hero_partial: project/hero-series.html.haml
     documentation page.
 
 %h2{:id => "get-it"} How to get it
-- if series.status == 'end-of-life'
-  :asciidoc
-    :projectName: #{project_description.name}
-    :version: #{series.version}
-    [WARNING]
-    ====
-    {projectName} {version} has reached its end-of-life: we recommend that you upgrade to a newer series if possible.
 
-    See also the link:/community/maintenance-policy[Maintenance policy].
-    ====
-- elsif series.status == 'limited-support'
-  :asciidoc
-    :projectName: #{project_description.name}
-    :version: #{series.version}
-    [WARNING]
-    ====
-    {projectName} {version} is in limited maintenance mode: we recommend that you upgrade to a newer series if possible or look for link:../../support[paid support].
+%p
+  Current series status:
+  = partial( 'project/series-status-label.html.haml', { "series" => series } )
 
-    See also the link:/community/maintenance-policy[Maintenance policy].
-    ====
 .ui.grid.equal.height.stackable.download-options
   .row
     - if latest_release_maven.coord
@@ -235,21 +214,6 @@ project_hero_partial: project/hero-series.html.haml
     here.
 
 %h2{:id => "whats-new"} What's new
-
-- if ! latest_release.stable
-  :asciidoc
-    :projectName: #{project_description.name}
-    :version: #{series.version}
-    [NOTE]
-    ====
-    {projectName} {version} is still in development:
-
-    * some features may be incomplete;
-    * newly introduced features may change in a backward-incompatible way before the stable release.
-
-    We encourage you to link:#get-it[give it a try] and to link:/community/[let us know]
-    of any bugs or problems you encounter.
-    ====
 
 - if latest_release[:announcement_url]
   %p

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -257,6 +257,20 @@ project_hero_partial: project/hero-series.html.haml
     %a{:href => "#{latest_release.announcement_url}"}
       #{latest_release.version}.
 
+- whats_new = whats_new(project_description, series)
+- if not whats_new.nil?
+  %p
+    Highlights of new features and enhancements can be found here:
+  %p
+    - if not whats_new.html_url.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{whats_new.html_url}")
+        %i.icon.file.text.outline
+        HTML
+    - if not whats_new.pdf_url.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{whats_new.pdf_url}")
+        %i.icon.file.pdf.outline
+        PDF
+
 %p
   A detailed list of new features, improvements and fixes in this series can be found
   - if project_description[:jira][:key]

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -14,8 +14,6 @@ project_hero_partial: project/hero-series.html.haml
 
 - latest_release_maven = maven(project_description, series, latest_release)
 
-- getting_started_guides = getting_started_guides(project_description, series)
-- migration_guide = migration_guide(project_description, series)
 - dist_sourceforge = dist_sourceforge(project_description, series, latest_release)
 
 -# The TOC is just for convenience but too large for mobile
@@ -33,14 +31,6 @@ project_hero_partial: project/hero-series.html.haml
     %li
       %a.item{:href => "#get-it"}
         How to get it
-    - if not getting_started_guides.empty?
-      %li
-        %a.item{:href => "#getting_started"}
-          Getting started
-    - if not migration_guide.nil?
-      %li
-        %a.item{:href => "#migrate"}
-          Migrating
     %li
       %a.item{:href => "#whats-new"}
         What's new
@@ -113,21 +103,29 @@ project_hero_partial: project/hero-series.html.haml
       Maintenance policy.
 
 %h2{:id => "documentation"} Documentation
+- if series.status == 'end-of-life'
+  :asciidoc
+    :projectName: #{project_description.name}
+    :version: #{series.version}
+    [WARNING]
+    ====
+    {projectName} {version} has reached its end-of-life: we recommend that you upgrade to a newer series if possible.
+
+    See also the link:/community/maintenance-policy[Maintenance policy].
+    ====
+- elsif series.status == 'limited-support'
+  :asciidoc
+    :projectName: #{project_description.name}
+    :version: #{series.version}
+    [WARNING]
+    ====
+    {projectName} {version} is in limited maintenance mode: we recommend that you upgrade to a newer series if possible or look for link:../../support[paid support].
+
+    See also the link:/community/maintenance-policy[Maintenance policy].
+    ====
 %p
   Documentation for #{project_description.name} #{series.version} can be accessed through the links below:
-%p
-  - reference_doc = reference_doc(project_description, series)
-  %a.ui.right.labeled.icon.button(href="#{reference_doc.html_url}")
-    %i.icon.file.text.outline
-    HTML
-  - if not reference_doc.pdf_url.nil?
-    %a.ui.right.labeled.icon.button(href="#{reference_doc.pdf_url}")
-      %i.icon.file.pdf.outline
-      PDF
-  - javadoc = javadoc(project_description, series)
-  %a.ui.right.labeled.icon.button(href="#{javadoc.html_url}")
-    %i.icon.code.outline
-    API (Javadoc)
+= partial( 'project/series-documentation.html.haml', { "project" => project_description, "series" => series, "anchors" => true } )
 
 %p
   You can find more documentation for all series on the
@@ -235,58 +233,6 @@ project_hero_partial: project/hero-series.html.haml
   More information about specific releases (announcements, download links) can be found
   %a{:href => "#releases"}
     here.
-
-- if not getting_started_guides.empty?
-  %h2{:id => "getting_started"} Getting started
-  - if series.status == 'end-of-life'
-    :asciidoc
-      :projectName: #{project_description.name}
-      :version: #{series.version}
-      [WARNING]
-      ====
-      {projectName} {version} has reached its end-of-life: we recommend that you upgrade to a newer series if possible.
-
-      See also the link:/community/maintenance-policy[Maintenance policy].
-      ====
-  - elsif series.status == 'limited-support'
-    :asciidoc
-      :projectName: #{project_description.name}
-      :version: #{series.version}
-      [WARNING]
-      ====
-      {projectName} {version} is in limited maintenance mode: we recommend that you upgrade to a newer series if possible or look for link:../../support[paid support].
-
-      See also the link:/community/maintenance-policy[Maintenance policy].
-      ====
-  %p
-    If you want to start using #{project_description.name} #{series.version}, please refer to the getting started guide:
-  - getting_started_guides.each do |getting_started_guide|
-    %p
-      - if getting_started_guide.name
-        %span.ui.label.basic.horizontal
-          = getting_started_guide.name
-      - if not getting_started_guide.html_url.nil?
-        %a.ui.right.labeled.icon.button.small(href="#{getting_started_guide.html_url}")
-          %i.icon.file.text.outline
-          HTML
-      - if not getting_started_guide.pdf_url.nil?
-        %a.ui.right.labeled.icon.button.small(href="#{getting_started_guide.pdf_url}")
-          %i.icon.file.pdf.outline
-          PDF
-
-- if not migration_guide.nil?
-  %h2{:id => "migrate"} Migrating
-  %p
-    If you need to upgrade from a previous series, please refer to the migration guide:
-  %p
-    - if not migration_guide.html_url.nil?
-      %a.ui.right.labeled.icon.button.small(href="#{migration_guide.html_url}")
-        %i.icon.file.text.outline
-        HTML
-    - if not migration_guide.pdf_url.nil?
-      %a.ui.right.labeled.icon.button.small(href="#{migration_guide.pdf_url}")
-        %i.icon.file.pdf.outline
-        PDF
 
 %h2{:id => "whats-new"} What's new
 

--- a/_partials/project/series-documentation.html.haml
+++ b/_partials/project/series-documentation.html.haml
@@ -20,6 +20,19 @@
       %a.ui.right.labeled.icon.button.small(href="#{getting_started_guide.pdf_url}")
         %i.icon.file.pdf.outline
         PDF
+- whats_new = whats_new(project_description, series)
+- if not whats_new.nil?
+  %p
+    %span.ui.label.basic.horizontal
+      What's new
+    - if not whats_new.html_url.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{whats_new.html_url}")
+        %i.icon.file.text.outline
+        HTML
+    - if not whats_new.pdf_url.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{whats_new.pdf_url}")
+        %i.icon.file.pdf.outline
+        PDF
 - migration_guide = migration_guide(project_description, series)
 - if not migration_guide.nil?
   %p

--- a/_partials/project/series-documentation.html.haml
+++ b/_partials/project/series-documentation.html.haml
@@ -1,0 +1,53 @@
+- project_description = page.project
+- series = page.series
+- anchors = page.anchors
+
+- getting_started_guides = getting_started_guides(project_description, series)
+- if anchors && ! getting_started_guides.empty?
+  - # Legacy anchor, kept just so we don't break existing links
+  %a{:id => "getting_started"}
+- getting_started_guides.each do |getting_started_guide|
+  %p
+    %span.ui.label.basic.horizontal
+      Getting started guide
+      - if getting_started_guide.name
+        = "(#{getting_started_guide.name})"
+    - if not getting_started_guide.html_url.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{getting_started_guide.html_url}")
+        %i.icon.file.text.outline
+        HTML
+    - if not getting_started_guide.pdf_url.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{getting_started_guide.pdf_url}")
+        %i.icon.file.pdf.outline
+        PDF
+- migration_guide = migration_guide(project_description, series)
+- if not migration_guide.nil?
+  %p
+    - if anchors
+      - # Legacy anchor, kept just so we don't break existing links
+      %a{:id => "migrate"}
+    %span.ui.label.basic.horizontal
+      Migration guide
+    - if not migration_guide.html_url.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{migration_guide.html_url}")
+        %i.icon.file.text.outline
+        HTML
+    - if not migration_guide.pdf_url.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{migration_guide.pdf_url}")
+        %i.icon.file.pdf.outline
+        PDF
+- reference_doc = reference_doc(project_description, series)
+%p
+  %span.ui.label.basic.horizontal
+    Reference
+  %a.ui.right.labeled.icon.button.small(href="#{reference_doc.html_url}")
+    %i.icon.file.text.outline
+    HTML
+  - if not reference_doc.pdf_url.nil?
+    %a.ui.right.labeled.icon.button.small(href="#{reference_doc.pdf_url}")
+      %i.icon.file.pdf.outline
+      PDF
+  - javadoc = javadoc(project_description, series)
+  %a.ui.right.labeled.icon.button.small(href="#{javadoc.html_url}")
+    %i.icon.code.outline
+    API (Javadoc)


### PR DESCRIPTION
With these changes, the "Getting started" and "Migrating" section of the release pages are moved to the ["Documentation" section of that same page](https://hibernate.org/orm/releases/7.0/#documentation):

![image](https://github.com/user-attachments/assets/847e8481-531b-42b6-85ee-f66d890a11aa)


Also, in the near future, when we'll publish "What's new"/"Release highlights" as part of project documentation (like the migration guide), we'll be able to link to it [like this](https://github.com/yrodiere/hibernate.org/commit/4d3615debc36df29a667399b9a03ae23df8161e8).

Then the "Documentation" section will look like this:

![Screenshot From 2025-04-11 16-42-24](https://github.com/user-attachments/assets/ab5c1312-5493-4e1d-954c-1f6a318bfd95)

And the "What's new" section will look like this:

![Screenshot From 2025-04-11 16-47-40](https://github.com/user-attachments/assets/9424535a-dba6-481b-86bb-93097c48cd19)

