### PR TITLE
End limited support on 5.6

### DIFF
--- a/_data/projects/orm/releases/5.6/series.yml
+++ b/_data/projects/orm/releases/5.6/series.yml
@@ -2,7 +2,6 @@ summary: Dropped support for Javassist, Performance
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/5.6/lgpl.txt
-status: limited-support
 displayed: false
 links:
   migration_guide:


### PR DESCRIPTION
The only supported product it was still used in was RHBQ 2.x, whose support ended in 2024:

https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Quarkus

I don't know of any other still-supported product using 5.6 whose maintainers contribute to Hibernate ORM, so 5.6 is effectively dead.