### PR TITLE
[ORM] Move 6.4 out of limited support

### DIFF
--- a/_data/projects/orm/releases/6.4/series.yml
+++ b/_data/projects/orm/releases/6.4/series.yml
@@ -5,7 +5,6 @@ license:
 links:
   whats_new:
     html: "/orm/releases/{series.version}/#whats-new"
-status: limited-support
 maven:
   artifacts:
     - artifact_id: hibernate-core


### PR DESCRIPTION
It was only used in Quarkus 3.15, which is out of support.