### PR TITLE
Adjust corporate contributors

### DIFF
--- a/community/corporate-contributors.html.haml
+++ b/community/corporate-contributors.html.haml
@@ -64,18 +64,6 @@ title: Corporate contributors
       %a.ui.blue.label(href='/ogm/') Hibernate OGM
   .ui.card.fluid.contributor
     .image
-      %a(href='https://www.epam.com/')
-        %img{:src => "#{relative("/images/contributors/epam.png", page)}"}
-    .content
-      .header
-        %a(href='https://www.epam.com/') EPAM Systems, Inc.
-      .description
-        %p EPAM Systems, Inc. provides complex software engineering solutions and technology services with delivery capacity distributed across Central and Eastern Europe. It delivers services to clients located primarily in North America, Western Europe, and Central and Eastern Europe or CEE.
-        %p EPAM Systems, Inc. contributed developers time to the Hibernate OGM project.
-    .extra.content
-      %a.ui.blue.label(href='/ogm/') Hibernate OGM
-  .ui.card.fluid.contributor
-    .image
       %a(href='https://www.mongodb.com/')
         %img{:src => "#{relative("/images/contributors/mongodb.svg", page)}"}
     .content
@@ -167,3 +155,25 @@ title: Corporate contributors
             Zulip Cloud Standard
           instance.
         %p Zulip is an open-source modern team chat app designed to keep both live and asynchronous conversations organized.
+
+
+%h2{:id => "contributors"} Alumni
+
+.ui.message
+  .content
+    These companies contributed in the past,
+    though they are no longer active on Hibernate projects.
+
+.ui.stackable.corporate-contributors#alumni
+  .ui.card.fluid.contributor
+    .image
+      %a(href='https://www.epam.com/')
+        %img{:src => "#{relative("/images/contributors/epam.png", page)}"}
+    .content
+      .header
+        %a(href='https://www.epam.com/') EPAM Systems, Inc.
+      .description
+        %p EPAM Systems, Inc. provides complex software engineering solutions and technology services with delivery capacity distributed across Central and Eastern Europe. It delivers services to clients located primarily in North America, Western Europe, and Central and Eastern Europe or CEE.
+        %p EPAM Systems, Inc. contributed developers time to the Hibernate OGM project.
+    .extra.content
+      %a.ui.blue.label(href='/ogm/') Hibernate OGM

--- a/community/corporate-contributors.html.haml
+++ b/community/corporate-contributors.html.haml
@@ -47,6 +47,18 @@ title: Corporate contributors
       %a.ui.blue.label(href='/orm/') Hibernate ORM
   .ui.card.fluid.contributor
     .image
+      %a(href='https://www.mongodb.com/')
+        %img{:src => "#{relative("/images/contributors/mongodb.svg", page)}"}
+    .content
+      .header
+        %a(href='https://www.mongodb.com/') MongoDB
+      .description
+        %p MongoDB is the world’s most popular document database, giving developers a flexible, intuitive way to work with data. With MongoDB Atlas, teams get a fully managed cloud DBaaS platform that combines the flexible document model with a suite of data services, best-in-class security, and enterprise scalability, empowering developers to build any type of application.
+        %p MongoDB proudly contributes to the Hibernate ORM project through the MongoDB Extension for Hibernate ORM, bringing first-class support for MongoDB’s document model to the Hibernate ecosystem.
+    .extra.content
+      %a.ui.blue.label(href='https://github.com/mongodb/mongo-hibernate') MongoDB Extension for Hibernate ORM
+  .ui.card.fluid.contributor
+    .image
       %a(href='https://www.sap.com/')
         %img{:src => "#{relative("/images/contributors/sap.png", page)}"}
     .content
@@ -62,37 +74,12 @@ title: Corporate contributors
       %a.ui.blue.label(href='/orm/') Hibernate ORM
       %a.ui.blue.label(href='/search/') Hibernate Search
       %a.ui.blue.label(href='/ogm/') Hibernate OGM
-  .ui.card.fluid.contributor
-    .image
-      %a(href='https://www.mongodb.com/')
-        %img{:src => "#{relative("/images/contributors/mongodb.svg", page)}"}
-    .content
-      .header
-        %a(href='https://www.mongodb.com/') MongoDB
-      .description
-        %p MongoDB is the world’s most popular document database, giving developers a flexible, intuitive way to work with data. With MongoDB Atlas, teams get a fully managed cloud DBaaS platform that combines the flexible document model with a suite of data services, best-in-class security, and enterprise scalability, empowering developers to build any type of application.
-        %p MongoDB proudly contributes to the Hibernate ORM project through the MongoDB Extension for Hibernate ORM, bringing first-class support for MongoDB’s document model to the Hibernate ecosystem.
-    .extra.content
-      %a.ui.blue.label(href='https://github.com/mongodb/mongo-hibernate') MongoDB Extension for Hibernate ORM
 
 %p &nbsp;
 
 %h2{:id => "infrastructure"} Infrastructure providers
 
 .ui.relaxed.divided.items.infrastructure-providers
-  .item
-    .image.multiple
-      %a(href='https://www.ibm.com/')
-        %img.ibm{:src => "#{relative("/images/contributors/ibm-logo.png", page)}"}
-      %a(href='https://www.redhat.com/')
-        %img.redhat{:src => "#{relative("/images/contributors/redhat-logo.svg", page)}"}
-    .content
-      %p.header
-        %a(href='https://www.ibm.com/') IBM
-        and
-        %a(href='https://www.redhat.com/') Red Hat
-      .description
-        %p IBM and Red Hat provide funding for our official CI infrastructure based on Jenkins.
   .item
     .image
       %a(href='https://www.atlassian.com/')
@@ -134,6 +121,19 @@ title: Corporate contributors
       %a.header(href='https://github.com/') GitHub
       .description
         %p Our source code is hosted on GitHub and we use GitHub Actions for part of our CI.
+  .item
+    .image.multiple
+      %a(href='https://www.ibm.com/')
+        %img.ibm{:src => "#{relative("/images/contributors/ibm-logo.png", page)}"}
+      %a(href='https://www.redhat.com/')
+        %img.redhat{:src => "#{relative("/images/contributors/redhat-logo.svg", page)}"}
+    .content
+      %p.header
+        %a(href='https://www.ibm.com/') IBM
+        and
+        %a(href='https://www.redhat.com/') Red Hat
+      .description
+        %p IBM and Red Hat provide funding for our official CI infrastructure based on Jenkins.
   .item
     .image
       %a(href='https://testpilot.oracle.com/')


### PR DESCRIPTION
Based on #300 which must be merged first.

See below for result.

Changes:

* Move EPAM to an Alumni section
* Order corporate contributors and infrastructure providers alphabetically


<img width="1580" height="3666" alt="image" src="https://github.com/user-attachments/assets/9b1673ca-31df-428d-a1cf-3d023bb919ea" />

