### PR TITLE
[HSEARCH/HV] Only show Sourceforge links for older release series

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -472,9 +472,6 @@ projects:
       whats_new:
         html: https://docs.hibernate.org/validator/{series.version}/whats-new/en-US/html_single
         pdf: https://docs.hibernate.org/validator/{series.version}/whats-new/en-US/pdf/hibernate_validator_whats_new.pdf
-      dist:
-        sourceforge:
-          zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
     maven:
       signing:
         since: '2022-02-08'

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -221,9 +221,6 @@ projects:
       whats_new:
         html: https://docs.hibernate.org/search/{series.version}/whats-new/en-US/html_single
         pdf: https://docs.hibernate.org/search/{series.version}/whats-new/en-US/pdf/hibernate_search_whats_new.pdf
-      dist:
-        sourceforge:
-          zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
     maven:
       signing:
         since: '2022-01-26'

--- a/_data/projects/search/releases/4.4/series.yml
+++ b/_data/projects/search/releases/4.4/series.yml
@@ -9,6 +9,9 @@ links:
     html: https://developer.jboss.org/docs/DOC-15249
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/4.5/series.yml
+++ b/_data/projects/search/releases/4.5/series.yml
@@ -9,6 +9,9 @@ links:
     html: https://developer.jboss.org/docs/DOC-15249
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.0/series.yml
+++ b/_data/projects/search/releases/5.0/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.1/series.yml
+++ b/_data/projects/search/releases/5.1/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.11/series.yml
+++ b/_data/projects/search/releases/5.11/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.2/series.yml
+++ b/_data/projects/search/releases/5.2/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.3/series.yml
+++ b/_data/projects/search/releases/5.3/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.4/series.yml
+++ b/_data/projects/search/releases/5.4/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.5/series.yml
+++ b/_data/projects/search/releases/5.5/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.6/series.yml
+++ b/_data/projects/search/releases/5.6/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.7/series.yml
+++ b/_data/projects/search/releases/5.7/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.8/series.yml
+++ b/_data/projects/search/releases/5.8/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/5.9/series.yml
+++ b/_data/projects/search/releases/5.9/series.yml
@@ -9,6 +9,9 @@ links:
     html: /search/documentation/migrate/{series.version}/
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/6.0/series.yml
+++ b/_data/projects/search/releases/6.0/series.yml
@@ -12,6 +12,9 @@ links:
     pdf: https://docs.hibernate.org/search/{series.version}/reference/en-US/pdf/hibernate_search_reference.pdf#getting-started
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   artifacts:
     - artifact_id: hibernate-search-mapper-orm

--- a/_data/projects/search/releases/6.1/series.yml
+++ b/_data/projects/search/releases/6.1/series.yml
@@ -12,6 +12,9 @@ links:
     pdf: https://docs.hibernate.org/search/{series.version}/reference/en-US/pdf/hibernate_search_reference.pdf#getting-started
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   artifacts:
     - artifact_id: hibernate-search-mapper-orm-orm6

--- a/_data/projects/search/releases/7.0/series.yml
+++ b/_data/projects/search/releases/7.0/series.yml
@@ -7,6 +7,9 @@ license:
 links:
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   artifacts:
     - artifact_id: hibernate-search-bom

--- a/_data/projects/search/releases/7.1/series.yml
+++ b/_data/projects/search/releases/7.1/series.yml
@@ -8,6 +8,9 @@ license:
 links:
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   artifacts:
     - artifact_id: hibernate-search-bom

--- a/_data/projects/search/releases/8.0/series.yml
+++ b/_data/projects/search/releases/8.0/series.yml
@@ -7,6 +7,9 @@ summary: >-
 links:
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/{release.version}/hibernate-search-{release.version}-dist.zip/download
 maven:
   artifacts:
     - artifact_id: hibernate-search-bom

--- a/_data/projects/validator/releases/4.3/series.yml
+++ b/_data/projects/validator/releases/4.3/series.yml
@@ -4,6 +4,9 @@ links:
     html: "/validator/releases/{series.version}/#whats-new"
   migration_guide:
     html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/validator/releases/5.0/series.yml
+++ b/_data/projects/validator/releases/5.0/series.yml
@@ -4,6 +4,9 @@ links:
     html: "/validator/releases/{series.version}/#whats-new"
   migration_guide:
     html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/validator/releases/5.1/series.yml
+++ b/_data/projects/validator/releases/5.1/series.yml
@@ -4,6 +4,9 @@ links:
     html: "/validator/releases/{series.version}/#whats-new"
   migration_guide:
     html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/validator/releases/5.2/series.yml
+++ b/_data/projects/validator/releases/5.2/series.yml
@@ -4,6 +4,9 @@ links:
     html: "/validator/releases/{series.version}/#whats-new"
   migration_guide:
     html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/validator/releases/5.3/series.yml
+++ b/_data/projects/validator/releases/5.3/series.yml
@@ -4,6 +4,9 @@ links:
     html: "/validator/releases/{series.version}/#whats-new"
   migration_guide:
     html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/validator/releases/5.4/series.yml
+++ b/_data/projects/validator/releases/5.4/series.yml
@@ -4,6 +4,9 @@ links:
     html: "/validator/releases/{series.version}/#whats-new"
   migration_guide:
     html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/validator/releases/6.0/series.yml
+++ b/_data/projects/validator/releases/6.0/series.yml
@@ -4,6 +4,9 @@ links:
     html: "/validator/releases/{series.version}/#whats-new"
   migration_guide:
     html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
 maven:
   artifacts:
     - artifact_id: hibernate-validator

--- a/_data/projects/validator/releases/6.1/series.yml
+++ b/_data/projects/validator/releases/6.1/series.yml
@@ -4,6 +4,9 @@ links:
     html: "/validator/releases/{series.version}/#whats-new"
   migration_guide:
     html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
 maven:
   repo:
     snapshots: jboss

--- a/_data/projects/validator/releases/7.0/series.yml
+++ b/_data/projects/validator/releases/7.0/series.yml
@@ -4,6 +4,9 @@ links:
     html: "/validator/releases/{series.version}/#whats-new"
   migration_guide:
     html: /validator/documentation/migration-guide/#{series.version.dashes}-x
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/{release.version}/hibernate-validator-{release.version}-dist.zip/download
 maven:
   artifacts:
     - artifact_id: hibernate-validator


### PR DESCRIPTION
I didn't add the links for the currently "at some level of support" versions (thinking that we may be doing more releases for them and hence new versions won't get uploaded to Sourceforge.