### PR TITLE
[WIP] Added mongodb extension for hibernate orm to community page

### DIFF
--- a/community/index.adoc
+++ b/community/index.adoc
@@ -22,6 +22,7 @@ Best to first check the documentation. Yes it sounds boring, but knowing a tool 
 <a class="ui label" href="/validator/documentation/"><i class="icon book"></i>Validator</a>
 <a class="ui label" href="/reactive/documentation/"><i class="icon book"></i>Reactive</a>
 <a class="ui label" href="/tools/documentation/"><i class="icon book"></i>Tools</a>
+<a class="ui label" href="https://www.mongodb.com/docs/languages/java/mongodb-hibernate/current"><i class="icon book"></i>MongoDB Extension for Hibernate ORM</a>
 </div>
 +++
 
@@ -34,6 +35,7 @@ After the documentation, probably the best place to look for answers. We activel
 <a class="ui label" href="https://stackoverflow.com/questions/tagged/hibernate-validator">hibernate-validator</a>
 <a class="ui label" href="https://stackoverflow.com/questions/tagged/hibernate-reactive">hibernate-reactive</a>
 <a class="ui label" href="https://stackoverflow.com/questions/tagged/hibernate-tools">hibernate-tools</a>
+<a class="ui label" href="https://stackoverflow.com/questions/tagged/mongo-hibernate">MongoDB Extension for Hibernate ORM</a>
 </div>
 +++
 
@@ -72,6 +74,7 @@ Here are the pages dedicated to each project:
 <a class="ui label" href="https://hibernate.atlassian.net/browse/HV">Hibernate Validator</a>
 <a class="ui label" href="https://github.com/hibernate/hibernate-reactive/issues">Hibernate Reactive</a>
 <a class="ui label" href="https://hibernate.atlassian.net/browse/HBX">Hibernate Tools</a>
+<a class="ui label" href="https://jira.mongodb.org/projects/HIBERNATE">MongoDB Extension for Hibernate ORM</a>
 </div>
 +++
 +


### PR DESCRIPTION
Adding MongoDB extension for Hibernate ORM to the community page https://hibernate.org/community/. 

WIP since it needs additional review from @yrodiere and we shouldn't merge until launch next week (10/28)