### PR TITLE
Update supported JDKs for each family version

### DIFF
--- a/_data/projects/reactive/releases/2.4/series.yml
+++ b/_data/projects/reactive/releases/2.4/series.yml
@@ -6,7 +6,7 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 11, 17, 20, 21, 22 or 23
+    version: 11, 17, 21, or 25 
   orm:
     version: 6.6
   vertx:

--- a/_data/projects/reactive/releases/3.1/series.yml
+++ b/_data/projects/reactive/releases/3.1/series.yml
@@ -6,7 +6,7 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 24
+    version: 17, 21, or 25
   orm:
     version: 7.1
   vertx:

--- a/_data/projects/reactive/releases/4.1/series.yml
+++ b/_data/projects/reactive/releases/4.1/series.yml
@@ -5,7 +5,7 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 24
+    version: 17, 21, or 25
   orm:
     version: 7.1
   vertx:


### PR DESCRIPTION
And remove limited-support for 3.1 because the only difference with 4.1 is the Vert.x version dependency.