### PR TITLE
Fix links to "what's new" incorrectly pointing to external websites instead of this one

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -207,6 +207,8 @@ projects:
       migration_guide:
         html: https://docs.jboss.org/hibernate/search/{series.version}/migration/html_single/
         pdf: https://docs.jboss.org/hibernate/search/{series.version}/migration/pdf/hibernate_search_migration.pdf
+      whats_new:
+        html: "/search/releases/{series.version}/#whats-new"
       dist:
         sourceforge:
           zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
@@ -444,6 +446,8 @@ projects:
         pdf: https://docs.jboss.org/hibernate/validator/{series.version}/reference/en-US/pdf/hibernate_validator_reference.pdf#validator-gettingstarted
       migration_guide:
         html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+      whats_new:
+        html: "/validator/releases/{series.version}/#whats-new"
       dist:
         sourceforge:
           zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
@@ -553,6 +557,8 @@ projects:
         pdf: https://docs.jboss.org/hibernate/ogm/{series.version}/reference/en-US/pdf/hibernate_ogm_reference.pdf#ogm-gettingstarted
       migration_guide:
         html: https://docs.jboss.org/hibernate/stable/ogm/reference/en-US/html_single/#ogm-migrating
+      whats_new:
+        html: "/ogm/releases/{series.version}/#whats-new"
       dist:
         sourceforge:
           zip: https://sourceforge.net/projects/hibernate/files/hibernate-ogm/{release.version}/hibernate-ogm-{release.version}-dist.zip/download
@@ -650,6 +656,8 @@ projects:
           html: /reactive/documentation/{series.version}/javadocs/
       getting_started_guide:
         html: /reactive/documentation/{series.version}/reference/html_single/#getting-started
+      whats_new:
+        html: "/reactive/releases/{series.version}/#whats-new"
       dist:
     maven:
       coord:

--- a/_data/projects/orm/releases/4.2/series.yml
+++ b/_data/projects/orm/releases/4.2/series.yml
@@ -12,7 +12,8 @@ links:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
   migration_guide:
     html:
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/4.3/series.yml
+++ b/_data/projects/orm/releases/4.3/series.yml
@@ -13,7 +13,8 @@ links:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
   migration_guide:
     html:
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/5.0/series.yml
+++ b/_data/projects/orm/releases/5.0/series.yml
@@ -10,7 +10,8 @@ links:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
   migration_guide:
     html: https://github.com/hibernate/hibernate-orm/blob/5.0/migration-guide.adoc
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/5.1/series.yml
+++ b/_data/projects/orm/releases/5.1/series.yml
@@ -8,7 +8,8 @@ links:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
   migration_guide:
     html: https://github.com/hibernate/hibernate-orm/blob/5.1/migration-guide.adoc
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/5.2/series.yml
+++ b/_data/projects/orm/releases/5.2/series.yml
@@ -8,7 +8,8 @@ links:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
   migration_guide:
     html: https://github.com/hibernate/hibernate-orm/blob/5.2/migration-guide.adoc
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/5.3/series.yml
+++ b/_data/projects/orm/releases/5.3/series.yml
@@ -35,7 +35,8 @@ links:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
   migration_guide:
     html: https://github.com/hibernate/hibernate-orm/blob/5.3/migration-guide.adoc
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 integration_constraints:
   java:
     version: 8, 11 or 17 (with 5.3.22+)

--- a/_data/projects/orm/releases/5.4/series.yml
+++ b/_data/projects/orm/releases/5.4/series.yml
@@ -35,7 +35,8 @@ links:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
   migration_guide:
     html: https://github.com/hibernate/hibernate-orm/blob/5.4/migration-guide.adoc
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 integration_constraints:
   java:
     version: 8, 11 or 17 (with 5.4.32+)

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -35,7 +35,8 @@ links:
       zip: https://sourceforge.net/projects/hibernate/files/hibernate-orm/{release.version}/hibernate-release-{release.version}.zip/download
   migration_guide:
     html: https://github.com/hibernate/hibernate-orm/blob/5.5/migration-guide.adoc
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 integration_constraints:
   java:
     version: 8, 11 or 17

--- a/_data/projects/orm/releases/5.6/series.yml
+++ b/_data/projects/orm/releases/5.6/series.yml
@@ -7,7 +7,8 @@ displayed: false
 links:
   migration_guide:
     html: https://github.com/hibernate/hibernate-orm/blob/5.6/migration-guide.adoc
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/6.0/series.yml
+++ b/_data/projects/orm/releases/6.0/series.yml
@@ -3,7 +3,8 @@ license:
   name: LGPL v2.1
   url: https://raw.github.com/hibernate/hibernate-orm/6.0/lgpl.txt
 links:
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   repo:
     snapshots: jboss

--- a/_data/projects/orm/releases/6.1/series.yml
+++ b/_data/projects/orm/releases/6.1/series.yml
@@ -3,7 +3,8 @@ license:
   name: LGPL v2.1
   url: https://raw.github.com/hibernate/hibernate-orm/6.1/lgpl.txt
 links:
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/6.2/series.yml
+++ b/_data/projects/orm/releases/6.2/series.yml
@@ -3,7 +3,8 @@ license:
   name: LGPL v2.1
   url: https://raw.github.com/hibernate/hibernate-orm/6.2/lgpl.txt
 links:
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 status: limited-support
 displayed: false
 maven:

--- a/_data/projects/orm/releases/6.3/series.yml
+++ b/_data/projects/orm/releases/6.3/series.yml
@@ -3,7 +3,8 @@ license:
   name: LGPL v2.1
   url: https://raw.github.com/hibernate/hibernate-orm/6.3/lgpl.txt
 links:
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/6.4/series.yml
+++ b/_data/projects/orm/releases/6.4/series.yml
@@ -3,7 +3,8 @@ license:
   name: LGPL v2.1
   url: https://raw.github.com/hibernate/hibernate-orm/6.4/lgpl.txt
 links:
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 status: limited-support
 maven:
   artifacts:

--- a/_data/projects/orm/releases/6.5/series.yml
+++ b/_data/projects/orm/releases/6.5/series.yml
@@ -3,7 +3,8 @@ license:
   name: LGPL v2.1
   url: https://raw.github.com/hibernate/hibernate-orm/6.5/lgpl.txt
 links:
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -3,7 +3,8 @@ license:
   name: LGPL v2.1
   url: https://raw.github.com/hibernate/hibernate-orm/6.6/lgpl.txt
 links:
-  whats_new: # Nothing, we put it directly on the website
+  whats_new:
+    html: "/orm/releases/{series.version}/#whats-new"
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -7,6 +7,8 @@ project_hero_partial: project/hero-series.html.haml
 -# Provides info about a particular series
 -# List releases defined for the given series
 
+- current_path = page.output_path.sub(/index\.html$/, "").sub(/\.html$/,"/")
+
 -# Metadata from site.yml for the project
 - project_description = site.projects[page.project]
 - series = project_description.release_series[page.series_version]
@@ -222,7 +224,7 @@ project_hero_partial: project/hero-series.html.haml
       #{latest_release.version}.
 
 - whats_new = whats_new(project_description, series)
-- if not whats_new.nil?
+- if !whats_new.nil? && (!whats_new.html_url.nil? && !whats_new.html_url.start_with?(current_path) || !whats_new.pdf_url.nil?)
   %p
     Highlights of new features and enhancements can be found here:
   %p


### PR DESCRIPTION
Fixes issue reported [here](https://hibernate.zulipchat.com/#narrow/channel/132096-hibernate-user/topic/Release.20page/with/517502926)