### PR TITLE
Restore Hibernate Tools in the main menu

### DIFF
--- a/_partials/menu/desktop-top.html.haml
+++ b/_partials/menu/desktop-top.html.haml
@@ -9,8 +9,7 @@
     %a.item{:href => "/ogm/", :class=>"#{'active' if current_path.start_with?('/ogm')}"} OGM
   %a.item{:href => "/reactive/", :class=>"#{'active' if current_path.start_with?('/reactive')}"} Reactive
   %a.item{:href => "/repositories/", :class=>"#{'active' if current_path.start_with?('/repositories')}"} Repositories
-  - if current_path.start_with?('/tools')
-    %a.item{:href => "/tools/", :class=>"#{'active' if current_path.start_with?('/tools')}"} Tools
+  %a.item{:href => "/tools/", :class=>"#{'active' if current_path.start_with?('/tools')}"} Tools
   %a.item{:href => "/others/", :class=>"#{'active' if current_path.start_with?('/others')}"} Others
   .right.menu
     %a.item(href="#{site.in_relation_to.base_url}") Blog

--- a/_partials/menu/mobile.html.haml
+++ b/_partials/menu/mobile.html.haml
@@ -10,8 +10,7 @@
       = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'OGM', 'project_key' => 'ogm', 'project_icon' => 'sitemap'})
     = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'Reactive', 'project_key' => 'reactive', 'project_icon' => 'flask'})
     = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'Repositories', 'project_key' => 'repositories', 'project_icon' => 'university'})
-    - if current_path.start_with?('/tools')
-      = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'Tools', 'project_key' => 'tools', 'project_icon' => 'wrench'})
+    = partial( 'menu/mobile-section-project.html.haml', {'real_page' => real_page, 'project_name' => 'Tools', 'project_key' => 'tools', 'project_icon' => 'wrench'})
     %a.item(href="/others/")
       Others
     = partial( 'menu/mobile-section-community.html.haml', {'real_page' => real_page})

--- a/index.html.haml
+++ b/index.html.haml
@@ -54,7 +54,7 @@ title: Hibernate. Everything data.
               %i.right.arrow.icon
               More
       .project
-        .ui.raised.segment.tools
+        .ui.raised.segment.reactive
           %h3.ui.header
             %a{:href => relative("/reactive/")} Hibernate Reactive
           %p
@@ -65,7 +65,7 @@ title: Hibernate. Everything data.
               %i.right.arrow.icon
               More
       .project
-        .ui.raised.segment.tools
+        .ui.raised.segment.data
           %h3.ui.header
             %a{:href => relative("/repositories/")} Data Repositories
           %p
@@ -78,10 +78,21 @@ title: Hibernate. Everything data.
       .project
         .ui.raised.segment.tools
           %h3.ui.header
+            %a{:href => relative("/tools/")} Hibernate Tools
+          %p
+            %i.big.icon.wrench
+            Command line tools and IDE plugins for your Hibernate usages.
+          .ui.right.aligned.basic.segment
+            %a.ui.button.right.labeled.icon.a.primary{:href => relative("/tools/")}
+              %i.right.arrow.icon
+              More
+      .project
+        .ui.raised.segment.others
+          %h3.ui.header
             %a{:href => relative("/others/")} Others
           %p
             %i.big.icon.pause
-            Less-active projects (Hibernate Tools, Hibernate OGM, Hibernate Shards).
+            Less-active projects (Hibernate OGM, Hibernate Shards).
           .ui.right.aligned.basic.segment
             %a.ui.button.right.labeled.icon.a.primary{:href => relative("/others/")}
               %i.right.arrow.icon

--- a/index.html.haml
+++ b/index.html.haml
@@ -19,85 +19,91 @@ title: Hibernate. Everything data.
     %h1 More than an ORM, discover the Hibernate galaxy.
 .ui.container.content#content
   .projects
-    .ui.doubling.stackable
-      .project
-        .ui.raised.segment.orm
-          %h3.ui.header
-            %a{:href => relative("/orm/")} Hibernate ORM
-          %p
-            %i.big.icon.database
-            Domain model persistence for relational databases.
-          .ui.right.aligned.basic.segment
-            %a.ui.button.right.labeled.icon.a.primary{:href => relative("/orm/")}
-              %i.right.arrow.icon
-              More
-      .project
-        .ui.raised.segment.search
-          %h3.ui.header
-            %a{:href => relative("/search/")} Hibernate Search
-          %p
-            %i.big.icon.search
-            Full-text search for your domain model.
-          .ui.right.aligned.basic.segment
-            %a.button.ui.right.labeled.icon.a.primary{:href => relative("/search/")}
-              %i.right.arrow.icon
-              More
-      .project
-        .ui.raised.segment.validator
-          %h3.ui.header
-            %a{:href => relative("/validator/")} Hibernate Validator
-          %p
-            %i.big.icon.checkmark.box
-            Annotation based constraints for your domain model.
-          .ui.right.aligned.basic.segment
-            %a.ui.button.right.labeled.icon.a.primary{:href => relative("/validator/")}
-              %i.right.arrow.icon
-              More
-      .project
-        .ui.raised.segment.reactive
-          %h3.ui.header
-            %a{:href => relative("/reactive/")} Hibernate Reactive
-          %p
-            %i.big.icon.flask
-            Reactive domain model persistence for relational databases.
-          .ui.right.aligned.basic.segment
-            %a.ui.button.right.labeled.icon.a.primary{:href => relative("/reactive/")}
-              %i.right.arrow.icon
-              More
-      .project
-        .ui.raised.segment.data
-          %h3.ui.header
-            %a{:href => relative("/repositories/")} Data Repositories
-          %p
-            %i.big.icon.university
-            A simplified programming model based on Jakarta Data.
-          .ui.right.aligned.basic.segment
-            %a.ui.button.right.labeled.icon.a.primary{:href => relative("/repositories/")}
-              %i.right.arrow.icon
-              More
-      .project
-        .ui.raised.segment.tools
-          %h3.ui.header
-            %a{:href => relative("/tools/")} Hibernate Tools
-          %p
-            %i.big.icon.wrench
-            Command line tools and IDE plugins for your Hibernate usages.
-          .ui.right.aligned.basic.segment
-            %a.ui.button.right.labeled.icon.a.primary{:href => relative("/tools/")}
-              %i.right.arrow.icon
-              More
-      .project
-        .ui.raised.segment.others
-          %h3.ui.header
-            %a{:href => relative("/others/")} Others
-          %p
-            %i.big.icon.pause
-            Less-active projects (Hibernate OGM, Hibernate Shards).
-          .ui.right.aligned.basic.segment
-            %a.ui.button.right.labeled.icon.a.primary{:href => relative("/others/")}
-              %i.right.arrow.icon
-              More
+    .ui.three.column.doubling.grid.stackable
       .column
+        .ui.raised.segment.orm
+          .project
+            %h3.ui.header
+              %a{:href => relative("/orm/")} Hibernate ORM
+            %p
+              %i.big.icon.database
+              Domain model persistence for relational databases.
+            .ui.right.aligned.basic.segment
+              %a.ui.button.right.labeled.icon.a.primary{:href => relative("/orm/")}
+                %i.right.arrow.icon
+                More
+      .column
+        .ui.raised.segment.search
+          .project
+            %h3.ui.header
+              %a{:href => relative("/search/")} Hibernate Search
+            %p
+              %i.big.icon.search
+              Full-text search for your domain model.
+            .ui.right.aligned.basic.segment
+              %a.button.ui.right.labeled.icon.a.primary{:href => relative("/search/")}
+                %i.right.arrow.icon
+                More
+      .column
+        .ui.raised.segment.validator
+          .project
+            %h3.ui.header
+              %a{:href => relative("/validator/")} Hibernate Validator
+            %p
+              %i.big.icon.checkmark.box
+              Annotation based constraints for your domain model.
+            .ui.right.aligned.basic.segment
+              %a.ui.button.right.labeled.icon.a.primary{:href => relative("/validator/")}
+                %i.right.arrow.icon
+                More
+      .column
+        .ui.raised.segment.reactive
+          .project
+            %h3.ui.header
+              %a{:href => relative("/reactive/")} Hibernate Reactive
+            %p
+              %i.big.icon.flask
+              Reactive domain model persistence for relational databases.
+            .ui.right.aligned.basic.segment
+              %a.ui.button.right.labeled.icon.a.primary{:href => relative("/reactive/")}
+                %i.right.arrow.icon
+                More
+      .column
+        .ui.raised.segment.data
+          .project
+            %h3.ui.header
+              %a{:href => relative("/repositories/")} Data Repositories
+            %p
+              %i.big.icon.university
+              A simplified programming model based on Jakarta Data.
+            .ui.right.aligned.basic.segment
+              %a.ui.button.right.labeled.icon.a.primary{:href => relative("/repositories/")}
+                %i.right.arrow.icon
+                More
+      .column
+        .ui.raised.segment.tools
+          .project
+            %h3.ui.header
+              %a{:href => relative("/tools/")} Hibernate Tools
+            %p
+              %i.big.icon.wrench
+              Command line tools and IDE plugins for your Hibernate usages.
+            .ui.right.aligned.basic.segment
+              %a.ui.button.right.labeled.icon.a.primary{:href => relative("/tools/")}
+                %i.right.arrow.icon
+                More
+      .column
+        .ui.raised.segment.others
+          .project
+            %h3.ui.header
+              %a{:href => relative("/others/")} Others
+            %p
+              %i.big.icon.pause
+              Less-active projects (Hibernate OGM, Hibernate Shards).
+            .ui.right.aligned.basic.segment
+              %a.ui.button.right.labeled.icon.a.primary{:href => relative("/others/")}
+                %i.right.arrow.icon
+                More
 
 :javascript
   $(document).ready(function() {

--- a/others/index.adoc
+++ b/others/index.adoc
@@ -5,15 +5,6 @@ Emmanuel Bernard
 We always have new ideas to solve data related problems.
 You will find some of these experiments here.
 
-== Hibernate Tools
-
-++++
-<a class="ui button right labeled icon a primary" href="/tools/">
-  <i class="right arrow icon"></i>
-  More about Hibernate Tools
-</a>
-++++
-
 == Hibernate OGM
 
 [role="ui message warning"]

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -176,28 +176,12 @@
 .projects {
 	margin-top: 30px;
 
+	.ui.grid {
+    justify-content: space-around;
+  }
+
 	.ui.segment {
 		background-color: #fafafa;
-	}
-
-	.project {
-		.ui.raised.segment {
-			height: 100%;
-			display: flex;
-			flex-direction: column;
-
-			.ui.basic.segment {
-				margin-top: auto;
-			}
-		}
-	}
-
-	.ui.doubling.stackable {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(275px, 1fr));
-		align-items: stretch;
-		column-gap: 28px;
-		row-gap: 28px;
 	}
 }
 


### PR DESCRIPTION
Available on staging: https://staging.hibernate.org/

~~Requires https://github.com/hibernate/hibernate-tools/pull/5316 -- @koentsje can you please merge that?~~ Done

~~I added a minimal "documentation" page with links to what we currently have -- as I understand it, Koen is still working on this, in particular when it comes to the reference documentation for Maven and Gradle.~~ Moved to #272

I checked that instructions for Maven and Gradle work correctly without any issue: entity Java files get generated, with annotations.

@gavinking Can you please have a look and confirm that you won't revert this again.

Without answer, I'll merge around August 18th.