### PR TITLE
[ORM] Add links to Quarkus docs on Jakarta Data

### DIFF
--- a/repositories/index.html.haml
+++ b/repositories/index.html.haml
@@ -89,10 +89,6 @@ project: repositories
   :asciidoc
     == Quarkus integration
 
-    Hibernate Data Repositories 6.6 works in Quarkus. Just add:
-
-    - `jakarta.data:jakarta.data-api` and
-    - `org.hibernate.orm:hibernate-jpamodelgen`
-
-    as dependencies via Maven.
-
+    Hibernate Data Repositories 6.6 works in Quarkus. Just add `jakarta.data:jakarta.data-api` as a dependency,
+    and link:https://quarkus.io/guides/hibernate-orm#jakarta-data[configure the `hibernate-jpamodelgen` annotation processor]
+    according to your build tool rules.


### PR DESCRIPTION
The quickstart guide (commented out link) didn't get into this release, but it is already merged in the development branch, so it should get there eventually. 

btw... this page mentions versions explicitly (e.g. 6.6 or 7) and I wonder if we should add some note/reminder somewhere (probably to the ORM release process?) to check/update the page, or we somehow link it to "current version of ORM? 