### PR TITLE
Fix limited support

### DIFF
--- a/_data/projects/orm/releases/5.3/series.yml
+++ b/_data/projects/orm/releases/5.3/series.yml
@@ -2,8 +2,6 @@ summary: JPA 2.2, inheritance caching
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/5.3/lgpl.txt
-status: limited-support
-displayed: false
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/orm/releases/7.2/series.yml
+++ b/_data/projects/orm/releases/7.2/series.yml
@@ -3,6 +3,7 @@ summary: >-
   @EmbeddedTable,
   FindMultipleOptions, 
   Vector Support for SQL Server
+status: limited-support
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/search/releases/5.10/series.yml
+++ b/_data/projects/search/releases/5.10/series.yml
@@ -1,6 +1,4 @@
 summary: ORM 5.3 and JPA 2.2 compatibility, integration to DI frameworks through Hibernate ORM 5.3, upgrade to WildFly 17 and JGroups 4, JPMS automatic module names.
-status: limited-support
-displayed: false
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-search/5.10/lgpl.txt

--- a/_data/projects/validator/releases/6.2/series.yml
+++ b/_data/projects/validator/releases/6.2/series.yml
@@ -1,4 +1,5 @@
 summary: Keep javax.* packages, Expression Language overhaul, @SafeHtml removal
+# Not actually included in any downstream integration we care about, but Marko wants to continue supporting it as the last version using javax. package names.
 status: limited-support
 links:
   whats_new:

--- a/_data/projects/validator/releases/9.0/series.yml
+++ b/_data/projects/validator/releases/9.0/series.yml
@@ -23,7 +23,6 @@ maven:
       summary: Annotation processor
     - artifact_id: hibernate-validator-test-utils
       summary: Set of test utilities that can help testing custom constraints.
-status: limited-support
 integration_constraints:
   java:
     version: 17, 21, 23 or 24


### PR DESCRIPTION
Fix existing incorrect information, and mark ORM 5.3 and Search 5.10 as EOL.

See also https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/5.2E3.20EOL/with/580204394