### PR TITLE
[HR] Mark 3.2 as stable

### DIFF
--- a/_data/projects/reactive/releases/3.1/series.yml
+++ b/_data/projects/reactive/releases/3.1/series.yml
@@ -1,5 +1,5 @@
 summary: Release compatible with Hibernate ORM 7.1 and Vert.x 4.5
-:status: limited-support
+status: limited-support
 maven:
   artifacts:
     - artifact_id: hibernate-reactive-core

--- a/_data/projects/reactive/releases/3.2/series.yml
+++ b/_data/projects/reactive/releases/3.2/series.yml
@@ -1,4 +1,5 @@
 summary: Release compatible with Hibernate ORM 7.2 and Vert.x 4.5
+status: stable
 maven:
   artifacts:
     - artifact_id: hibernate-reactive-core


### PR DESCRIPTION
Because it is definitely not EOL.

Result:

<img width="1537" height="1029" alt="image" src="https://github.com/user-attachments/assets/db540772-7de8-4878-ae52-5e2752366eb4" />

@DavideD FYI
