### PR TITLE
Add downstream frameworks to the compatibility matrix, compute limited-support based on that

### DIFF
--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -3,6 +3,10 @@
 # - external software that can be used through Hibernate projects.
 #
 # 'series.yml' files of each project reference the versions of integrators the corresponding series is included in.
+#
+# Active series are documented for downstream projects that any member of the Hibernate team is involved in,
+# because then this member provides at least "limited support" for the corresponding Hibernate project series,
+# even if this series is not the latest stable.
 java:
   name: Java
   url: https://www.oracle.com/java/technologies/downloads/
@@ -52,14 +56,26 @@ quarkus:
   name: Quarkus
   url: https://quarkus.io/
   downstream: true
+  hibernate_involvement: true
+  active_series:
+    - "3.20" # TODO should this be considered EOL? It should be according to https://access.redhat.com/support/policy/updates/red_hat_build_of_quarkus_notes but I see recent commits in https://github.com/quarkusio/quarkus/commits/3.20/
+    - "3.27"
+    - "3.32"
 wildfly:
   name: WildFly
   url: https://www.wildfly.org/
   downstream: true
+  hibernate_involvement: true
+  active_series:
+    - "39"
 rheap:
   name: Red Hat EAP
   url: https://www.redhat.com/en/technologies/jboss-middleware/application-platform
   downstream: true
+  hibernate_involvement: true
+  active_series:
+    - "8.0"
+    - "8.1"
 spring_boot:
   name: Spring Boot
   url: https://spring.io/projects/spring-boot

--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -1,3 +1,8 @@
+# "Integrations" here is meant as either:
+# - downstream software that expose Hibernate projects to their users.
+# - external software that can be used through Hibernate projects.
+#
+# 'series.yml' files of each project reference the versions of integrators the corresponding series is included in.
 java:
   name: Java
   url: https://www.oracle.com/java/technologies/downloads/
@@ -43,3 +48,12 @@ search:
 vertx:
   name: Vert.x
   url: https://vertx.io
+quarkus:
+  name: Quarkus
+  url: https://quarkus.io/
+wildfly:
+  name: WildFly
+  url: https://www.wildfly.org/
+spring_boot:
+  name: Spring Boot
+  url: https://spring.io/projects/spring-boot

--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -56,6 +56,10 @@ wildfly:
   name: WildFly
   url: https://www.wildfly.org/
   downstream: true
+rheap:
+  name: Red Hat EAP
+  url: https://www.redhat.com/en/technologies/jboss-middleware/application-platform
+  downstream: true
 spring_boot:
   name: Spring Boot
   url: https://spring.io/projects/spring-boot

--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -51,9 +51,12 @@ vertx:
 quarkus:
   name: Quarkus
   url: https://quarkus.io/
+  downstream: true
 wildfly:
   name: WildFly
   url: https://www.wildfly.org/
+  downstream: true
 spring_boot:
   name: Spring Boot
   url: https://spring.io/projects/spring-boot
+  downstream: true

--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -7,36 +7,23 @@
 # Active series are documented for downstream projects that any member of the Hibernate team is involved in,
 # because then this member provides at least "limited support" for the corresponding Hibernate project series,
 # even if this series is not the latest stable.
+#
+# IMPORTANT: The order of entries in this file is the order they are displayed in compatibility matrices on the website.
 java:
   name: Java
   url: https://www.oracle.com/java/technologies/downloads/
+orm:
+  name: Hibernate ORM
+  url: /orm/
+search:
+  name: Hibernate Search
+  url: /search/
 java_ee_jpa:
   name: JPA
   url: https://www.oracle.com/technetwork/java/javaee/tech/persistence-jsp-140049.html
 jakarta_ee_jpa:
   name: Jakarta Persistence
   url: https://jakarta.ee/specifications/persistence/
-java_ee:
-  name: Java EE
-  url: https://www.oracle.com/java/technologies/java-ee-glance.html
-jakarta_ee:
-  name: Jakarta EE
-  url: https://jakarta.ee
-dialect_mongodb:
-  name: MongoDB Extension
-  url: https://github.com/mongodb/mongo-hibernate/
-orm:
-  name: Hibernate ORM
-  url: /orm/
-lucene:
-  name: Apache Lucene
-  url: https://lucene.apache.org/core/
-elasticsearch:
-  name: Elasticsearch server
-  url: https://www.elastic.co/products/elasticsearch
-opensearch:
-  name: OpenSearch server
-  url: https://www.opensearch.org
 jakarta_ee_data:
   name: Jakarta Data
   url: https://jakarta.ee/specifications/data/
@@ -46,12 +33,27 @@ java_ee_bv:
 jakarta_ee_bv:
   name: Jakarta Validation
   url: https://beanvalidation.org/
-search:
-  name: Hibernate Search
-  url: /search/
+java_ee:
+  name: Java EE
+  url: https://www.oracle.com/java/technologies/java-ee-glance.html
+jakarta_ee:
+  name: Jakarta EE
+  url: https://jakarta.ee
 vertx:
   name: Vert.x
   url: https://vertx.io
+dialect_mongodb:
+  name: MongoDB Extension
+  url: https://github.com/mongodb/mongo-hibernate/
+lucene:
+  name: Apache Lucene
+  url: https://lucene.apache.org/core/
+elasticsearch:
+  name: Elasticsearch server
+  url: https://www.elastic.co/products/elasticsearch
+opensearch:
+  name: OpenSearch server
+  url: https://www.opensearch.org
 quarkus:
   name: Quarkus
   url: https://quarkus.io/

--- a/_data/projects/ogm/releases/5.0/series.yml
+++ b/_data/projects/ogm/releases/5.0/series.yml
@@ -20,7 +20,9 @@ links:
     html: https://developer.jboss.org/docs/DOC-52281
 integration_constraints:
   java:
-    version: 7 or 8
+    version:
+      - 7
+      - 8
   java_ee_jpa:
     version: 2.1
   orm:

--- a/_data/projects/ogm/releases/5.1/series.yml
+++ b/_data/projects/ogm/releases/5.1/series.yml
@@ -22,7 +22,9 @@ links:
     html: https://developer.jboss.org/docs/DOC-52281
 integration_constraints:
   java:
-    version: 7 or 8
+    version:
+      - 7
+      - 8
   java_ee_jpa:
     version: 2.1
   orm:

--- a/_data/projects/ogm/releases/5.4/series.yml
+++ b/_data/projects/ogm/releases/5.4/series.yml
@@ -22,4 +22,4 @@ integration_constraints:
   orm:
     version: 5.3
   search:
-    version: "5.10"
+    version: 5.10

--- a/_data/projects/orm/releases/4.2/series.yml
+++ b/_data/projects/orm/releases/4.2/series.yml
@@ -39,6 +39,8 @@ maven:
       summary: Ehcache second-level caching
 integration_constraints:
   java:
-    version: 6+
+    version:
+      - 6
+      - 7
   java_ee_jpa:
     version: 2.0

--- a/_data/projects/orm/releases/4.3/series.yml
+++ b/_data/projects/orm/releases/4.3/series.yml
@@ -40,6 +40,8 @@ maven:
       summary: Ehcache second-level caching
 integration_constraints:
   java:
-    version: 6 or 7
+    version:
+      - 6
+      - 7
   java_ee_jpa:
     version: 2.1

--- a/_data/projects/orm/releases/5.0/series.yml
+++ b/_data/projects/orm/releases/5.0/series.yml
@@ -43,6 +43,9 @@ maven:
       summary: Ehcache second-level caching
 integration_constraints:
   java:
-    version: 6, 7 or 8
+    version:
+      - 6
+      - 7
+      - 8
   java_ee_jpa:
     version: 2.1

--- a/_data/projects/orm/releases/5.0/series.yml
+++ b/_data/projects/orm/releases/5.0/series.yml
@@ -49,3 +49,5 @@ integration_constraints:
       - 8
   java_ee_jpa:
     version: 2.1
+  spring_boot:
+    version: '1.5'

--- a/_data/projects/orm/releases/5.1/series.yml
+++ b/_data/projects/orm/releases/5.1/series.yml
@@ -49,4 +49,8 @@ integration_constraints:
       - value: 8
   java_ee_jpa:
     version: 2.1
+  wildfly:
+    version:
+      - '12'
+      - '13'
 

--- a/_data/projects/orm/releases/5.1/series.yml
+++ b/_data/projects/orm/releases/5.1/series.yml
@@ -41,7 +41,12 @@ maven:
       summary: Ehcache second-level caching
 integration_constraints:
   java:
-    version: 6/7/8 through 5.1.3; 7/8 through 5.1.16; 8 for 5.1.17
+    version:
+      - value: 6
+        comment: "up to 5.1.15"
+      - value: 7
+        comment: "up to 5.1.16"
+      - value: 8
   java_ee_jpa:
     version: 2.1
 

--- a/_data/projects/orm/releases/5.2/series.yml
+++ b/_data/projects/orm/releases/5.2/series.yml
@@ -40,4 +40,6 @@ integration_constraints:
     version: 8
   java_ee_jpa:
     version: 2.1
+  spring_boot:
+    version: '2.0'
 

--- a/_data/projects/orm/releases/5.3/series.yml
+++ b/_data/projects/orm/releases/5.3/series.yml
@@ -37,7 +37,11 @@ links:
     html: "/orm/releases/{series.version}/#whats-new"
 integration_constraints:
   java:
-    version: 8, 11 or 17 (with 5.3.22+)
+    version:
+      - 8
+      - 11
+      - value: 17
+        comment: "with 5.3.22+"
   java_ee_jpa:
     version: 2.2
   java_ee:

--- a/_data/projects/orm/releases/5.3/series.yml
+++ b/_data/projects/orm/releases/5.3/series.yml
@@ -52,4 +52,6 @@ integration_constraints:
     version:
       from: '13'
       to: '16'
+  rheap:
+    version: '7.4'
 

--- a/_data/projects/orm/releases/5.3/series.yml
+++ b/_data/projects/orm/releases/5.3/series.yml
@@ -46,4 +46,10 @@ integration_constraints:
     version: 2.2
   java_ee:
     version: 8
+  spring_boot:
+    version: '2.1'
+  wildfly:
+    version:
+      from: '13'
+      to: '16'
 

--- a/_data/projects/orm/releases/5.4/series.yml
+++ b/_data/projects/orm/releases/5.4/series.yml
@@ -39,7 +39,11 @@ links:
     html: "/orm/releases/{series.version}/#whats-new"
 integration_constraints:
   java:
-    version: 8, 11 or 17 (with 5.4.32+)
+    version:
+      - 8
+      - 11
+      - value: 17
+        comment: "with 5.4.32+"
   java_ee_jpa:
     version: 2.2
   java_ee:

--- a/_data/projects/orm/releases/5.4/series.yml
+++ b/_data/projects/orm/releases/5.4/series.yml
@@ -48,4 +48,12 @@ integration_constraints:
     version: 2.2
   java_ee:
     version: 8
+  quarkus:
+    version:
+      from: '1.0'
+      to: '1.13'
+  spring_boot:
+    version:
+      from: '2.2'
+      to: '2.5'
 

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -39,7 +39,10 @@ links:
     html: "/orm/releases/{series.version}/#whats-new"
 integration_constraints:
   java:
-    version: 8, 11 or 17
+    version:
+      - 8
+      - 11
+      - 17
   java_ee_jpa:
     version: 2.2
   jakarta_ee_jpa:

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -51,4 +51,8 @@ integration_constraints:
     version: 8
   jakarta_ee:
     version: 9
+  quarkus:
+    version:
+      from: '2.0'
+      to: '2.3.0'
 

--- a/_data/projects/orm/releases/5.6/series.yml
+++ b/_data/projects/orm/releases/5.6/series.yml
@@ -37,7 +37,11 @@ maven:
       summary: Ehcache second-level caching
 integration_constraints:
   java:
-    version: 8, 11, 17 or 18
+    version:
+      - 8
+      - 11
+      - 17
+      - 18
   java_ee_jpa:
     version: 2.2
   jakarta_ee_jpa:

--- a/_data/projects/orm/releases/5.6/series.yml
+++ b/_data/projects/orm/releases/5.6/series.yml
@@ -48,4 +48,12 @@ integration_constraints:
     version: 3.0
   jakarta_ee:
     version: 9
+  quarkus:
+    version:
+      value: '2.3'
+      comment: excluding 2.3.0
+  spring_boot:
+    version:
+      from: '2.6'
+      to: '2.7'
 

--- a/_data/projects/orm/releases/6.0/series.yml
+++ b/_data/projects/orm/releases/6.0/series.yml
@@ -25,9 +25,16 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 11, 17 or 18
+    version:
+      - 11
+      - 17
+      - 18
   jakarta_ee_jpa:
-    version: 3.1 and 3.0
+    version:
+      - 3.1
+      - 3.0
   jakarta_ee:
-    version: 10 and 9
+    version:
+      - 10
+      - 9
 

--- a/_data/projects/orm/releases/6.1/series.yml
+++ b/_data/projects/orm/releases/6.1/series.yml
@@ -23,8 +23,15 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 11, 17 or 18
+    version:
+      - 11
+      - 17
+      - 18
   jakarta_ee_jpa:
-    version: 3.1 and 3.0
+    version:
+      - 3.1
+      - 3.0
   jakarta_ee:
-    version: 10 and 9
+    version:
+      - 10
+      - 9

--- a/_data/projects/orm/releases/6.1/series.yml
+++ b/_data/projects/orm/releases/6.1/series.yml
@@ -35,3 +35,7 @@ integration_constraints:
     version:
       - 10
       - 9
+  spring_boot:
+    version: '3.0'
+  wildfly:
+    version: '27'

--- a/_data/projects/orm/releases/6.2/series.yml
+++ b/_data/projects/orm/releases/6.2/series.yml
@@ -25,7 +25,11 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 11, 17, 20 or 21
+    version:
+      - 11
+      - 17
+      - 20
+      - 21
   jakarta_ee_jpa:
     version: 3.1
   jakarta_ee:

--- a/_data/projects/orm/releases/6.2/series.yml
+++ b/_data/projects/orm/releases/6.2/series.yml
@@ -34,3 +34,13 @@ integration_constraints:
     version: 3.1
   jakarta_ee:
     version: 10
+  quarkus:
+    version:
+      from: '3.0'
+      to: '3.6'
+  spring_boot:
+    version: '3.1'
+  wildfly:
+    version:
+      from: '28'
+      to: '29'

--- a/_data/projects/orm/releases/6.2/series.yml
+++ b/_data/projects/orm/releases/6.2/series.yml
@@ -44,3 +44,5 @@ integration_constraints:
     version:
       from: '28'
       to: '29'
+  rheap:
+    version: '8.0'

--- a/_data/projects/orm/releases/6.2/series.yml
+++ b/_data/projects/orm/releases/6.2/series.yml
@@ -5,7 +5,6 @@ license:
 links:
   whats_new:
     html: "/orm/releases/{series.version}/#whats-new"
-status: limited-support
 displayed: false
 maven:
   artifacts:

--- a/_data/projects/orm/releases/6.3/series.yml
+++ b/_data/projects/orm/releases/6.3/series.yml
@@ -23,7 +23,10 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 11, 17 or 21
+    version:
+      - 11
+      - 17
+      - 21
   jakarta_ee_jpa:
     version: 3.1
   jakarta_ee:

--- a/_data/projects/orm/releases/6.4/series.yml
+++ b/_data/projects/orm/releases/6.4/series.yml
@@ -23,7 +23,10 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 11, 17 or 21
+    version:
+      - 11
+      - 17
+      - 21
   jakarta_ee_jpa:
     version: 3.1
   jakarta_ee:

--- a/_data/projects/orm/releases/6.4/series.yml
+++ b/_data/projects/orm/releases/6.4/series.yml
@@ -31,3 +31,13 @@ integration_constraints:
     version: 3.1
   jakarta_ee:
     version: 10
+  quarkus:
+    version:
+      from: '3.7'
+      to: '3.10'
+  spring_boot:
+    version: '3.2'
+  wildfly:
+    version:
+      from: '31'
+      to: '33'

--- a/_data/projects/orm/releases/6.5/series.yml
+++ b/_data/projects/orm/releases/6.5/series.yml
@@ -31,3 +31,9 @@ integration_constraints:
     version: 3.1
   jakarta_ee:
     version: 10
+  quarkus:
+    version:
+      from: '3.11'
+      to: '3.13'
+  spring_boot:
+    version: '3.3'

--- a/_data/projects/orm/releases/6.5/series.yml
+++ b/_data/projects/orm/releases/6.5/series.yml
@@ -23,7 +23,10 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 11, 17 or 21
+    version:
+      - 11
+      - 17
+      - 21
   jakarta_ee_jpa:
     version: 3.1
   jakarta_ee:

--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -36,6 +36,18 @@ integration_constraints:
     version: 10
   dialect_mongodb:
     version: 1.0
+  quarkus:
+    version:
+      from: '3.14'
+      to: '3.23'
+  spring_boot:
+    version:
+      from: '3.4'
+      to: '3.5'
+  wildfly:
+    version:
+      from: '34'
+      to: '39'
 subprojects:
   repositories:
     summary: Jakarta Data 1.0, compatibility with Hibernate ORM 6

--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -31,6 +31,8 @@ integration_constraints:
         comment: "6.6.40+"
   jakarta_ee_jpa:
     version: 3.1
+  jakarta_ee_data:
+    version: 1.0
   jakarta_ee:
     version: 10
   dialect_mongodb:
@@ -58,15 +60,3 @@ subprojects:
           summary: Annotation processor
         - artifact_id: hibernate-core
           summary: Runtime support
-    integration_constraints:
-      java:
-        version:
-          - 17
-          - 21
-          - 23
-      jakarta_ee_data:
-        version: 1.0
-      jakarta_ee:
-        version: 11
-      orm:
-        version: 6.6

--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -5,7 +5,6 @@ license:
 links:
   whats_new:
     html: "/orm/releases/{series.version}/#whats-new"
-status: limited-support
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -24,7 +24,12 @@ maven:
       summary: JCache second-level caching
 integration_constraints:
   java:
-    version: 11, 17, 21 or 25 (6.6.40+)
+    version:
+      - 11
+      - 17
+      - 21
+      - value: 25
+        comment: "6.6.40+"
   jakarta_ee_jpa:
     version: 3.1
   jakarta_ee:
@@ -42,7 +47,10 @@ subprojects:
           summary: Runtime support
     integration_constraints:
       java:
-        version: 17, 21 or 23
+        version:
+          - 17
+          - 21
+          - 23
       jakarta_ee_data:
         version: 1.0
       jakarta_ee:

--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -48,6 +48,8 @@ integration_constraints:
     version:
       from: '34'
       to: '39'
+  rheap:
+    version: '8.1'
 subprojects:
   repositories:
     summary: Jakarta Data 1.0, compatibility with Hibernate ORM 6

--- a/_data/projects/orm/releases/7.0/series.yml
+++ b/_data/projects/orm/releases/7.0/series.yml
@@ -29,7 +29,10 @@ maven:
       summary: Leverages Jandex to support managed-resource scanning (entity discovery, etc) in Hibernate ORM.
 integration_constraints:
   java:
-    version: 17, 21 or 23
+    version:
+      - 17
+      - 21
+      - 23
   jakarta_ee_jpa:
     version: 3.2
   jakarta_ee:
@@ -45,7 +48,10 @@ subprojects:
           summary: Runtime support
     integration_constraints:
       java:
-        version: 17, 21 or 23
+        version:
+          - 17
+          - 21
+          - 23
       jakarta_ee_data:
         version: 1.0
       jakarta_ee:

--- a/_data/projects/orm/releases/7.0/series.yml
+++ b/_data/projects/orm/releases/7.0/series.yml
@@ -37,6 +37,12 @@ integration_constraints:
     version: 3.2
   jakarta_ee:
     version: 11
+  quarkus:
+    version:
+      from: '3.24'
+      to: '3.25'
+  wildfly:
+    version: '37'
 subprojects:
   repositories:
     summary: Jakarta Data 1.0, compatibility with Hibernate ORM 7, reactive repositories

--- a/_data/projects/orm/releases/7.0/series.yml
+++ b/_data/projects/orm/releases/7.0/series.yml
@@ -35,6 +35,8 @@ integration_constraints:
       - 23
   jakarta_ee_jpa:
     version: 3.2
+  jakarta_ee_data:
+    version: 1.0
   jakarta_ee:
     version: 11
   quarkus:
@@ -54,16 +56,4 @@ subprojects:
           summary: Annotation processor
         - artifact_id: hibernate-core
           summary: Runtime support
-    integration_constraints:
-      java:
-        version:
-          - 17
-          - 21
-          - 23
-      jakarta_ee_data:
-        version: 1.0
-      jakarta_ee:
-        version: 11
-      orm:
-        version: 7.0
 

--- a/_data/projects/orm/releases/7.0/series.yml
+++ b/_data/projects/orm/releases/7.0/series.yml
@@ -42,7 +42,9 @@ integration_constraints:
       from: '3.24'
       to: '3.25'
   wildfly:
-    version: '37'
+    version:
+      value: '37'
+      comment: "Preview"
 subprojects:
   repositories:
     summary: Jakarta Data 1.0, compatibility with Hibernate ORM 7, reactive repositories

--- a/_data/projects/orm/releases/7.1/series.yml
+++ b/_data/projects/orm/releases/7.1/series.yml
@@ -46,6 +46,7 @@ integration_constraints:
     version:
       from: '38'
       to: '39'
+      comment: "Preview"
 subprojects:
   repositories:
     summary: Jakarta Data 1.0, compatibility with Hibernate ORM 7.1, reactive repositories

--- a/_data/projects/orm/releases/7.1/series.yml
+++ b/_data/projects/orm/releases/7.1/series.yml
@@ -1,5 +1,4 @@
 summary: Resource Scanning, Locking Improvements
-status: limited-support
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/7.1/series.yml
+++ b/_data/projects/orm/releases/7.1/series.yml
@@ -38,6 +38,14 @@ integration_constraints:
     version: 3.2
   jakarta_ee:
     version: 11
+  quarkus:
+    version:
+      from: '3.26'
+      to: '3.30'
+  wildfly:
+    version:
+      from: '38'
+      to: '39'
 subprojects:
   repositories:
     summary: Jakarta Data 1.0, compatibility with Hibernate ORM 7.1, reactive repositories

--- a/_data/projects/orm/releases/7.1/series.yml
+++ b/_data/projects/orm/releases/7.1/series.yml
@@ -35,6 +35,8 @@ integration_constraints:
       - 25
   jakarta_ee_jpa:
     version: 3.2
+  jakarta_ee_data:
+    version: 1.0
   jakarta_ee:
     version: 11
   quarkus:
@@ -55,16 +57,4 @@ subprojects:
           summary: Annotation processor
         - artifact_id: hibernate-core
           summary: Runtime support
-    integration_constraints:
-      java:
-        version:
-          - 17
-          - 21
-          - 25
-      jakarta_ee_data:
-        version: 1.0
-      jakarta_ee:
-        version: 11
-      orm:
-        version: 7.1
 

--- a/_data/projects/orm/releases/7.1/series.yml
+++ b/_data/projects/orm/releases/7.1/series.yml
@@ -30,7 +30,10 @@ maven:
       summary: Leverages Jandex to support managed-resource scanning (entity discovery, etc) in Hibernate ORM.
 integration_constraints:
   java:
-    version: 17, 21 or 25
+    version:
+      - 17
+      - 21
+      - 25
   jakarta_ee_jpa:
     version: 3.2
   jakarta_ee:
@@ -46,7 +49,10 @@ subprojects:
           summary: Runtime support
     integration_constraints:
       java:
-        version: 17, 21 or 25
+        version:
+          - 17
+          - 21
+          - 25
       jakarta_ee_data:
         version: 1.0
       jakarta_ee:

--- a/_data/projects/orm/releases/7.2/series.yml
+++ b/_data/projects/orm/releases/7.2/series.yml
@@ -34,7 +34,10 @@ maven:
       summary: Leverages Jandex to support managed-resource scanning (entity discovery, etc) in Hibernate ORM.
 integration_constraints:
   java:
-    version: 17, 21 or 25
+    version:
+      - 17
+      - 21
+      - 25
   jakarta_ee_jpa:
     version: 3.2
   jakarta_ee:
@@ -50,7 +53,10 @@ subprojects:
           summary: Runtime support
     integration_constraints:
       java:
-        version: 17, 21 or 25
+        version:
+          - 17
+          - 21
+          - 25
       jakarta_ee_data:
         version: 1.0
       jakarta_ee:

--- a/_data/projects/orm/releases/7.2/series.yml
+++ b/_data/projects/orm/releases/7.2/series.yml
@@ -40,6 +40,8 @@ integration_constraints:
       - 25
   jakarta_ee_jpa:
     version: 3.2
+  jakarta_ee_data:
+    version: 1.0
   jakarta_ee:
     version: 11
   quarkus:
@@ -55,16 +57,3 @@ subprojects:
           summary: Annotation processor
         - artifact_id: hibernate-core
           summary: Runtime support
-    integration_constraints:
-      java:
-        version:
-          - 17
-          - 21
-          - 25
-      jakarta_ee_data:
-        version: 1.0
-      jakarta_ee:
-        version: 11
-      orm:
-        version: 7.2
-

--- a/_data/projects/orm/releases/7.2/series.yml
+++ b/_data/projects/orm/releases/7.2/series.yml
@@ -42,6 +42,10 @@ integration_constraints:
     version: 3.2
   jakarta_ee:
     version: 11
+  quarkus:
+    version: '3.31'
+  spring_boot:
+    version: '4.0'
 subprojects:
   repositories:
     summary: Compatibility with Hibernate ORM 7.2

--- a/_data/projects/orm/releases/7.3/series.yml
+++ b/_data/projects/orm/releases/7.3/series.yml
@@ -39,6 +39,8 @@ integration_constraints:
       - 25
   jakarta_ee_jpa:
     version: 3.2
+  jakarta_ee_data:
+    version: 1.0
   jakarta_ee:
     version: 11
 subprojects:
@@ -50,16 +52,4 @@ subprojects:
           summary: Annotation processor
         - artifact_id: hibernate-core
           summary: Runtime support
-    integration_constraints:
-      java:
-        version:
-          - 17
-          - 21
-          - 25
-      jakarta_ee_data:
-        version: 1.0
-      jakarta_ee:
-        version: 11
-      orm:
-        version: 7.3
 

--- a/_data/projects/orm/releases/7.3/series.yml
+++ b/_data/projects/orm/releases/7.3/series.yml
@@ -33,7 +33,10 @@ maven:
       summary: Leverages Jandex to support managed-resource scanning (entity discovery, etc) in Hibernate ORM.
 integration_constraints:
   java:
-    version: 17, 21 or 25
+    version:
+      - 17
+      - 21
+      - 25
   jakarta_ee_jpa:
     version: 3.2
   jakarta_ee:
@@ -49,7 +52,10 @@ subprojects:
           summary: Runtime support
     integration_constraints:
       java:
-        version: 17, 21 or 25
+        version:
+          - 17
+          - 21
+          - 25
       jakarta_ee_data:
         version: 1.0
       jakarta_ee:

--- a/_data/projects/orm/releases/8.0/series.yml
+++ b/_data/projects/orm/releases/8.0/series.yml
@@ -36,6 +36,8 @@ integration_constraints:
       - 25
   jakarta_ee_jpa:
     version: 4.0
+  jakarta_ee_data:
+    version: 1.0
   jakarta_ee:
     version: 12
 subprojects:
@@ -47,16 +49,4 @@ subprojects:
           summary: Annotation processor
         - artifact_id: hibernate-core
           summary: Runtime support
-    integration_constraints:
-      java:
-        version:
-          - 17
-          - 21
-          - 25
-      jakarta_ee_data:
-        version: 1.0
-      jakarta_ee:
-        version: 11
-      orm:
-        version: 7.3
 

--- a/_data/projects/orm/releases/8.0/series.yml
+++ b/_data/projects/orm/releases/8.0/series.yml
@@ -30,7 +30,10 @@ maven:
       summary: Leverages Jandex to support managed-resource scanning (entity discovery, etc) in Hibernate ORM.
 integration_constraints:
   java:
-    version: 17, 21 or 25
+    version:
+      - 17
+      - 21
+      - 25
   jakarta_ee_jpa:
     version: 4.0
   jakarta_ee:
@@ -46,7 +49,10 @@ subprojects:
           summary: Runtime support
     integration_constraints:
       java:
-        version: 17, 21 or 25
+        version:
+          - 17
+          - 21
+          - 25
       jakarta_ee_data:
         version: 1.0
       jakarta_ee:

--- a/_data/projects/reactive/releases/1.0/series.yml
+++ b/_data/projects/reactive/releases/1.0/series.yml
@@ -13,3 +13,7 @@ integration_constraints:
     version: 5.6
   vertx:
     version: 4.1
+  quarkus:
+    version:
+      from: '1.0'
+      to: '2.4'

--- a/_data/projects/reactive/releases/1.0/series.yml
+++ b/_data/projects/reactive/releases/1.0/series.yml
@@ -5,7 +5,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 11, 16 or 17
+    version:
+      - 11
+      - 16
+      - 17
   orm:
     version: 5.6
   vertx:

--- a/_data/projects/reactive/releases/1.1/series.yml
+++ b/_data/projects/reactive/releases/1.1/series.yml
@@ -14,3 +14,7 @@ integration_constraints:
     version: 5.6
   vertx:
     version: 4.2
+  quarkus:
+    version:
+      from: '2.5'
+      to: '2.16'

--- a/_data/projects/reactive/releases/1.1/series.yml
+++ b/_data/projects/reactive/releases/1.1/series.yml
@@ -6,7 +6,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 11, 16 or 17
+    version:
+      - 11
+      - 16
+      - 17
   orm:
     version: 5.6
   vertx:

--- a/_data/projects/reactive/releases/2.0/series.yml
+++ b/_data/projects/reactive/releases/2.0/series.yml
@@ -14,3 +14,7 @@ integration_constraints:
     version: 6.2
   vertx:
     version: 4.4
+  quarkus:
+    version:
+      from: '3.0'
+      to: '3.6'

--- a/_data/projects/reactive/releases/2.0/series.yml
+++ b/_data/projects/reactive/releases/2.0/series.yml
@@ -5,7 +5,11 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 11, 17, 20 or 21
+    version:
+      - 11
+      - 17
+      - 20
+      - 21
   orm:
     version: 6.2
   vertx:

--- a/_data/projects/reactive/releases/2.1/series.yml
+++ b/_data/projects/reactive/releases/2.1/series.yml
@@ -14,3 +14,7 @@ integration_constraints:
     version: 6.3
   vertx:
     version: 4.5
+  quarkus:
+    version:
+      from: '3.0'
+      to: '3.6'

--- a/_data/projects/reactive/releases/2.1/series.yml
+++ b/_data/projects/reactive/releases/2.1/series.yml
@@ -5,7 +5,11 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 11, 17, 20, or 21
+    version:
+      - 11
+      - 17
+      - 20
+      - 21
   orm:
     version: 6.3
   vertx:

--- a/_data/projects/reactive/releases/2.2/series.yml
+++ b/_data/projects/reactive/releases/2.2/series.yml
@@ -14,3 +14,7 @@ integration_constraints:
     version: 6.4
   vertx:
     version: 4.5
+  quarkus:
+    version:
+      from: '3.7'
+      to: '3.10'

--- a/_data/projects/reactive/releases/2.2/series.yml
+++ b/_data/projects/reactive/releases/2.2/series.yml
@@ -5,7 +5,11 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 11, 17, 20 or 21
+    version:
+      - 11
+      - 17
+      - 20
+      - 21
   orm:
     version: 6.4
   vertx:

--- a/_data/projects/reactive/releases/2.3/series.yml
+++ b/_data/projects/reactive/releases/2.3/series.yml
@@ -14,3 +14,7 @@ integration_constraints:
     version: 6.5
   vertx:
     version: 4.5
+  quarkus:
+    version:
+      from: '3.11'
+      to: '3.13'

--- a/_data/projects/reactive/releases/2.3/series.yml
+++ b/_data/projects/reactive/releases/2.3/series.yml
@@ -5,7 +5,11 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 11, 17, 20 or 21
+    version:
+      - 11
+      - 17
+      - 20
+      - 21
   orm:
     version: 6.5
   vertx:

--- a/_data/projects/reactive/releases/2.4/series.yml
+++ b/_data/projects/reactive/releases/2.4/series.yml
@@ -1,5 +1,4 @@
 summary: Release compatible with Hibernate ORM 6.6
-:status: limited-support
 maven:
   artifacts:
     - artifact_id: hibernate-reactive-core

--- a/_data/projects/reactive/releases/2.4/series.yml
+++ b/_data/projects/reactive/releases/2.4/series.yml
@@ -15,3 +15,7 @@ integration_constraints:
     version: 6.6
   vertx:
     version: 4.5
+  quarkus:
+    version:
+      from: '3.14'
+      to: '3.23'

--- a/_data/projects/reactive/releases/2.4/series.yml
+++ b/_data/projects/reactive/releases/2.4/series.yml
@@ -6,7 +6,11 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 11, 17, 21, or 25 
+    version:
+      - 11
+      - 17
+      - 21
+      - 25
   orm:
     version: 6.6
   vertx:

--- a/_data/projects/reactive/releases/3.0/series.yml
+++ b/_data/projects/reactive/releases/3.0/series.yml
@@ -5,7 +5,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 24
+    version:
+      - 17
+      - 21
+      - 24
   orm:
     version: 7.0
   vertx:

--- a/_data/projects/reactive/releases/3.0/series.yml
+++ b/_data/projects/reactive/releases/3.0/series.yml
@@ -13,3 +13,7 @@ integration_constraints:
     version: 7.0
   vertx:
     version: 4.5
+  quarkus:
+    version:
+      from: '3.24'
+      to: '3.25'

--- a/_data/projects/reactive/releases/3.1/series.yml
+++ b/_data/projects/reactive/releases/3.1/series.yml
@@ -6,7 +6,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 25
+    version:
+      - 17
+      - 21
+      - 25
   orm:
     version: 7.1
   vertx:

--- a/_data/projects/reactive/releases/3.1/series.yml
+++ b/_data/projects/reactive/releases/3.1/series.yml
@@ -14,3 +14,7 @@ integration_constraints:
     version: 7.1
   vertx:
     version: 4.5
+  quarkus:
+    version:
+      from: '3.26'
+      to: '3.30'

--- a/_data/projects/reactive/releases/3.1/series.yml
+++ b/_data/projects/reactive/releases/3.1/series.yml
@@ -1,5 +1,4 @@
 summary: Release compatible with Hibernate ORM 7.1 and Vert.x 4.5
-status: limited-support
 maven:
   artifacts:
     - artifact_id: hibernate-reactive-core

--- a/_data/projects/reactive/releases/3.2/series.yml
+++ b/_data/projects/reactive/releases/3.2/series.yml
@@ -14,3 +14,5 @@ integration_constraints:
     version: 7.2
   vertx:
     version: 4.5 
+  quarkus:
+    version: '3.31'

--- a/_data/projects/reactive/releases/3.2/series.yml
+++ b/_data/projects/reactive/releases/3.2/series.yml
@@ -6,7 +6,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 25
+    version:
+      - 17
+      - 21
+      - 25
   orm:
     version: 7.2
   vertx:

--- a/_data/projects/reactive/releases/3.3/series.yml
+++ b/_data/projects/reactive/releases/3.3/series.yml
@@ -6,7 +6,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 25
+    version:
+      - 17
+      - 21
+      - 25
   orm:
     version: 7.3
   vertx:

--- a/_data/projects/reactive/releases/4.0/series.yml
+++ b/_data/projects/reactive/releases/4.0/series.yml
@@ -5,7 +5,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 24
+    version:
+      - 17
+      - 21
+      - 24
   orm:
     version: 7.0
   vertx:

--- a/_data/projects/reactive/releases/4.1/series.yml
+++ b/_data/projects/reactive/releases/4.1/series.yml
@@ -5,7 +5,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 25
+    version:
+      - 17
+      - 21
+      - 25
   orm:
     version: 7.1
   vertx:

--- a/_data/projects/reactive/releases/4.2/series.yml
+++ b/_data/projects/reactive/releases/4.2/series.yml
@@ -5,7 +5,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 25
+    version:
+      - 17
+      - 21
+      - 25
   orm:
     version: 7.2
   vertx:

--- a/_data/projects/reactive/releases/4.3/series.yml
+++ b/_data/projects/reactive/releases/4.3/series.yml
@@ -5,7 +5,10 @@ maven:
       summary: Core implementation
 integration_constraints:
   java:
-    version: 17, 21, or 25
+    version:
+      - 17
+      - 21
+      - 25
   orm:
     version: 7.3
   vertx:

--- a/_data/projects/search/releases/4.4/series.yml
+++ b/_data/projects/search/releases/4.4/series.yml
@@ -30,7 +30,10 @@ maven:
       summary: Analyzer dependencies from Lucene/Solr
 integration_constraints:
   java:
-    version: 6, 7 or 8
+    version:
+      - 6
+      - 7
+      - 8
   orm:
     version: 4.2
   lucene:

--- a/_data/projects/search/releases/4.5/series.yml
+++ b/_data/projects/search/releases/4.5/series.yml
@@ -30,7 +30,10 @@ maven:
       summary: Analyzer dependencies from Lucene/Solr
 integration_constraints:
   java:
-    version: 6, 7 or 8
+    version:
+      - 6
+      - 7
+      - 8
   orm:
     version: 4.3
   lucene:

--- a/_data/projects/search/releases/5.0/series.yml
+++ b/_data/projects/search/releases/5.0/series.yml
@@ -28,7 +28,9 @@ maven:
       summary: JMS backend
 integration_constraints:
   java:
-    version: 7 or 8
+    version:
+      - 7
+      - 8
   orm:
     version: 4.3
   lucene:

--- a/_data/projects/search/releases/5.1/series.yml
+++ b/_data/projects/search/releases/5.1/series.yml
@@ -28,7 +28,9 @@ maven:
       summary: JMS backend
 integration_constraints:
   java:
-    version: 7 or 8
+    version:
+      - 7
+      - 8
   orm:
     version: 4.3
   lucene:

--- a/_data/projects/search/releases/5.10/series.yml
+++ b/_data/projects/search/releases/5.10/series.yml
@@ -55,3 +55,7 @@ integration_constraints:
       to: 5.6
   lucene:
     version: 5.5
+  wildfly:
+    version:
+      from: '14'
+      to: '26'

--- a/_data/projects/search/releases/5.10/series.yml
+++ b/_data/projects/search/releases/5.10/series.yml
@@ -59,3 +59,5 @@ integration_constraints:
     version:
       from: '14'
       to: '26'
+  rheap:
+    version: '7.4'

--- a/_data/projects/search/releases/5.10/series.yml
+++ b/_data/projects/search/releases/5.10/series.yml
@@ -41,10 +41,17 @@ maven:
       summary: WildFly feature pack - JGroups backend
 integration_constraints:
   java:
-    version: 8, 11 (with 5.10.7+) or 17 (with 5.10.11+)
+    version:
+      - 8
+      - value: 11
+        comment: "with 5.10.7+"
+      - value: 17
+        comment: "with 5.10.11+"
   orm:
     version: 5.3
   elasticsearch:
-    version: 2.0 - 5.6
+    version:
+      from: 2.0
+      to: 5.6
   lucene:
     version: 5.5

--- a/_data/projects/search/releases/5.11/series.yml
+++ b/_data/projects/search/releases/5.11/series.yml
@@ -44,10 +44,16 @@ maven:
       summary: WildFly feature pack - JGroups backend
 integration_constraints:
   java:
-    version: 8, 11 or 17 (with 5.11.9+)
+    version:
+      - 8
+      - 11
+      - value: 17
+        comment: "with 5.11.9+"
   orm:
     version: 5.4
   elasticsearch:
-    version: 2.0 - 5.6
+    version:
+      from: 2.0
+      to: 5.6
   lucene:
     version: 5.5

--- a/_data/projects/search/releases/5.2/series.yml
+++ b/_data/projects/search/releases/5.2/series.yml
@@ -28,7 +28,9 @@ maven:
       summary: JMS backend
 integration_constraints:
   java:
-    version: 7 or 8
+    version:
+      - 7
+      - 8
   orm:
     version: 4.3
   lucene:

--- a/_data/projects/search/releases/5.3/series.yml
+++ b/_data/projects/search/releases/5.3/series.yml
@@ -28,7 +28,9 @@ maven:
       summary: JMS backend
 integration_constraints:
   java:
-    version: 7 or 8
+    version:
+      - 7
+      - 8
   orm:
     version: 5.0
   lucene:

--- a/_data/projects/search/releases/5.4/series.yml
+++ b/_data/projects/search/releases/5.4/series.yml
@@ -28,7 +28,9 @@ maven:
       summary: JMS backend
 integration_constraints:
   java:
-    version: 7 or 8
+    version:
+      - 7
+      - 8
   orm:
     version: 5.0
   lucene:

--- a/_data/projects/search/releases/5.5/series.yml
+++ b/_data/projects/search/releases/5.5/series.yml
@@ -28,8 +28,14 @@ maven:
       summary: JMS backend
 integration_constraints:
   java:
-    version: 7 or 8
+    version:
+      - 7
+      - 8
   orm:
-    version: 5.0 - 5.1
+    version:
+      from: 5.0
+      to: 5.1
   lucene:
-    version: 5.2 - 5.4
+    version:
+      from: 5.2
+      to: 5.4

--- a/_data/projects/search/releases/5.5/series.yml
+++ b/_data/projects/search/releases/5.5/series.yml
@@ -39,3 +39,7 @@ integration_constraints:
     version:
       from: 5.2
       to: 5.4
+  wildfly:
+    version:
+      from: 11
+      to: 13

--- a/_data/projects/search/releases/5.6/series.yml
+++ b/_data/projects/search/releases/5.6/series.yml
@@ -30,10 +30,16 @@ maven:
       summary: JMS backend
 integration_constraints:
   java:
-    version: 7 or 8
+    version:
+      - 7
+      - 8
   orm:
-    version: 5.0 - 5.1
+    version:
+      from: 5.0
+      to: 5.1
   elasticsearch:
-    version: 2.0 - 2.4
+    version:
+      from: 2.0
+      to: 2.4
   lucene:
     version: 5.5

--- a/_data/projects/search/releases/5.7/series.yml
+++ b/_data/projects/search/releases/5.7/series.yml
@@ -32,8 +32,12 @@ integration_constraints:
   java:
     version: 8
   orm:
-    version: 5.2 (>= 5.2.3.Final)
+    version:
+      value: 5.2
+      comment: ">= 5.2.3.Final"
   elasticsearch:
-    version: 2.0 - 2.4
+    version:
+      from: 2.0
+      to: 2.4
   lucene:
     version: 5.5

--- a/_data/projects/search/releases/5.8/series.yml
+++ b/_data/projects/search/releases/5.8/series.yml
@@ -34,8 +34,12 @@ integration_constraints:
   java:
     version: 8
   orm:
-    version: 5.2 (>= 5.2.3.Final)
+    version:
+      value: 5.2
+      comment: ">= 5.2.3.Final"
   elasticsearch:
-    version: 2.0 - 5.6
+    version:
+      from: 2.0
+      to: 5.6
   lucene:
     version: 5.5

--- a/_data/projects/search/releases/5.9/series.yml
+++ b/_data/projects/search/releases/5.9/series.yml
@@ -46,8 +46,12 @@ integration_constraints:
   java:
     version: 8
   orm:
-    version: 5.2 (>= 5.2.3.Final)
+    version:
+      value: 5.2
+      comment: ">= 5.2.3.Final"
   elasticsearch:
-    version: 2.0 - 5.6
+    version:
+      from: 2.0
+      to: 5.6
   lucene:
     version: 5.5

--- a/_data/projects/search/releases/6.0/series.yml
+++ b/_data/projects/search/releases/6.0/series.yml
@@ -33,10 +33,19 @@ maven:
       summary: Helper for migrating from Hibernate Search 5 to Hibernate Search 6 (Hibernate ORM mapper + Lucene backend)
 integration_constraints:
   java:
-    version: 8, 11 or 17
+    version:
+      - 8
+      - 11
+      - 17
   orm:
-    version: 5.4 (>= 5.4.4.Final), 5.5 or 5.6
+    version:
+      - value: 5.4
+        comment: ">= 5.4.4.Final"
+      - 5.5
+      - 5.6
   elasticsearch:
-    version: 5.6 - 7.10
+    version:
+      from: 5.6
+      to: 7.10
   lucene:
     version: 8.7

--- a/_data/projects/search/releases/6.0/series.yml
+++ b/_data/projects/search/releases/6.0/series.yml
@@ -49,3 +49,7 @@ integration_constraints:
       to: 7.10
   lucene:
     version: 8.7
+  quarkus:
+    version:
+      from: '1.0'
+      to: '2.6'

--- a/_data/projects/search/releases/6.1/series.yml
+++ b/_data/projects/search/releases/6.1/series.yml
@@ -68,3 +68,11 @@ integration_constraints:
       to: 1.2
   lucene:
     version: 8.11
+  quarkus:
+    version:
+      from: '2.7'
+      to: '3.1'
+  wildfly:
+    version:
+      from: '27'
+      to: '28'

--- a/_data/projects/search/releases/6.1/series.yml
+++ b/_data/projects/search/releases/6.1/series.yml
@@ -45,15 +45,26 @@ maven:
       summary: Helper for migrating from Hibernate Search 5 to Hibernate Search 6 (Hibernate ORM mapper + Lucene backend) (Hibernate ORM 5)
 integration_constraints:
   java:
-    version: 8, 11, 17 or 18
+    version:
+      - 8
+      - 11
+      - 17
+      - 18
   orm:
-    version: >-
-      5.6 in the main artifacts
-      pass:[<br>]
-      https://docs.hibernate.org/search/6.1/reference/en-US/html_single/#other-integrations-orm6[6.0 - 6.2 through `*-orm6` artifacts]
+    version:
+      - value: 5.6
+        comment: in the main artifacts
+      - from: 6.0
+        to: 6.2
+        comment: >-
+          https://docs.hibernate.org/search/6.1/reference/en-US/html_single/#other-integrations-orm6[through `*-orm6` artifacts]
   elasticsearch:
-    version: 5.6 - 7.16
+    version:
+      from: 5.6
+      to: 7.16
   opensearch:
-    version: 1.0 - 1.2
+    version:
+      from: 1.0
+      to: 1.2
   lucene:
     version: 8.11

--- a/_data/projects/search/releases/6.2/series.yml
+++ b/_data/projects/search/releases/6.2/series.yml
@@ -66,3 +66,11 @@ integration_constraints:
       to: 2.11
   lucene:
     version: 8.11
+  quarkus:
+    version:
+      from: '3.2'
+      to: '3.6'
+  wildfly:
+    version:
+      from: '29'
+      to: '30'

--- a/_data/projects/search/releases/6.2/series.yml
+++ b/_data/projects/search/releases/6.2/series.yml
@@ -43,15 +43,26 @@ maven:
       summary: Helper for migrating from Hibernate Search 5 to Hibernate Search 6 (Hibernate ORM mapper + Lucene backend) (Hibernate ORM 5)
 integration_constraints:
   java:
-    version: 8, 11, 17 or 21
+    version:
+      - 8
+      - 11
+      - 17
+      - 21
   orm:
-    version: >-
-      5.6 in the main artifacts
-      pass:[<br>]
-      https://docs.hibernate.org/search/6.2/reference/en-US/html_single/#other-integrations-orm6[6.2 - 6.3 through `*-orm6` artifacts]
+    version:
+      - value: 5.6
+        comment: in the main artifacts
+      - from: 6.2
+        to: 6.3
+        comment: >-
+          https://docs.hibernate.org/search/6.2/reference/en-US/html_single/#other-integrations-orm6[through `*-orm6` artifacts]
   elasticsearch:
-    version: 5.6 - 8.10
+    version:
+      from: 5.6
+      to: 8.10
   opensearch:
-    version: 1.0 - 2.11
+    version:
+      from: 1.0
+      to: 2.11
   lucene:
     version: 8.11

--- a/_data/projects/search/releases/6.2/series.yml
+++ b/_data/projects/search/releases/6.2/series.yml
@@ -74,3 +74,5 @@ integration_constraints:
     version:
       from: '29'
       to: '30'
+  rheap:
+    version: '8.0'

--- a/_data/projects/search/releases/6.2/series.yml
+++ b/_data/projects/search/releases/6.2/series.yml
@@ -4,7 +4,6 @@ summary: >-
   highlighting,
   `excludePaths` for `@IndexedEmbedded`,
   Elasticsearch schema export
-status: limited-support
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-search/6.2/lgpl.txt

--- a/_data/projects/search/releases/7.0/series.yml
+++ b/_data/projects/search/releases/7.0/series.yml
@@ -34,12 +34,19 @@ maven:
       summary: Helper for migrating from Hibernate Search 5 to Hibernate Search 6/7 (Hibernate ORM mapper + Lucene backend)
 integration_constraints:
   java:
-    version: 11, 17 or 21
+    version:
+      - 11
+      - 17
+      - 21
   orm:
     version: 6.4
   elasticsearch:
-    version: 7.10 - 8.12
+    version:
+      from: 7.10
+      to: 8.12
   opensearch:
-    version: 1.3 - 2.11
+    version:
+      from: 1.3
+      to: 2.11
   lucene:
     version: 9.8

--- a/_data/projects/search/releases/7.0/series.yml
+++ b/_data/projects/search/releases/7.0/series.yml
@@ -50,3 +50,9 @@ integration_constraints:
       to: 2.11
   lucene:
     version: 9.8
+  quarkus:
+    version:
+      from: '3.7'
+      to: '3.8'
+  wildfly:
+    version: '31'

--- a/_data/projects/search/releases/7.1/series.yml
+++ b/_data/projects/search/releases/7.1/series.yml
@@ -35,12 +35,21 @@ maven:
       summary: Helper for migrating from Hibernate Search 5 to Hibernate Search 6/7 (Hibernate ORM mapper + Lucene backend)
 integration_constraints:
   java:
-    version: 11, 17 or 21
+    version:
+      - 11
+      - 17
+      - 21
   orm:
-    version: 6.4/6.5
+    version:
+      - 6.4
+      - 6.5
   elasticsearch:
-    version: 7.10 - 8.13
+    version:
+      from: 7.10
+      to: 8.13
   opensearch:
-    version: 1.3 - 2.13
+    version:
+      from: 1.3
+      to: 2.13
   lucene:
     version: 9.9

--- a/_data/projects/search/releases/7.1/series.yml
+++ b/_data/projects/search/releases/7.1/series.yml
@@ -53,3 +53,11 @@ integration_constraints:
       to: 2.13
   lucene:
     version: 9.9
+  quarkus:
+    version:
+      from: '3.9'
+      to: '3.13'
+  wildfly:
+    version:
+      from: '32'
+      to: '33'

--- a/_data/projects/search/releases/7.2/series.yml
+++ b/_data/projects/search/releases/7.2/series.yml
@@ -48,3 +48,11 @@ integration_constraints:
       to: 2.16
   lucene:
     version: 9.11
+  quarkus:
+    version:
+      from: '3.14'
+      to: '3.23'
+  wildfly:
+    version:
+      from: '34'
+      to: '39'

--- a/_data/projects/search/releases/7.2/series.yml
+++ b/_data/projects/search/releases/7.2/series.yml
@@ -56,3 +56,5 @@ integration_constraints:
     version:
       from: '34'
       to: '39'
+  rheap:
+    version: '8.1'

--- a/_data/projects/search/releases/7.2/series.yml
+++ b/_data/projects/search/releases/7.2/series.yml
@@ -2,7 +2,6 @@ summary: >-
   Re-licensing as Apache License 2.0,
   query string predicates on numeric/date fields,
   analyzer API
-status: limited-support
 links:
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"

--- a/_data/projects/search/releases/7.2/series.yml
+++ b/_data/projects/search/releases/7.2/series.yml
@@ -30,12 +30,21 @@ maven:
       summary: Helper for migrating from Hibernate Search 5 to Hibernate Search 6/7 (Hibernate ORM mapper + Lucene backend)
 integration_constraints:
   java:
-    version: 11, 17, 21, 23 or 25
+    version:
+      - 11
+      - 17
+      - 21
+      - 23
+      - 25
   orm:
     version: 6.6
   elasticsearch:
-    version: 7.10 - 8.18
+    version:
+      from: 7.10
+      to: 8.18
   opensearch:
-    version: 1.3 - 2.16
+    version:
+      from: 1.3
+      to: 2.16
   lucene:
     version: 9.11

--- a/_data/projects/search/releases/8.0/series.yml
+++ b/_data/projects/search/releases/8.0/series.yml
@@ -38,12 +38,21 @@ maven:
       summary: Hibernate Search annotation processor capable of generating the static metamodel
 integration_constraints:
   java:
-    version: 17, 21, or 23
+    version:
+      - 17
+      - 21
+      - 23
   orm:
     version: 7.0
   elasticsearch:
-    version: 7.10 - 9.0
+    version:
+      from: 7.10
+      to: 9.0
   opensearch:
-    version: 1.3 - 3.0
+    version:
+      from: 1.3
+      to: 3.0
   lucene:
-    version: 9.12 / 10.2
+    version:
+      - 9.12
+      - 10.2

--- a/_data/projects/search/releases/8.0/series.yml
+++ b/_data/projects/search/releases/8.0/series.yml
@@ -56,3 +56,9 @@ integration_constraints:
     version:
       - 9.12
       - 10.2
+  quarkus:
+    version:
+      from: '3.24'
+      to: '3.25'
+  wildfly:
+    version: '37'

--- a/_data/projects/search/releases/8.0/series.yml
+++ b/_data/projects/search/releases/8.0/series.yml
@@ -61,4 +61,6 @@ integration_constraints:
       from: '3.24'
       to: '3.25'
   wildfly:
-    version: '37'
+    version:
+      value: '37'
+      comment: "Preview"

--- a/_data/projects/search/releases/8.1/series.yml
+++ b/_data/projects/search/releases/8.1/series.yml
@@ -58,3 +58,11 @@ integration_constraints:
     version:
       - 9.12
       - 10.2
+  quarkus:
+    version:
+      from: '3.26'
+      to: '3.30'
+  wildfly:
+    version:
+      from: '38'
+      to: '39'

--- a/_data/projects/search/releases/8.1/series.yml
+++ b/_data/projects/search/releases/8.1/series.yml
@@ -40,12 +40,21 @@ maven:
       summary: Hibernate Search annotation processor capable of generating the static metamodel
 integration_constraints:
   java:
-    version: 17, 21, or 25
+    version:
+      - 17
+      - 21
+      - 25
   orm:
     version: 7.1
   elasticsearch:
-    version: 7.10 - 9.1
+    version:
+      from: 7.10
+      to: 9.1
   opensearch:
-    version: 1.3 - 3.1
+    version:
+      from: 1.3
+      to: 3.1
   lucene:
-    version: 9.12 / 10.2
+    version:
+      - 9.12
+      - 10.2

--- a/_data/projects/search/releases/8.1/series.yml
+++ b/_data/projects/search/releases/8.1/series.yml
@@ -4,7 +4,6 @@ summary: >-
   upgrade to Hibernate ORM 7.1
   compatibility with new versions of Elasticsearch/OpenSearch,
   other bugfixes, improvements and upgrades
-status: limited-support
 links:
   whats_new:
     html: "/search/releases/{series.version}/#whats-new"

--- a/_data/projects/search/releases/8.1/series.yml
+++ b/_data/projects/search/releases/8.1/series.yml
@@ -66,3 +66,4 @@ integration_constraints:
     version:
       from: '38'
       to: '39'
+      comment: "Preview"

--- a/_data/projects/search/releases/8.2/series.yml
+++ b/_data/projects/search/releases/8.2/series.yml
@@ -41,12 +41,21 @@ maven:
       summary: Hibernate Search annotation processor capable of generating the static metamodel
 integration_constraints:
   java:
-    version: 17, 21, or 25
+    version:
+      - 17
+      - 21
+      - 25
   orm:
     version: 7.2
   elasticsearch:
-    version: 7.10 - 9.2
+    version:
+      from: 7.10
+      to: 9.2
   opensearch:
-    version: 1.3 - 3.4
+    version:
+      from: 1.3
+      to: 3.4
   lucene:
-    version: 9.12 / 10.3
+    version:
+      - 9.12
+      - 10.3

--- a/_data/projects/search/releases/8.2/series.yml
+++ b/_data/projects/search/releases/8.2/series.yml
@@ -59,3 +59,5 @@ integration_constraints:
     version:
       - 9.12
       - 10.3
+  quarkus:
+    version: '3.31'

--- a/_data/projects/search/releases/8.3/series.yml
+++ b/_data/projects/search/releases/8.3/series.yml
@@ -40,12 +40,21 @@ maven:
       summary: Hibernate Search annotation processor capable of generating the static metamodel
 integration_constraints:
   java:
-    version: 17, 21, or 25
+    version:
+      - 17
+      - 21
+      - 25
   orm:
     version: 7.3
   elasticsearch:
-    version: 7.10 - 9.3
+    version:
+      from: 7.10
+      to: 9.3
   opensearch:
-    version: 1.3 - 3.4
+    version:
+      from: 1.3
+      to: 3.4
   lucene:
-    version: 9.12 / 10.3
+    version:
+      - 9.12
+      - 10.3

--- a/_data/projects/validator/releases/5.0/series.yml
+++ b/_data/projects/validator/releases/5.0/series.yml
@@ -23,6 +23,8 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 6 or 7
+    version:
+      - 6
+      - 7
   java_ee_bv:
     version: 1.1

--- a/_data/projects/validator/releases/5.1/series.yml
+++ b/_data/projects/validator/releases/5.1/series.yml
@@ -23,6 +23,8 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 6 or 7
+    version:
+      - 6
+      - 7
   java_ee_bv:
     version: 1.1

--- a/_data/projects/validator/releases/5.2/series.yml
+++ b/_data/projects/validator/releases/5.2/series.yml
@@ -25,7 +25,10 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 6, 7 or 8
+    version:
+      - 6
+      - 7
+      - 8
   java_ee_bv:
     version: 1.1
 

--- a/_data/projects/validator/releases/5.3/series.yml
+++ b/_data/projects/validator/releases/5.3/series.yml
@@ -31,3 +31,7 @@ integration_constraints:
       - 8
   java_ee_bv:
     version: 1.1
+  spring_boot:
+    version: '1.5'
+  wildfly:
+    version: '11'

--- a/_data/projects/validator/releases/5.3/series.yml
+++ b/_data/projects/validator/releases/5.3/series.yml
@@ -25,6 +25,9 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 6, 7 or 8
+    version:
+      - 6
+      - 7
+      - 8
   java_ee_bv:
     version: 1.1

--- a/_data/projects/validator/releases/5.4/series.yml
+++ b/_data/projects/validator/releases/5.4/series.yml
@@ -25,6 +25,9 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 6, 7 or 8
+    version:
+      - 6
+      - 7
+      - 8
   java_ee_bv:
     version: 1.1

--- a/_data/projects/validator/releases/6.0/series.yml
+++ b/_data/projects/validator/releases/6.0/series.yml
@@ -19,7 +19,10 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 8, 11 or 17
+    version:
+      - 8
+      - 11
+      - 17
   java_ee_bv:
     version: 2.0
   java_ee:

--- a/_data/projects/validator/releases/6.0/series.yml
+++ b/_data/projects/validator/releases/6.0/series.yml
@@ -27,3 +27,11 @@ integration_constraints:
     version: 2.0
   java_ee:
     version: 8
+  spring_boot:
+    version:
+      from: '2.0'
+      to: '2.2'
+  wildfly:
+    version:
+      from: '12'
+      to: '16'

--- a/_data/projects/validator/releases/6.0/series.yml
+++ b/_data/projects/validator/releases/6.0/series.yml
@@ -35,3 +35,5 @@ integration_constraints:
     version:
       from: '12'
       to: '16'
+  rheap:
+    version: '7.4'

--- a/_data/projects/validator/releases/6.1/series.yml
+++ b/_data/projects/validator/releases/6.1/series.yml
@@ -29,3 +29,11 @@ integration_constraints:
     version: 2.0
   jakarta_ee:
     version: 8
+  quarkus:
+    version:
+      from: '1.0'
+      to: '1.11'
+  spring_boot:
+    version:
+      from: '2.3'
+      to: '2.4'

--- a/_data/projects/validator/releases/6.1/series.yml
+++ b/_data/projects/validator/releases/6.1/series.yml
@@ -21,7 +21,10 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 8, 11 or 17
+    version:
+      - 8
+      - 11
+      - 17
   jakarta_ee_bv:
     version: 2.0
   jakarta_ee:

--- a/_data/projects/validator/releases/6.2/series.yml
+++ b/_data/projects/validator/releases/6.2/series.yml
@@ -24,3 +24,11 @@ integration_constraints:
     version: 2.0
   jakarta_ee:
     version: 8
+  quarkus:
+    version:
+      from: '1.12'
+      to: '2.16'
+  spring_boot:
+    version:
+      from: '2.4'
+      to: '2.7'

--- a/_data/projects/validator/releases/6.2/series.yml
+++ b/_data/projects/validator/releases/6.2/series.yml
@@ -16,7 +16,10 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 8, 11 or 17
+    version:
+      - 8
+      - 11
+      - 17
   jakarta_ee_bv:
     version: 2.0
   jakarta_ee:

--- a/_data/projects/validator/releases/7.0/series.yml
+++ b/_data/projects/validator/releases/7.0/series.yml
@@ -17,7 +17,10 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 8, 11 or 17
+    version:
+      - 8
+      - 11
+      - 17
   jakarta_ee_bv:
     version: 3.0
   jakarta_ee:

--- a/_data/projects/validator/releases/8.0/series.yml
+++ b/_data/projects/validator/releases/8.0/series.yml
@@ -25,3 +25,15 @@ integration_constraints:
     version: 3.0
   jakarta_ee:
     version: 10
+  quarkus:
+    version:
+      from: '3.0'
+      to: '3.23'
+  spring_boot:
+    version:
+      from: '3.0'
+      to: '3.5'
+  wildfly:
+    version:
+      from: '27'
+      to: '39'

--- a/_data/projects/validator/releases/8.0/series.yml
+++ b/_data/projects/validator/releases/8.0/series.yml
@@ -37,3 +37,7 @@ integration_constraints:
     version:
       from: '27'
       to: '39'
+  rheap:
+    version:
+      from: '8.0'
+      to: '8.1'

--- a/_data/projects/validator/releases/8.0/series.yml
+++ b/_data/projects/validator/releases/8.0/series.yml
@@ -15,7 +15,12 @@ maven:
 status: limited-support
 integration_constraints:
   java:
-    version: 11, 17, 21, 22 or 23
+    version:
+      - 11
+      - 17
+      - 21
+      - 22
+      - 23
   jakarta_ee_bv:
     version: 3.0
   jakarta_ee:

--- a/_data/projects/validator/releases/8.0/series.yml
+++ b/_data/projects/validator/releases/8.0/series.yml
@@ -12,7 +12,6 @@ maven:
       summary: CDI integration
     - artifact_id: hibernate-validator-annotation-processor
       summary: Annotation processor
-status: limited-support
 integration_constraints:
   java:
     version:

--- a/_data/projects/validator/releases/9.0/series.yml
+++ b/_data/projects/validator/releases/9.0/series.yml
@@ -34,3 +34,11 @@ integration_constraints:
     version: 3.1
   jakarta_ee:
     version: 11
+  quarkus:
+    version: '3.29'
+  spring_boot:
+    version: '4.0'
+  wildfly:
+    version:
+      from: '37'
+      to: '38'

--- a/_data/projects/validator/releases/9.0/series.yml
+++ b/_data/projects/validator/releases/9.0/series.yml
@@ -42,3 +42,4 @@ integration_constraints:
     version:
       from: '37'
       to: '38'
+      comment: "Preview"

--- a/_data/projects/validator/releases/9.0/series.yml
+++ b/_data/projects/validator/releases/9.0/series.yml
@@ -25,7 +25,11 @@ maven:
       summary: Set of test utilities that can help testing custom constraints.
 integration_constraints:
   java:
-    version: 17, 21, 23 or 24
+    version:
+      - 17
+      - 21
+      - 23
+      - 24
   jakarta_ee_bv:
     version: 3.1
   jakarta_ee:

--- a/_data/projects/validator/releases/9.1/series.yml
+++ b/_data/projects/validator/releases/9.1/series.yml
@@ -31,4 +31,6 @@ integration_constraints:
       from: '3.30'
       to: '3.31'
   wildfly:
-    version: '39'
+    version:
+      value: '39'
+      comment: "Preview"

--- a/_data/projects/validator/releases/9.1/series.yml
+++ b/_data/projects/validator/releases/9.1/series.yml
@@ -26,3 +26,9 @@ integration_constraints:
     version: 3.1
   jakarta_ee:
     version: 11
+  quarkus:
+    version:
+      from: '3.30'
+      to: '3.31'
+  wildfly:
+    version: '39'

--- a/_data/projects/validator/releases/9.1/series.yml
+++ b/_data/projects/validator/releases/9.1/series.yml
@@ -18,7 +18,10 @@ maven:
       summary: Set of test utilities that can help testing custom constraints.
 integration_constraints:
   java:
-    version: 17, 21 or 25
+    version:
+      - 17
+      - 21
+      - 25
   jakarta_ee_bv:
     version: 3.1
   jakarta_ee:

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -44,9 +44,9 @@ Awestruct::Extensions::Pipeline.new do
   helper Awestruct::Extensions::Links
 
   # register extensions and transformers
+  extension Awestruct::Extensions::DataFileParser.new
   extension Awestruct::Extensions::ReleaseFileParser.new
   extension Awestruct::Extensions::LinkResolver.new
-  extension Awestruct::Extensions::DataFileParser.new
   extension Awestruct::Extensions::MetadataPublisher.new
   transformer Awestruct::Extensions::JsMinifier.new
   transformer Awestruct::Extensions::CssMinifier.new

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -48,6 +48,7 @@ module Awestruct
         if subproject_of
           project_id = subproject_of['project_id']
           subproject_id = project[:id]
+          project[:superproject_id] = project_id
           since_series = Version.new(subproject_of['since_series'])
         else
           project_id = project[:id]
@@ -127,6 +128,14 @@ module Awestruct
         end
 
         series[:releases] = Array.new
+
+        if subproject_id
+          # Automatically add the constraint "this subproject is compatible with the same version of the superproject"
+          superproject_constraint = Hash.new
+          superproject_constraint[:version] = series[:version]
+          series[:integration_constraints][project[:superproject_id]] = superproject_constraint
+        end
+
         return series
       end
 

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -175,6 +175,17 @@ module Awestruct
         return release
       end
 
+      def hasActiveIntegration(series)
+        series[:integration_constraints]&.each do |integration_key,integration_constraint|
+          integration = @site.integrations[integration_key]
+          next unless integration[:downstream] && integration[:hibernate_involvement]
+          integration[:active_series]&.each do |active_version_string|
+            return true if Version.new(active_version_string).matches?(integration_constraint[:version])
+          end
+        end
+        false
+      end
+
       def sortReleaseHashes(project)
         releases = project[:releases]
         unless releases == nil
@@ -235,6 +246,11 @@ module Awestruct
                 if !series.stable
                   series[:status] = 'development'
                   project[:next_dev_series] = series
+                elsif hasActiveIntegration(series)
+                  # Series with an active integration are considered in "limited support":
+                  # some team members will continue updating them for the specific needs
+                  # of that integration.
+                  series[:status] = 'limited-support'
                 else
                   # By default, stable series that are not the latest are considered end-of-life'd.
                   # This can be overridden in yaml.
@@ -263,21 +279,48 @@ module Awestruct
     class Version
       include Comparable
 
-      attr_reader :major, :feature_group, :feature, :bugfix
+      attr_reader :major, :minor, :micro, :suffix
 
       def initialize(version="")
-        v = version.to_s.split(".")
+        version_str = version.is_a?(Hash) ? (version[:value] || version['value']) : version
+        v = version_str.to_s.split(".")
         @major = v[0].to_i
-        @feature_group = v[1].to_i
-        @feature = v[2].to_i
-        @bugfix = v[3] == nil ? nil : VersionBugfix.new(v[3])
+        @minor = v[1].to_i
+        @micro = v[2].to_i
+        @suffix = v[3] == nil ? nil : VersionSuffix.new(v[3])
       end
 
       def <=>(other)
         return @major <=> other.major if ((@major <=> other.major) != 0)
-        return @feature_group <=> other.feature_group if ((@feature_group <=> other.feature_group) != 0)
-        return @feature <=> other.feature if ((@feature <=> other.feature) != 0)
-        return @bugfix <=> other.bugfix
+        return @minor <=> other.minor if ((@minor <=> other.minor) != 0)
+        return @micro <=> other.micro if ((@micro <=> other.micro) != 0)
+        return @suffix <=> other.suffix
+      end
+
+      def matches?(constraint)
+        if constraint.is_a?(Array)
+          constraint.each do |c|
+            if self.matches?(c)
+              return true
+            end
+          end
+        elsif constraint.is_a?(Hash) && constraint.key?(:from)
+          from_version = Version.new(constraint[:from])
+          to_version = constraint[:to] ? Version.new(constraint[:to]) : nil
+          return self >= from_version && (to_version.nil? || self <= to_version)
+        else
+          constraint_version = Version.new(constraint)
+          # Constraint "7" matches "7.1", "7.2", etc.
+          # Constraint "7.0" matches "7.0.1", "7.0.2", etc.
+          return false if @major != constraint_version.major
+          return true if constraint_version.minor == 0 && constraint_version.micro == 0
+
+          return false if @minor != constraint_version.minor
+          return true if constraint_version.micro == 0
+
+          return @micro == constraint_version.micro
+        end
+        false
       end
 
       def self.sort
@@ -285,11 +328,11 @@ module Awestruct
       end
 
       def to_s
-        @major.to_s + "." + @feature_group.to_s + "." + @feature.to_s + "." + @bugfix.to_s
+        @major.to_s + "." + @minor.to_s + "." + @micro.to_s + "." + @suffix.to_s
       end
     end
 
-    class VersionBugfix
+    class VersionSuffix
       include Comparable
 
       attr_reader :prefix, :number

--- a/_ext/releases.rb
+++ b/_ext/releases.rb
@@ -33,7 +33,7 @@ module Awestruct
       end
 
       def integration_constraint(constraint)
-        version = constraint.version
+        version = constraint[:version]
         if version.nil?
           return nil
         end

--- a/_ext/releases.rb
+++ b/_ext/releases.rb
@@ -31,6 +31,38 @@ module Awestruct
         project = site.projects[p.project]
         return project.release_series[version]
       end
+
+      def integration_constraint(constraint)
+        version = constraint.version
+        if version.nil?
+          return nil
+        end
+        if version.is_a?(Array)
+          rendered = version.map { |v| integration_constraint_version(v) }
+          if rendered.length <= 1
+            rendered.join
+          elsif rendered.length == 2
+            rendered.join(" or ")
+          else
+            rendered[0..-2].join(", ") + " or " + rendered[-1]
+          end
+        else
+          integration_constraint_version(version)
+        end
+      end
+
+      def integration_constraint_version(version)
+        if version.is_a?(Hash)
+          if version.key?(:from)
+            "#{integration_constraint_version(version.from)} &rarr; #{integration_constraint_version(version.to)}" +
+              (version.key?(:comment) ? " (#{version.comment})" : "")
+          else
+            version.value.to_s + (version.key?(:comment) ? " (#{version.comment})" : "")
+          end
+        else
+          version.to_s
+        end
+      end
     end
   end
 end

--- a/_ext/releases.rb
+++ b/_ext/releases.rb
@@ -51,13 +51,13 @@ module Awestruct
         end
       end
 
-      def integration_constraint_version(version)
+      def integration_constraint_version(version, includeComment = true)
         if version.is_a?(Hash)
           if version.key?(:from)
-            "#{integration_constraint_version(version.from)} &rarr; #{integration_constraint_version(version.to)}" +
-              (version.key?(:comment) ? " (#{version.comment})" : "")
+            "#{integration_constraint_version(version.from, includeComment)} &rarr; #{integration_constraint_version(version.to, includeComment)}" +
+              (includeComment && version.key?(:comment) ? " (#{version.comment})" : "")
           else
-            version.value.to_s + (version.key?(:comment) ? " (#{version.comment})" : "")
+            version.value.to_s + (includeComment && version.key?(:comment) ? " (#{version.comment})" : "")
           end
         else
           version.to_s

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -105,7 +105,7 @@ project_hero_partial: project/hero-series.html.haml
         %td
           :asciidoc
             :doctype: inline
-            #{constraint.version}
+            #{integration_constraint(constraint)}
   %p
     Not compatible with your requirements? Have a look at the
     %a{:href => "../"}

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -96,16 +96,19 @@ project_hero_partial: project/hero-series.html.haml
 - unless series.integration_constraints.nil? || series.integration_constraints.empty?
   %h2{:id => "compatibility"} Compatibility
   %table.ui.collapsing.definition.table.striped.celled.unstackable.center.aligned
-    - series.integration_constraints.each_pair do |integration_id,constraint|
-      - integration = site.integrations[integration_id]
-      %tr
-        %td.left.aligned
-          %a{:href => "#{integration&.url}"}
-            = integration&.name
-        %td
-          :asciidoc
-            :doctype: inline
-            #{integration_constraint(constraint)}
+    - # Integration constraints must be in the same order as in integrations.yml
+    - site.integrations.each do |integration_id, integration|
+      - constraint = series.integration_constraints[integration_id]
+      - if constraint
+        - integration = site.integrations[integration_id]
+        %tr
+          %td.left.aligned
+            %a{:href => "#{integration&.url}"}
+              = integration&.name
+          %td
+            :asciidoc
+              :doctype: inline
+              #{integration_constraint(constraint)}
   %p
     Not compatible with your requirements? Have a look at the
     %a{:href => "../"}

--- a/_layouts/project/project-releases.html.haml
+++ b/_layouts/project/project-releases.html.haml
@@ -119,7 +119,7 @@ project_buttons_partial: project/releases-buttons.html.haml
                   %td
                     :asciidoc
                       :doctype: inline
-                      #{constraint.version}
+                      #{integration_constraint(constraint)}
   %p
     See also the
     %a{:href => "/community/compatibility-policy"}

--- a/_spec/version_spec.rb
+++ b/_spec/version_spec.rb
@@ -24,19 +24,19 @@ describe Awestruct::Extensions::Version do
 
 	describe "#feature_group" do
     	it "feature_group number is correct" do
-        	expect(@versions[8].feature_group).to eql 1
+        	expect(@versions[8].minor).to eql 1
     	end
 	end
 
 	describe "#feature" do
     	it "feature number is correct" do
-        	expect(@versions[8].feature).to eql 2
+        	expect(@versions[8].micro).to eql 2
     	end
 	end
 
 	describe "#bugfix" do
     	it "bugfix number is correct" do
-        	expect(@versions[8].bugfix).to eql "Beta4"
+        	expect(@versions[8].suffix).to eql "Beta4"
     	end
 	end
 

--- a/metadata/integrations.csv.haml
+++ b/metadata/integrations.csv.haml
@@ -1,0 +1,26 @@
+-# Generate CSV of integration constraints for downstream frameworks
+- downstream_integrations = site.integrations.select { |id, integration| integration.downstream == true }
+- downstream_ids = downstream_integrations.keys.sort
+- projects = ['orm', 'search', 'validator', 'reactive']
+Project,Series,#{downstream_ids.map { |id| downstream_integrations[id].name }.join(',')}
+- projects.each do |project_id|
+  - project = site.projects[project_id]
+  - next if project.nil? || project.release_series.nil?
+  - project.release_series.to_a.reverse.each do |series_version, series|
+    - next if series.integration_constraints.nil?
+    - row = [project_id, "\"#{series_version}\""]
+    - downstream_ids.each do |integration_id|
+      - constraint = series.integration_constraints[integration_id]
+      - if constraint.nil?
+        - row << ''
+      - else
+        - version = constraint.version
+        - if version.nil?
+          - row << ''
+        - elsif version.is_a?(Array)
+          - row << "\"#{version.map { |v| integration_constraint_version(v, false) }.join('/')}\""
+        - elsif version.is_a?(Hash) && version.key?(:from)
+          - row << "\"#{integration_constraint_version(version.from, false)}-#{integration_constraint_version(version.to, false)}\""
+        - else
+          - row << "\"#{integration_constraint_version(version, false)}\""
+    = row.join(',')

--- a/survival-guide.adoc
+++ b/survival-guide.adoc
@@ -254,9 +254,9 @@ This includes some project-related data.
 See the file for more information about available attributes.
 
 [[data_directory]]
-=== `_data`
+=== `_data/projects`
 
-The `_data` directory contains YAML-formatted data for the releases of each project.
+The `_data/projects` directory contains YAML-formatted data for the releases of each project.
 
 The structure of this directory is as follows:
 
@@ -278,7 +278,7 @@ The `series.yml` file may contain the following attributes:
 *** `artifact_id`: the Maven artifact ID.
 *** `group_id`: the Maven group ID. Optional: defaults to the group ID defined on the series, or on the project.
 *** `summary`: a short text (6/7 words at most) summarizing the purpose of this artifact. You can use Asciidoc syntax here.
-** `integration_constraints`: a map, with keys being the integration IDs defined in `site.yml`,
+** `integration_constraints`: a map, with keys being the integration IDs defined in <<data_integrations,`_data/integrations.yml`>>,
    and values being objects with a `version` attribute describing the version constraints summarily
    (about a dozen characters, and you can use Asciidoc syntax here).
 
@@ -294,6 +294,13 @@ and may contain the following attributes:
 ** `summary`: a one-sentence summary of the content of the release.  You can use Asciidoc syntax here.
 ** `displayed`: `true` to display the release on hibernate.org, `false` to hide it.
    Defaults to `true`. Note that a release will only be displayed if its series is displayed.
+
+[[data_integrations]]
+=== `_data/integrations.yml`
+
+`_data/integrations.yml` contains a list of integrations to be referenced in the `integration_constraints` section of `series.yml` files.
+
+See <<data_directory>>.
 
 [[staging]]
 == Preview changes on staging.hibernate.org

--- a/survival-guide.adoc
+++ b/survival-guide.adoc
@@ -209,21 +209,23 @@ By default, a series will have the following status (the small label appearing h
 
 * `development` if all it's releases are unstable (still in development);
 * `latest-stable` if it's the latest series with a stable release;
+* `limited-support` if it's a stable series (not the latest) that is used in downstream integrations (Quarkus, WildFly, etc.);
 * `end-of-life` otherwise.
 
-To override this status,
+Most of the time, the status <<limited-support-automatic,is correctly inferred to the correct value>>, and you do not need to set it manually.
+If you encounter some edge cases, you can override it:
 edit the `_data/<project ID>/releases/<series version>/series.yml` file
-to set the `status` attribute to `true` (just add the attribute if it is missing).
-
-This attribute can in particular be set to:
+to set the `status` attribute to one of the following:
 
 `limited-support`::
 to convey the intent of not automatically fixing all bugs,
-while downstream frameworks (Quarkus, WildFly) or commercial offerings (RHBQ, RHEAP)
-may still provide stronger guarantees.
+while still somewhat maintaining the series,
+even if no downstream integrations include it.
 `stable`::
 to convey the intent of still actively maintaining the series,
 even if it is not the latest stable.
+
+=== Series visibility ("older series")
 
 By default, an end-of-life'd series is considered "older" and not displayed with the other series:
 it is not displayed in the drop-down "Releases" submenu,
@@ -233,6 +235,24 @@ and it is not displayed in the project's compatibility matrix.
 You can override this behavior, to hide a non-EOL'd series or display an EOL'd series,
 by editing the `_data/<project ID>/releases/<series version>/series.yml` file
 and setting the `displayed` attribute to `true` or `false` (just add the attribute if it is missing).
+
+[[limited-support-automatic]]
+=== Automatic computation of `limited-support`
+
+Series that do not have a status, and are not the latest stable,
+can be considered `limited-support` if they are used in an active downstream integration (Quarkus, WildFly, etc.).
+
+To make that happen for a given series:
+
+1. Document the compatible downstream integrations in `integration_constraints` in `series.yml` (see existing files).
+2. Document the active series in `integrations.yml`.
+
+The build should automatically detect which series of a Hibernate project are compatible
+with an active series of a downstream integration.
+
+Note only integrations marked as "downstream: true" and "hibernate_involvement: true" are considered,
+because if nobody from the Hibernate team is involved in the downstream project,
+then nobody has both the expertise and interest to maintain for the relevant series.
 
 === Hide a specific release
 


### PR DESCRIPTION
Because:

1. We are currently keeping track of this information internally, and even people from our team are having a hard time finding the information.
2. The `limited-support` is hard to compute manually, both because of the above and because the rules were not always clear.

Now it's automated, we just need to keep `integration_constraints` updated (we already do) and also `integrations.yml` (that's new, but relatively simple).

Also, this exposes the downstream framework compatibility constraint as a CSV at http://hibernate.org/metadata/integrations.csv