### PR TITLE
[ORM] Mark JDK 25 as supported in 6.6.40+, 7.1 and Repositories 7.2

### DIFF
--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -24,7 +24,7 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 11, 17, 21, 22 or 23
+    version: 11, 17, 21 or 25 (6.6.40+)
   jakarta_ee_jpa:
     version: 3.1
   jakarta_ee:

--- a/_data/projects/orm/releases/7.1/series.yml
+++ b/_data/projects/orm/releases/7.1/series.yml
@@ -30,7 +30,7 @@ maven:
       summary: Leverages Jandex to support managed-resource scanning (entity discovery, etc) in Hibernate ORM.
 integration_constraints:
   java:
-    version: 17, 21 or 23
+    version: 17, 21 or 25
   jakarta_ee_jpa:
     version: 3.2
   jakarta_ee:
@@ -46,7 +46,7 @@ subprojects:
           summary: Runtime support
     integration_constraints:
       java:
-        version: 17, 21 or 23
+        version: 17, 21 or 25
       jakarta_ee_data:
         version: 1.0
       jakarta_ee:

--- a/_data/projects/orm/releases/7.2/series.yml
+++ b/_data/projects/orm/releases/7.2/series.yml
@@ -49,7 +49,7 @@ subprojects:
           summary: Runtime support
     integration_constraints:
       java:
-        version: 17, 21 or 23
+        version: 17, 21 or 25
       jakarta_ee_data:
         version: 1.0
       jakarta_ee:


### PR DESCRIPTION
Because it is:

* https://github.com/hibernate/hibernate-orm/pull/10345
* https://github.com/hibernate/hibernate-orm/pull/11153