### PR TITLE
Tools documentation

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -419,6 +419,10 @@ projects:
         - name: About
           href: '/tools/'
           css_class: 'home'
+        - name: Documentation
+          href: '/tools/documentation/'
+          css_class: 'folder open'
+          documentation_submenu: false
         - name: Contribute
           href: '/community/contribute/'
           css_class: 'users'

--- a/community/index.adoc
+++ b/community/index.adoc
@@ -21,7 +21,7 @@ Best to first check the documentation. Yes it sounds boring, but knowing a tool 
 <a class="ui label" href="/search/documentation/"><i class="icon book"></i>Search</a>
 <a class="ui label" href="/validator/documentation/"><i class="icon book"></i>Validator</a>
 <a class="ui label" href="/reactive/documentation/"><i class="icon book"></i>Reactive</a>
-<a class="ui label" href="http://tools.jboss.org/documentation/"><i class="icon book"></i>Tools</a>
+<a class="ui label" href="/tools/documentation/"><i class="icon book"></i>Tools</a>
 </div>
 +++
 

--- a/tools/documentation/index.adoc
+++ b/tools/documentation/index.adoc
@@ -1,0 +1,20 @@
+= Documentation
+:awestruct-layout: project-standard
+:awestruct-project: tools
+:page-interpolate: true
+:docs_base_url: https://github.com/hibernate/hibernate-tools/blob/main/
+
+link:{docs_base_url}/README.md[Main README]::
+Global overview and list of tools.
+link:{docs_base_url}/maven/README.md[`hibernate-tools-maven` reference]::
+Reference documentation for the Maven plugin of Hibernate Tools.
+link:{docs_base_url}/maven/docs/5-minute-tutorial.md[`hibernate-tools-maven` tutorial]::
+Five-minute tutorial for the Maven plugin of Hibernate Tools.
+link:{docs_base_url}/gradle/README.md[`hibernate-tools-gradle` reference]::
+Reference documentation for the Gradle plugin of Hibernate Tools.
+link:{docs_base_url}/gradle/docs/5-minute-tutorial.md[`hibernate-tools-gradle` tutorial]::
+Five-minute tutorial for the Gradle plugin of Hibernate Tools.
+link:{docs_base_url}/ant/docs/reference-guide.md[`hibernate-tools-ant` reference]::
+Reference documentation for the Ant tasks of Hibernate Tools.
+link:{docs_base_url}/ant/docs/5-minute-tutorial.md[`hibernate-tools-ant` tutorial]::
+Five-minute tutorial for the Ant tasks of Hibernate Tools.

--- a/tools/index.html.haml
+++ b/tools/index.html.haml
@@ -114,7 +114,7 @@ project: tools
     me@machine foo %
     -----
 
-    Of course all these defaults can be overridden and tuned. Please consult the documentation for more information.
+    Of course all these defaults can be overridden and tuned. Refer to the link:./documentation[documentation] for more information.
 
 .feature-block
   :asciidoc

--- a/tools/index.html.haml
+++ b/tools/index.html.haml
@@ -4,6 +4,11 @@ title: Tooling for your Hibernate projects.
 project: tools
 ---
 
+- latest_stable_orm_version = site.projects['orm'].latest_stable_release.version
+- # This is an approximation, because we don't have Hibernate Tools metadata on the website.
+- latest_stable_tools_version = latest_stable_orm_version
+- sakila_h2_version = '2.3.232'
+
 -# Center body
 .feature-block
   :asciidoc
@@ -67,8 +72,8 @@ project: tools
         <version>1.0-SNAPSHOT</version>
 
         <properties>
-            <hibernate-core.version>${hibernate.version}</hibernate-core.version>
-            <h2.version>${h2.version}</h2.version>
+            <hibernate-core.version>#{latest_stable_orm_version}</hibernate-core.version>
+            <h2.version>#{sakila_h2_version}</h2.version>
         </properties>
 
         <dependencies>
@@ -92,7 +97,7 @@ project: tools
     Having this in place, simply issuing:
     [source]
     -----
-    mvn org.hibernate.tool:hibernate-tools-maven:${hibernate.version}:hbm2java
+    mvn org.hibernate.tool:hibernate-tools-maven:#{latest_stable_tools_version}:hbm2java
     -----
     from a command line prompt in the project folder will use all the default settings to generate Java classes for the
     tables in `target/generated-sources/`.
@@ -124,7 +129,7 @@ project: tools
     -----
     plugins {
         id('application')
-        id('org.hibernate.tool.hibernate-tools-gradle') version '${hibernate-tools.version}'
+        id('org.hibernate.tool.hibernate-tools-gradle') version '#{latest_stable_tools_version}'
     }
 
     repositories {
@@ -132,7 +137,7 @@ project: tools
     }
 
     dependencies {
-        implementation('com.h2database:h2:${h2.version}')
+        implementation('com.h2database:h2:#{sakila_h2_version}')
     }
     -----
 
@@ -162,9 +167,9 @@ project: tools
         <property name="hibernate.tools.version" value=the-hibernate-tools-version-to-use/>
         <property name="h2.version" value=the-h2-version-to-use/>
 
-        <ivy:cachepath organisation="org.hibernate.tool" module="hibernate-tools-ant" revision="${hibernate.tools.version}"
+        <ivy:cachepath organisation="org.hibernate.tool" module="hibernate-tools-ant" revision="#{latest_stable_tools_version}"
                        pathid="hibernate-tools" inline="true"/>
-        <ivy:cachepath organisation="com.h2database" module="h2" revision="${h2.version}"
+        <ivy:cachepath organisation="com.h2database" module="h2" revision="#{sakila_h2_version}"
                        pathid="h2" inline="true"/>
 
         <path id="classpath">


### PR DESCRIPTION
Adds actual versions of ORM/Tools/H2 to the "About" page for tools, and adds a minimal "documentation" page with links to what we currently have -- as I understand it, Koen is still working on this, in particular when it comes to the reference documentation for Maven and Gradle.