### PR TITLE
Fix bug where end-of-life warning was not showing

### DIFF
--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -44,7 +44,7 @@ project_hero_partial: project/hero-series.html.haml
       %a.item{:href => "#releases"}
         Releases in this series
 
-- if series.status == 'endoflife'
+- if series.status == 'end-of-life'
   :asciidoc
     :projectName: #{project_description.name}
     :version: #{series.version}


### PR DESCRIPTION
<img width="854" height="529" alt="image" src="https://github.com/user-attachments/assets/7e9abe3d-2b23-425d-81c3-e4857dd667ee" />
