### PR TITLE
Expose project metadata as JSON

### DIFF
--- a/_ext/link_resolver.rb
+++ b/_ext/link_resolver.rb
@@ -1,0 +1,232 @@
+require 'logger'
+
+module Awestruct
+  module Extensions
+    class LinkResolver
+      def execute(site)
+        @site = site
+
+        site[:projects].each do |project_id, project|
+            project[:release_series]&.each_value do |series|
+              links = series['links'] || Hash.new
+              series['links'] = links
+              ['reference_doc', 'javadoc', 'migration_guide', 'short_guide', 'whats_new'].each do |key|
+                links[key] = DocumentRef.from_patterns(project, series, key)
+              end
+              ['getting_started_guide'].each do |key|
+                links[key] = DocumentRef.from_patterns_multi(project, series, key)
+              end
+              series[:releases]&.each do |release|
+                links = release['links'] || Hash.new
+                release['links'] = links
+                links[:maven] = MavenRef.from(@site, project, series, release)
+                links[:dist] ||= Hash.new
+                links[:dist][:sourceforge] = DistRef.from(project, series, release, :sourceforge)
+              end
+            end
+        end
+      end
+
+      def self._pattern_substitute(pattern, project, series = nil, release = nil)
+        if pattern.nil?
+          return nil
+        end
+        return pattern.gsub('{series.version}', series&.version || '')
+            .gsub('{series.latest_scm_ref}', series&.latest_scm_ref || '')
+            .gsub('{release.version}', release&.version || '')
+            .gsub('{series.version.dashes}', series&.version&.gsub('.', '-') || '')
+      end
+
+      class MavenRef
+        @@logger = Logger.new(STDERR)
+        @@logger.level = Logger::INFO
+
+        def self.from(site, project, series, release)
+          log_prefix = "#{project['name']}/#{series.version}/#{release.version}: "
+          project_maven = project['maven'] || {}
+          series_maven = series['maven'] || {}
+          release_maven = release['maven'] || {}
+          maven_coord = release_maven&.[]('coord') || series_maven&.[]('coord') || project_maven['coord']
+          @@logger.debug("#{log_prefix}Coord: #{maven_coord}")
+          maven_signing = project_maven&.[]('signing')
+          maven_repo = {}
+          maven_repo[:releases] = MavenRepoRef.from( site, release_maven&.[]('repo')&.[]('releases') || series_maven&.[]('repo')&.[]('releases') || project_maven&.[]('repo')&.[]('releases') )
+          maven_repo[:snapshots] = MavenRepoRef.from( site, release_maven&.[]('repo')&.[]('snapshots') || series_maven&.[]('repo')&.[]('snapshots') || project_maven&.[]('repo')&.[]('snapshots') )
+          @@logger.debug("#{log_prefix}Repo: #{maven_repo}")
+          maven_artifacts = release_maven&.[]('artifacts') || series_maven&.[]('artifacts') || project_maven['artifacts']
+          @@logger.debug("#{log_prefix}Artifacts: #{maven_artifacts}")
+          return MavenRef.new(maven_coord, maven_signing, maven_artifacts, maven_repo)
+        end
+
+        attr_reader :coord, :signing, :artifacts, :repo
+
+        def initialize(coord, signing, artifacts, repo)
+          @coord = coord
+          @signing = signing
+          @artifacts = artifacts
+          @repo = repo
+        end
+      end
+
+      class MavenRepoRef
+        def self.from(site, id)
+          data = site.maven.repo&.[](id)
+          return MavenRepoRef.new(id, data)
+        end
+
+        attr_reader :id, :data
+
+        def initialize(id, data)
+          @id = id
+          @data = data
+        end
+
+        def to_s
+          @id
+        end
+
+        def web_ui_all_artifacts_url(coord, version)
+          if @id != 'central'
+            raise StandardError, "Cannot generate web UI artifact links for repository: #{@id}"
+          end
+          if coord['artifact_id_pattern']
+            # The new Maven Central WebUI doesn't support artifact ID patterns, so we fall back to the old WebUI.
+            search_string = ERB::Util.url_encode("g:#{coord['group_id']} AND a:#{coord['artifact_id_pattern']} AND v:#{version}")
+            return "#{@data.old_web_ui_url}/search?q=#{search_string}"
+          else
+            search_string = ERB::Util.url_encode("g:#{coord['group_id']} v:#{version}")
+            return "#{@data.web_ui_url}/search?q=#{search_string}&sort=name"
+          end
+        end
+
+        def web_ui_artifact_url(group_id, artifact_id, version)
+          if @id != 'central'
+            raise StandardError, "Cannot generate web UI artifact links for repository: #{@id}"
+          end
+          return "#{@data.web_ui_url}/artifact/#{group_id}/#{artifact_id}/#{version}"
+        end
+
+        def direct_download_url(coord)
+          group_id_path = coord['group_id'].gsub('.', '/')
+          return "#{@data.repo_url}/#{group_id_path}/"
+        end
+      end
+
+      class DocumentRef
+        @@logger = Logger.new(STDERR)
+        @@logger.level = Logger::DEBUG
+
+        def self.from_patterns(project, series, link_key)
+          log_prefix = "#{project['name']}/#{series.version}/#{link_key}: "
+          link_root = series&.[]('links')&.[](link_key)
+          link_root ||= project&.[]('links')&.[](link_key)
+          return from_patterns_single(project, series, link_key, link_root)
+        end
+
+        def self.from_patterns_multi(project, series, link_key)
+          log_prefix = "#{project['name']}/#{series.version}/#{link_key}: "
+          link_root = series&.[]('links')&.[](link_key)
+          link_root ||= project&.[]('links')&.[](link_key)
+          links = []
+          if link_root.kind_of?(Array)
+            link_root.each do |link|
+              links.push(from_patterns_single(project, series, link_key, link))
+            end
+          else
+            links.push(from_patterns_single(project, series, link_key, link_root))
+          end
+          return links.compact
+        end
+
+        def self.from_patterns_single(project, series, link_key, link)
+          log_prefix = "#{project['name']}/#{series.version}/#{link_key}: "
+          if link.nil?
+            @@logger.debug("#{log_prefix}Link is nil")
+            return nil
+          end
+          displayed = link['displayed']
+          if not displayed.nil? and not displayed
+            @@logger.debug("#{log_prefix}Link is not displayed")
+            return nil
+          end
+          latest_stable_only = link['latest_stable_only']
+          if not latest_stable_only.nil? and latest_stable_only and not series.latest_stable
+            @@logger.debug("#{log_prefix}Link is for the latest stable series only")
+            return nil
+          end
+          name = link['name']
+          @@logger.debug("#{log_prefix}Link name: #{name}")
+          latest_stable = link['latest_stable']
+          if latest_stable and series.latest_stable
+            link = latest_stable
+            @@logger.debug("#{log_prefix}Link overridden for latest stable: #{link}")
+          end
+          html_pattern = link['html']
+          pdf_pattern = link['pdf']
+          @@logger.debug("#{log_prefix}Link patterns: #{html_pattern} / #{pdf_pattern}")
+          html_url = LinkResolver._pattern_substitute(html_pattern, project, series)
+          pdf_url = LinkResolver._pattern_substitute(pdf_pattern, project, series)
+          @@logger.debug("#{log_prefix}Link URLs: #{html_url} / #{pdf_url}")
+          if html_url.nil? and pdf_url.nil?
+            return nil
+          end
+          return DocumentRef.new(name, html_url, pdf_url)
+        end
+
+        attr_reader :name, :html_url, :pdf_url
+
+        def to_json(*args)
+          {:name => @name, :html_url => @html_url, :pdf_url => @pdf_url}
+              .compact
+              .to_json(*args)
+        end
+
+        def initialize(name, html_url, pdf_url)
+          @name = name
+          @html_url = html_url
+          @pdf_url = pdf_url
+        end
+      end
+
+      class DistRef
+        @@logger = Logger.new(STDERR)
+        @@logger.level = Logger::INFO
+
+        def self.from(project, series, release, link_key)
+          log_prefix = "#{project['name']}/#{series.version}/#{release&.version}/#{link_key}: "
+          link = release&.[]('links')&.[]('dist')&.[](link_key)
+          link ||= series&.[]('links')&.[]('dist')&.[](link_key)
+          link ||= project&.[]('links')&.[]('dist')&.[](link_key)
+          if link.nil?
+            @@logger.debug("#{log_prefix}Link is nil")
+            return nil
+          end
+          @@logger.debug("#{log_prefix}Link is #{link}")
+          displayed = link['displayed']
+          if not displayed.nil? and not displayed
+            @@logger.debug("#{log_prefix}Link is not displayed")
+            return nil
+          end
+          zip_pattern = link['zip']
+          @@logger.debug("#{log_prefix}Link patterns: #{zip_pattern}")
+          zip_url = LinkResolver._pattern_substitute(zip_pattern, project, series, release)
+          @@logger.debug("#{log_prefix}Link URLs: #{zip_url}")
+          if zip_url.nil?
+            return nil
+          end
+          return DistRef.new(zip_url)
+        end
+
+        attr_reader :zip_url
+
+        def to_json(*args)
+          {:zip_url => @zip_url}.to_json(*args)
+        end
+
+        def initialize(zip_url)
+          @zip_url = zip_url
+        end
+      end
+    end
+  end
+end

--- a/_ext/links.rb
+++ b/_ext/links.rb
@@ -9,31 +9,31 @@ module Awestruct
       end
 
       def reference_doc(project, series)
-        return DocumentRef.from_patterns(project, series, :reference_doc)
+        return series&.[](:links)&.[](:reference_doc)
       end
 
       def javadoc(project, series)
-        return DocumentRef.from_patterns(project, series, :javadoc)
+        return series&.[](:links)&.[](:javadoc)
       end
 
       def getting_started_guides(project, series)
-        return DocumentRef.from_patterns_multi(project, series, :getting_started_guide)
+        return series&.[](:links)&.[](:getting_started_guide)
       end
 
       def migration_guide(project, series)
-        return DocumentRef.from_patterns(project, series, :migration_guide)
+        return series&.[](:links)&.[](:migration_guide)
       end
 
       def short_guide(project, series)
-        return DocumentRef.from_patterns(project, series, :short_guide)
+        return series&.[](:links)&.[](:short_guide)
       end
 
       def whats_new(project, series)
-        return DocumentRef.from_patterns(project, series, :whats_new)
+        return series&.[](:links)&.[](:whats_new)
       end
 
       def maven(project, series, release)
-        return MavenRef.from(@site, project, series, release)
+        return release&.[](:links)&.[](:maven)
       end
 
       def github_issues_url(project)
@@ -62,198 +62,7 @@ module Awestruct
       end
 
       def dist_sourceforge(project, series, release)
-        return DistRef.from(project, series, release, :sourceforge)
-      end
-
-      def self._pattern_substitute(pattern, project, series = nil, release = nil)
-        if pattern.nil?
-          return nil
-        end
-        return pattern.gsub('{series.version}', series&.version || '')
-            .gsub('{series.latest_scm_ref}', series&.latest_scm_ref || '')
-            .gsub('{release.version}', release&.version || '')
-            .gsub('{series.version.dashes}', series&.version&.gsub('.', '-') || '')
-      end
-
-      class MavenRef
-        @@logger = Logger.new(STDERR)
-        @@logger.level = Logger::INFO
-
-        def self.from(site, project, series, release)
-          log_prefix = "#{project.name}/#{series.version}/#{release.version}: "
-          project_maven = project[:maven] || {}
-          series_maven = series[:maven] || {}
-          release_maven = release[:maven] || {}
-          maven_coord = release_maven&.[](:coord) || series_maven&.[](:coord) || project_maven[:coord]
-          @@logger.debug("#{log_prefix}Coord: #{maven_coord}")
-          maven_signing = project_maven&.[](:signing)
-          maven_repo = {}
-          maven_repo[:releases] = MavenRepoRef.from( site, release_maven&.[](:repo)&.[](:releases) || series_maven&.[](:repo)&.[](:releases) || project_maven&.[](:repo)&.[](:releases) )
-          maven_repo[:snapshots] = MavenRepoRef.from( site, release_maven&.[](:repo)&.[](:snapshots) || series_maven&.[](:repo)&.[](:snapshots) || project_maven&.[](:repo)&.[](:snapshots) )
-          @@logger.debug("#{log_prefix}Repo: #{maven_repo}")
-          maven_artifacts = release_maven&.[](:artifacts) || series_maven&.[](:artifacts) || project_maven[:artifacts]
-          @@logger.debug("#{log_prefix}Artifacts: #{maven_artifacts}")
-          return MavenRef.new(maven_coord, maven_signing, maven_artifacts, maven_repo)
-        end
-
-        attr_reader :coord, :signing, :artifacts, :repo
-
-        def initialize(coord, signing, artifacts, repo)
-          @coord = coord
-          @signing = signing
-          @artifacts = artifacts
-          @repo = repo
-        end
-      end
-
-      class MavenRepoRef
-        def self.from(site, id)
-          data = site.maven.repo&.[](id)
-          return MavenRepoRef.new(id, data)
-        end
-
-        attr_reader :id, :data
-
-        def initialize(id, data)
-          @id = id
-          @data = data
-        end
-
-        def to_s
-          @id
-        end
-
-        def web_ui_all_artifacts_url(coord, version)
-          if @id != 'central'
-            raise StandardError, "Cannot generate web UI artifact links for repository: #{@id}"
-          end
-          if coord.artifact_id_pattern?
-            # The new Maven Central WebUI doesn't support artifact ID patterns, so we fall back to the old WebUI.
-            search_string = ERB::Util.url_encode("g:#{coord.group_id} AND a:#{coord.artifact_id_pattern} AND v:#{version}")
-            return "#{@data.old_web_ui_url}/search?q=#{search_string}"
-          else
-            search_string = ERB::Util.url_encode("g:#{coord.group_id} v:#{version}")
-            return "#{@data.web_ui_url}/search?q=#{search_string}&sort=name"
-          end
-        end
-
-        def web_ui_artifact_url(group_id, artifact_id, version)
-          if @id != 'central'
-            raise StandardError, "Cannot generate web UI artifact links for repository: #{@id}"
-          end
-          return "#{@data.web_ui_url}/artifact/#{group_id}/#{artifact_id}/#{version}"
-        end
-
-        def direct_download_url(coord)
-          group_id_path = coord.group_id.gsub('.', '/')
-          return "#{@data.repo_url}/#{group_id_path}/"
-        end
-      end
-
-      class DocumentRef
-        @@logger = Logger.new(STDERR)
-        @@logger.level = Logger::INFO
-
-        def self.from_patterns(project, series, link_key)
-          log_prefix = "#{project.name}/#{series.version}/#{link_key}: "
-          link_root = series&.links&.[](link_key)
-          link_root ||= project&.links&.[](link_key)
-          return from_patterns_single(project, series, link_key, link_root)
-        end
-
-        def self.from_patterns_multi(project, series, link_key)
-          log_prefix = "#{project.name}/#{series.version}/#{link_key}: "
-          link_root = series&.links&.[](link_key)
-          link_root ||= project&.links&.[](link_key)
-          links = []
-          if link_root.kind_of?(Array)
-            link_root.each do |link|
-              links.push(from_patterns_single(project, series, link_key, link))
-            end
-          else
-            links.push(from_patterns_single(project, series, link_key, link_root))
-          end
-          return links.compact
-        end
-
-        def self.from_patterns_single(project, series, link_key, link)
-          log_prefix = "#{project.name}/#{series.version}/#{link_key}: "
-          if link.nil?
-            @@logger.debug("#{log_prefix}Link is nil")
-            return nil
-          end
-          displayed = link['displayed']
-          if not displayed.nil? and not displayed
-            @@logger.debug("#{log_prefix}Link is not displayed")
-            return nil
-          end
-          latest_stable_only = link['latest_stable_only']
-          if not latest_stable_only.nil? and latest_stable_only and not series.latest_stable
-            @@logger.debug("#{log_prefix}Link is for the latest stable series only")
-            return nil
-          end
-          name = link['name']
-          @@logger.debug("#{log_prefix}Link name: #{name}")
-          latest_stable = link['latest_stable']
-          if latest_stable and series.latest_stable
-            link = latest_stable
-            @@logger.debug("#{log_prefix}Link overridden for latest stable: #{link}")
-          end
-          html_pattern = link['html']
-          pdf_pattern = link['pdf']
-          @@logger.debug("#{log_prefix}Link patterns: #{html_pattern} / #{pdf_pattern}")
-          html_url = Links._pattern_substitute(html_pattern, project, series)
-          pdf_url = Links._pattern_substitute(pdf_pattern, project, series)
-          @@logger.debug("#{log_prefix}Link URLs: #{html_url} / #{pdf_url}")
-          if html_url.nil? and pdf_url.nil?
-            return nil
-          end
-          return DocumentRef.new(name, html_url, pdf_url)
-        end
-
-        attr_reader :name, :html_url, :pdf_url
-
-        def initialize(name, html_url, pdf_url)
-          @name = name
-          @html_url = html_url
-          @pdf_url = pdf_url
-        end
-      end
-
-      class DistRef
-        @@logger = Logger.new(STDERR)
-        @@logger.level = Logger::INFO
-
-        def self.from(project, series, release, link_key)
-          log_prefix = "#{project.name}/#{series.version}/#{release&.version}/#{link_key}: "
-          link = release&.links&.dist&.[](link_key)
-          link ||= series&.links&.dist&.[](link_key)
-          link ||= project&.links&.dist&.[](link_key)
-          if link.nil?
-            @@logger.debug("#{log_prefix}Link is nil")
-            return nil
-          end
-          @@logger.debug("#{log_prefix}Link is #{link}")
-          displayed = link['displayed']
-          if not displayed.nil? and not displayed
-            @@logger.debug("#{log_prefix}Link is not displayed")
-            return nil
-          end
-          zip_pattern = link['zip']
-          @@logger.debug("#{log_prefix}Link patterns: #{zip_pattern}")
-          zip_url = Links._pattern_substitute(zip_pattern, project, series, release)
-          @@logger.debug("#{log_prefix}Link URLs: #{zip_url}")
-          if zip_url.nil?
-            return nil
-          end
-          return DistRef.new(zip_url)
-        end
-
-        attr_reader :zip_url
-
-        def initialize(zip_url)
-          @zip_url = zip_url
-        end
+        return release&.[](:links)&.[](:dist)&.[](:sourceforge)
       end
     end
   end

--- a/_ext/metadata_publisher.rb
+++ b/_ext/metadata_publisher.rb
@@ -1,0 +1,61 @@
+require 'fileutils'
+require 'json'
+
+module Awestruct
+  module Extensions
+    class MetadataPublisher
+      @@logger = Logger.new(STDERR)
+      @@logger.level = Logger::INFO
+
+      def execute(site)
+        metadata_hash_for_json = Hash.new
+        site.data_json ||= Hash.new
+        site.data_json[:metadata] = metadata_hash_for_json
+
+        site[:projects].each do |project_id, project|
+          if (project[:id] == nil)
+            project[:id] = project_id
+          end
+          metadata_hash_for_json[project_id] = filterForJson(project).to_json
+        end
+      end
+
+      def filterForJson(project)
+        filtered = filter(project, {
+            description: nil,
+            copyright: nil,
+            jira: nil
+        })
+        filtered[:series] = project[:release_series]&.transform_values {|v| filter(v, {
+            # Just make to mention in this object all properties you want to keep in JSON.
+            # That's what we'll keep.
+            summary: nil,
+            status: nil,
+            license: {
+                name: nil,
+                since: nil
+            },
+            links: nil
+          })
+        }
+        return filtered
+      end
+
+      def filter(object, prototype)
+        if object == nil
+          return nil
+        elsif prototype.kind_of?(Array)
+          return object.collect {|o| filter(o, prototype[0])}
+        elsif prototype.kind_of?(Hash)
+          filtered = Hash.new
+          prototype.each_key { |key|
+            filtered[key] = filter(object[key], prototype[key])
+          }
+          return filtered
+        else
+          return object
+        end
+      end
+    end
+  end
+end

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -8,6 +8,7 @@ require 'data_file_parser'
 require 'redirect_creator'
 require 'directory_listing'
 require 'links'
+require 'link_resolver'
 
 # dependencies for asciidoc support
 require 'tilt'
@@ -44,6 +45,7 @@ Awestruct::Extensions::Pipeline.new do
 
   # register extensions and transformers
   extension Awestruct::Extensions::ReleaseFileParser.new
+  extension Awestruct::Extensions::LinkResolver.new
   extension Awestruct::Extensions::DataFileParser.new
   transformer Awestruct::Extensions::JsMinifier.new
   transformer Awestruct::Extensions::CssMinifier.new

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -9,6 +9,7 @@ require 'redirect_creator'
 require 'directory_listing'
 require 'links'
 require 'link_resolver'
+require 'metadata_publisher'
 
 # dependencies for asciidoc support
 require 'tilt'
@@ -47,6 +48,7 @@ Awestruct::Extensions::Pipeline.new do
   extension Awestruct::Extensions::ReleaseFileParser.new
   extension Awestruct::Extensions::LinkResolver.new
   extension Awestruct::Extensions::DataFileParser.new
+  extension Awestruct::Extensions::MetadataPublisher.new
   transformer Awestruct::Extensions::JsMinifier.new
   transformer Awestruct::Extensions::CssMinifier.new
   transformer Awestruct::Extensions::HtmlMinifier.new

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -117,6 +117,7 @@ module Awestruct
           series = series.merge(subproject_series)
         end
 
+        series[:project] = project
         if ( series[:version] == nil )
           series[:version] = File.basename( series_dir )
         end
@@ -141,6 +142,8 @@ module Awestruct
           release = release.merge(subproject_release)
         end
 
+        release[:project] = project
+        release[:series] = series
         if ( release[:version] == nil )
           File.basename( release_file ) =~ /^(.*)\.\w*$/
           release[:version] = $1

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -117,7 +117,6 @@ module Awestruct
           series = series.merge(subproject_series)
         end
 
-        series[:project] = project
         if ( series[:version] == nil )
           series[:version] = File.basename( series_dir )
         end
@@ -142,8 +141,6 @@ module Awestruct
           release = release.merge(subproject_release)
         end
 
-        release[:project] = project
-        release[:series] = series
         if ( release[:version] == nil )
           File.basename( release_file ) =~ /^(.*)\.\w*$/
           release[:version] = $1

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -160,7 +160,7 @@ project_hero_partial: project/hero-series.html.haml
             Below are the Maven coordinates of the main artifacts.
           %div.ui.relaxed.divided.list
             - latest_release_maven.artifacts.each do |artifact|
-              - group_id = latest_release_maven.coord.group_id
+              - group_id = latest_release_maven.coord['group_id']
               - artifact_id = artifact.artifact_id
               - version = latest_release.version
               %div.item
@@ -174,9 +174,9 @@ project_hero_partial: project/hero-series.html.haml
                     :asciidoc
                       :doctype: inline
                       #{(artifact[:summary] || artifact.artifact_id).strip}
-        - if latest_release_maven&.signing&.since
+        - if latest_release_maven&.signing&.[]('since')
           %p
-            All Maven artifacts of this project released after #{latest_release_maven.signing.since} are signed.
+            All Maven artifacts of this project released after #{latest_release_maven.signing['since']} are signed.
           %p
             To verify signed Maven artifacts, head to
             %a{:href => "/community/keys/"}

--- a/_partials/project/banner-series.html.haml
+++ b/_partials/project/banner-series.html.haml
@@ -14,7 +14,7 @@
           %h2
             %span
               = real_page.title
-            = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "tag" } )
+            = partial( 'project/series-status-label.html.haml', { "project_name" => project_name, "series" => series, "classes" => "tag" } )
         .column.four.wide.middle.aligned
           = partial( real_page.project_buttons_partial.nil? ? 'project/empty-buttons.html.haml' : real_page.project_buttons_partial, { "real_page" => real_page } )
 

--- a/_partials/project/series-status-label.html.haml
+++ b/_partials/project/series-status-label.html.haml
@@ -1,10 +1,11 @@
+- project_name = page["project_name"]
 - series = page["series"]
 - classes = page["classes"]
 - tooltipPosition = page["tooltipPosition"] || "bottom center"
 
 - if series.status == 'end-of-life'
   %span.ui.label.red{:class => "#{classes}"}
-    %span{:data => tooltipPosition == "none" ? Hash.new : {:tooltip => "#{series.project.name} #{series.version} has reached its end-of-life: \nwe recommend that you upgrade to a newer series if possible, \nbecause we are unlikely to fix bugs or provide new releases for this series.", :position => tooltipPosition}}
+    %span{:data => tooltipPosition == "none" ? Hash.new : {:tooltip => "#{project_name} #{series.version} has reached its end-of-life: \nwe recommend that you upgrade to a newer series if possible, \nbecause we are unlikely to fix bugs or provide new releases for this series.", :position => tooltipPosition}}
       end-of-life
 - elsif series.status == 'stable'
   %span.ui.label.green{:class => "#{classes}"}
@@ -14,11 +15,11 @@
     latest stable
 - elsif series.status == 'development'
   %span.ui.label.orange{:class => "#{classes}"}
-    %span{:data => tooltipPosition == "none" ? Hash.new : {:tooltip => "#{series.project.name} #{series.version} is still in development: \nwe encourage you to try it, but be prepared for changes.", :position => tooltipPosition}}
+    %span{:data => tooltipPosition == "none" ? Hash.new : {:tooltip => "#{project_name} #{series.version} is still in development: \nwe encourage you to try it, but be prepared for changes.", :position => tooltipPosition}}
       development
 - elsif series.status == 'limited-support'
   %span.ui.label.yellow{:class => "#{classes}"}
-    %span{:data => tooltipPosition == "none" ? Hash.new : {:tooltip => "#{series.project.name} #{series.version} is in limited support mode: \nwe recommend that you upgrade to a newer series if possible \nor look for paid support, because we will not always fix bugs \nor provide timely releases for this series.\nDownstream frameworks or commercial offerings (e.g. Red Hat's) \nmay provide stronger guarantees.", :position => tooltipPosition}}
+    %span{:data => tooltipPosition == "none" ? Hash.new : {:tooltip => "#{project_name} #{series.version} is in limited support mode: \nwe recommend that you upgrade to a newer series if possible \nor look for paid support, because we will not always fix bugs \nor provide timely releases for this series.\nDownstream frameworks or commercial offerings (e.g. Red Hat's) \nmay provide stronger guarantees.", :position => tooltipPosition}}
       limited-support
 - else
   - raise StandardError, "Unsupported series status: #{series.status}"

--- a/metadata/orm.json.haml
+++ b/metadata/orm.json.haml
@@ -1,7 +1,1 @@
-{
-"series":
-= site.projects.orm.release_series.to_json
-,
-"releases":
-= site.projects.orm.releases.to_json
-}
+= site.data_json.metadata.orm

--- a/metadata/orm.json.haml
+++ b/metadata/orm.json.haml
@@ -1,0 +1,7 @@
+{
+"series":
+= site.projects.orm.release_series.to_json
+,
+"releases":
+= site.projects.orm.releases.to_json
+}

--- a/metadata/reactive.json.haml
+++ b/metadata/reactive.json.haml
@@ -1,0 +1,7 @@
+{
+"series":
+= site.projects.reactive.release_series.to_json
+,
+"releases":
+= site.projects.reactive.releases.to_json
+}

--- a/metadata/reactive.json.haml
+++ b/metadata/reactive.json.haml
@@ -1,7 +1,1 @@
-{
-"series":
-= site.projects.reactive.release_series.to_json
-,
-"releases":
-= site.projects.reactive.releases.to_json
-}
+= site.data_json.metadata.reactive

--- a/metadata/search.json.haml
+++ b/metadata/search.json.haml
@@ -1,0 +1,7 @@
+{
+"series":
+= site.projects.search.release_series.to_json
+,
+"releases":
+= site.projects.search.releases.to_json
+}

--- a/metadata/search.json.haml
+++ b/metadata/search.json.haml
@@ -1,7 +1,1 @@
-{
-"series":
-= site.projects.search.release_series.to_json
-,
-"releases":
-= site.projects.search.releases.to_json
-}
+= site.data_json.metadata.search

--- a/metadata/validator.json.haml
+++ b/metadata/validator.json.haml
@@ -1,0 +1,7 @@
+{
+"series":
+= site.projects.validator.release_series.to_json
+,
+"releases":
+= site.projects.validator.releases.to_json
+}

--- a/metadata/validator.json.haml
+++ b/metadata/validator.json.haml
@@ -1,7 +1,1 @@
-{
-"series":
-= site.projects.validator.release_series.to_json
-,
-"releases":
-= site.projects.validator.releases.to_json
-}
+= site.data_json.metadata.validator


### PR DESCRIPTION
For consumption by e.g. Javascript on other websites.

It's a bit on the heavy side for now, but I guess we could filter it?

See:

https://staging.hibernate.org/metadata/orm.json
https://staging.hibernate.org/metadata/search.json
https://staging.hibernate.org/metadata/reactive.json
https://staging.hibernate.org/metadata/validator.json

E.g. you'd get something like this:

```json
{
  "description": "Automatic indexing of Hibernate ORM entities into Apache Lucene or Elasticsearch.\nAdvanced search API: full-text, geospatial, aggregations and more.\n",
  "copyright": {
    "url": "https://raw.githubusercontent.com/hibernate/hibernate-search/main/AUTHORS.txt"
  },
  "jira": {
    "key": "HSEARCH"
  },
  "series": {
    "8.1": {
      "summary": "Aggregation DSL improvements, platform BOMs, upgrade to Hibernate ORM 7.1 compatibility with new versions of Elasticsearch/OpenSearch, other bugfixes, improvements and upgrades",
      "status": "latest-stable",
      "license": {
        "name": "ASL v2",
        "since": "7.2.0.Alpha2"
      },
      "links": {
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/stable/search/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/stable/search/api/"
        },
        "migration_guide": {
          "html_url": "https://docs.jboss.org/hibernate/search/8.1/migration/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/8.1/migration/pdf/hibernate_search_migration.pdf"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/8.1/#whats-new"
        },
        "getting_started_guide": [
          {
            "name": "ORM",
            "html_url": "https://docs.jboss.org/hibernate/search/8.1/getting-started/orm/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/8.1/getting-started/orm/en-US/pdf/hibernate_search_getting_started_orm.pdf"
          },
          {
            "name": "Standalone",
            "html_url": "https://docs.jboss.org/hibernate/search/8.1/getting-started/standalone/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/8.1/getting-started/standalone/en-US/pdf/hibernate_search_getting_started_standalone.pdf"
          }
        ]
      }
    },
    "8.0": {
      "summary": "Integration with Hibernate ORM 7.0, metric aggregations, new Lucene-based backend, logging categories and more.",
      "status": "end-of-life",
      "license": {
        "name": "ASL v2",
        "since": "7.2.0.Alpha2"
      },
      "links": {
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/8.0/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/8.0/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/8.0/api/"
        },
        "migration_guide": {
          "html_url": "https://docs.jboss.org/hibernate/search/8.0/migration/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/8.0/migration/pdf/hibernate_search_migration.pdf"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/8.0/#whats-new"
        },
        "getting_started_guide": [
          {
            "name": "ORM",
            "html_url": "https://docs.jboss.org/hibernate/search/8.0/getting-started/orm/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/8.0/getting-started/orm/en-US/pdf/hibernate_search_getting_started_orm.pdf"
          },
          {
            "name": "Standalone",
            "html_url": "https://docs.jboss.org/hibernate/search/8.0/getting-started/standalone/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/8.0/getting-started/standalone/en-US/pdf/hibernate_search_getting_started_standalone.pdf"
          }
        ]
      }
    },
    "7.2": {
      "summary": "Re-licensing as Apache License 2.0, query string predicates on numeric/date fields, analyzer API",
      "status": "limited-support",
      "license": {
        "name": "ASL v2",
        "since": "7.2.0.Alpha2"
      },
      "links": {
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/7.2/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/7.2/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/7.2/api/"
        },
        "migration_guide": {
          "html_url": "https://docs.jboss.org/hibernate/search/7.2/migration/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/7.2/migration/pdf/hibernate_search_migration.pdf"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/7.2/#whats-new"
        },
        "getting_started_guide": [
          {
            "name": "ORM",
            "html_url": "https://docs.jboss.org/hibernate/search/7.2/getting-started/orm/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/7.2/getting-started/orm/en-US/pdf/hibernate_search_getting_started_orm.pdf"
          },
          {
            "name": "Standalone",
            "html_url": "https://docs.jboss.org/hibernate/search/7.2/getting-started/standalone/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/7.2/getting-started/standalone/en-US/pdf/hibernate_search_getting_started_standalone.pdf"
          }
        ]
      }
    },
    "7.1": {
      "summary": "Vector search, new query string predicate, simplified Standalone POJO mapper",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/7.1/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/7.1/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/7.1/api/"
        },
        "migration_guide": {
          "html_url": "https://docs.jboss.org/hibernate/search/7.1/migration/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/7.1/migration/pdf/hibernate_search_migration.pdf"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/7.1/#whats-new"
        },
        "getting_started_guide": [
          {
            "name": "ORM",
            "html_url": "https://docs.jboss.org/hibernate/search/7.1/getting-started/orm/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/7.1/getting-started/orm/en-US/pdf/hibernate_search_getting_started_orm.pdf"
          },
          {
            "name": "Standalone",
            "html_url": "https://docs.jboss.org/hibernate/search/7.1/getting-started/standalone/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/7.1/getting-started/standalone/en-US/pdf/hibernate_search_getting_started_standalone.pdf"
          }
        ]
      }
    },
    "7.0": {
      "summary": "Switch to Jakarta EE / ORM 6.4 without `-orm6` artifacts,  Hibernate Search BOM",
      "status": "limited-support",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/7.0/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/7.0/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/7.0/api/"
        },
        "migration_guide": {
          "html_url": "https://docs.jboss.org/hibernate/search/7.0/migration/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/7.0/migration/pdf/hibernate_search_migration.pdf"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/7.0/#whats-new"
        },
        "getting_started_guide": [
          {
            "name": "ORM",
            "html_url": "https://docs.jboss.org/hibernate/search/7.0/getting-started/orm/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/7.0/getting-started/orm/en-US/pdf/hibernate_search_getting_started_orm.pdf"
          },
          {
            "name": "Standalone",
            "html_url": "https://docs.jboss.org/hibernate/search/7.0/getting-started/standalone/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/7.0/getting-started/standalone/en-US/pdf/hibernate_search_getting_started_standalone.pdf"
          }
        ]
      }
    },
    "6.2": {
      "summary": "Standalone POJO Mapper, projection to custom (annotated) types, highlighting, `excludePaths` for `@IndexedEmbedded`, Elasticsearch schema export",
      "status": "limited-support",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/6.2/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/6.2/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/6.2/api/"
        },
        "migration_guide": {
          "html_url": "https://docs.jboss.org/hibernate/search/6.2/migration/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/6.2/migration/pdf/hibernate_search_migration.pdf"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/6.2/#whats-new"
        },
        "getting_started_guide": [
          {
            "name": "ORM",
            "html_url": "https://docs.jboss.org/hibernate/search/6.2/getting-started/orm/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/6.2/getting-started/orm/en-US/pdf/hibernate_search_getting_started_orm.pdf"
          },
          {
            "name": "Standalone",
            "html_url": "https://docs.jboss.org/hibernate/search/6.2/getting-started/standalone/en-US/html_single/",
            "pdf_url": "https://docs.jboss.org/hibernate/search/6.2/getting-started/standalone/en-US/pdf/hibernate_search_getting_started_standalone.pdf"
          }
        ]
      }
    },
    "6.1": {
      "summary": "Asynchronous, distributed automatic indexing, OpenSearch compatibility, conditional mass indexing, Jakarta EE / ORM 6 artifacts",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [
          {
            "html_url": "https://docs.jboss.org/hibernate/search/6.1/reference/en-US/html_single/#getting-started",
            "pdf_url": "https://docs.jboss.org/hibernate/search/6.1/reference/en-US/pdf/hibernate_search_reference.pdf#getting-started"
          }
        ],
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/6.1/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/6.1/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/6.1/api/"
        },
        "migration_guide": {
          "html_url": "https://docs.jboss.org/hibernate/search/6.1/migration/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/6.1/migration/pdf/hibernate_search_migration.pdf"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/6.1/#whats-new"
        }
      }
    },
    "6.0": {
      "summary": "API overhaul, safer and more concise Search DSL, more powerful bridges, smarter automatic indexing, nested documents",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [
          {
            "html_url": "https://docs.jboss.org/hibernate/search/6.0/reference/en-US/html_single/#getting-started",
            "pdf_url": "https://docs.jboss.org/hibernate/search/6.0/reference/en-US/pdf/hibernate_search_reference.pdf#getting-started"
          }
        ],
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/6.0/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/6.0/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/6.0/api/"
        },
        "migration_guide": {
          "html_url": "https://docs.jboss.org/hibernate/search/6.0/migration/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/6.0/migration/pdf/hibernate_search_migration.pdf"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/6.0/#whats-new"
        }
      }
    },
    "5.11": {
      "summary": "ORM 5.4 compatibility.",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [
          {
            "html_url": "/search/documentation/getting-started/5.11"
          }
        ],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.11/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.11/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.11/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.11/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.11/#whats-new"
        }
      }
    },
    "5.10": {
      "summary": "ORM 5.3 and JPA 2.2 compatibility, integration to DI frameworks through Hibernate ORM 5.3, upgrade to WildFly 17 and JGroups 4, JPMS automatic module names.",
      "status": "limited-support",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.10/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.10/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.10/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.10/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.10/#whats-new"
        }
      }
    },
    "5.9": {
      "summary": "JSR 352 (Batch for Java) mass indexing job, WildFly feature packs, improvements and deprecations paving the road to Search 6",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.9/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.9/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.9/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.9/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.9/#whats-new"
        }
      }
    },
    "5.8": {
      "summary": "Experimental integration with Elasticsearch 5.x, AWS integration, improvements and deprecations paving the road to Search 6",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.8/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.8/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.8/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.8/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.8/#whats-new"
        }
      }
    },
    "5.7": {
      "summary": "Improved integration with Elasticsearch 2.x, compatible with Hibernate ORM 5.2.x",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.7/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.7/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.7/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.7/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.7/#whats-new"
        }
      }
    },
    "5.6": {
      "summary": "Introduces experimental support for Elasticsearch, last release supporting Hibernate ORM 5.0.z or 5.1.z",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.6/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.6/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.6/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.6/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.6/#whats-new"
        }
      }
    },
    "5.5": {
      "summary": "Being maintained as it's included in WildFly. Supports Lucene only, requires Hibernate ORM 5.0.z or 5.1.z",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.5/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.5/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.5/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.5/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.5/#whats-new"
        }
      }
    },
    "5.4": {
      "summary": "Requires Hibernate ORM 5.0.0.Final; Last version compatible with Apache Lucene 4.x",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.4/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.4/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.4/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.4/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.4/#whats-new"
        }
      }
    },
    "5.3": {
      "summary": "Improved Faceting",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.3/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.3/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.3/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.3/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.3/#whats-new"
        }
      }
    },
    "5.2": {
      "summary": "Multi-tenancy, optimisations in criteria based loaders",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.2/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.2/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.2/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.2/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.2/#whats-new"
        }
      }
    },
    "5.1": {
      "summary": "Upgrade to Lucene 4 and much much more ...",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.1/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.1/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.1/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.1/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.1/#whats-new"
        }
      }
    },
    "5.0": {
      "summary": "Upgrade to Lucene 4 and much much more ...",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "/search/documentation/migrate/5.0/"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.0/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/5.0/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/5.0/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/5.0/#whats-new"
        }
      }
    },
    "4.5": {
      "summary": "Performance, WildFly 8 compatibility, JPA 2.1 / Hibernate ORM 4.3 compatibility",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "https://developer.jboss.org/docs/DOC-15249"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/4.5/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/4.5/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/4.5/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/4.5/#whats-new"
        }
      }
    },
    "4.4": {
      "summary": "Dynamic index sharding, new Metadata API, Hibernate ORM 4.2.x compatible",
      "status": "end-of-life",
      "license": {
        "name": "LGPL v2.1",
        "since": null
      },
      "links": {
        "getting_started_guide": [],
        "migration_guide": {
          "html_url": "https://developer.jboss.org/docs/DOC-15249"
        },
        "reference_doc": {
          "html_url": "https://docs.jboss.org/hibernate/search/4.4/reference/en-US/html_single/",
          "pdf_url": "https://docs.jboss.org/hibernate/search/4.4/reference/en-US/pdf/hibernate_search_reference.pdf"
        },
        "javadoc": {
          "html_url": "https://docs.jboss.org/hibernate/search/4.4/api/"
        },
        "short_guide": null,
        "whats_new": {
          "html_url": "/search/releases/4.4/#whats-new"
        }
      }
    }
  }
}

```