### PR TITLE
Dedicated page to list integrations and their compatibility with projects' series

### DIFF
--- a/.awestruct_ignore
+++ b/.awestruct_ignore
@@ -12,5 +12,8 @@ CONTRIBUTING.md
 LICENSE.md
 TODO.txt
 
+## Claude etc.
+.*
+
 ## CI
 Jenkinsfile

--- a/_data/projects/ogm/releases/4.2/series.yml
+++ b/_data/projects/ogm/releases/4.2/series.yml
@@ -18,10 +18,10 @@ links:
     html: https://developer.jboss.org/docs/DOC-52281
 integration_constraints:
   java:
-    version: 7
+    version: '7'
   java_ee_jpa:
-    version: 2.0
+    version: '2.0'
   orm:
-    version: 4.3
+    version: '4.3'
   search:
-    version: 5.2
+    version: '5.2'

--- a/_data/projects/ogm/releases/5.0/series.yml
+++ b/_data/projects/ogm/releases/5.0/series.yml
@@ -21,11 +21,11 @@ links:
 integration_constraints:
   java:
     version:
-      - 7
-      - 8
+      - '7'
+      - '8'
   java_ee_jpa:
-    version: 2.1
+    version: '2.1'
   orm:
-    version: 5.0
+    version: '5.0'
   search:
-    version: 5.5
+    version: '5.5'

--- a/_data/projects/ogm/releases/5.1/series.yml
+++ b/_data/projects/ogm/releases/5.1/series.yml
@@ -23,11 +23,11 @@ links:
 integration_constraints:
   java:
     version:
-      - 7
-      - 8
+      - '7'
+      - '8'
   java_ee_jpa:
-    version: 2.1
+    version: '2.1'
   orm:
-    version: 5.1
+    version: '5.1'
   search:
-    version: 5.6
+    version: '5.6'

--- a/_data/projects/ogm/releases/5.2/series.yml
+++ b/_data/projects/ogm/releases/5.2/series.yml
@@ -14,10 +14,10 @@ links:
     html: https://developer.jboss.org/docs/DOC-52281
 integration_constraints:
   java:
-    version: 8
+    version: '8'
   java_ee_jpa:
-    version: 2.1
+    version: '2.1'
   orm:
-    version: 5.1
+    version: '5.1'
   search:
-    version: 5.6
+    version: '5.6'

--- a/_data/projects/ogm/releases/5.3/series.yml
+++ b/_data/projects/ogm/releases/5.3/series.yml
@@ -14,10 +14,10 @@ links:
     html: https://developer.jboss.org/docs/DOC-52281
 integration_constraints:
   java:
-    version: 8
+    version: '8'
   java_ee_jpa:
-    version: 2.1
+    version: '2.1'
   orm:
-    version: 5.2
+    version: '5.2'
   search:
-    version: 5.9
+    version: '5.9'

--- a/_data/projects/ogm/releases/5.4/series.yml
+++ b/_data/projects/ogm/releases/5.4/series.yml
@@ -16,10 +16,10 @@ links:
     html: https://developer.jboss.org/docs/DOC-52281
 integration_constraints:
   java:
-    version: 8
+    version: '8'
   java_ee_jpa:
-    version: 2.2
+    version: '2.2'
   orm:
-    version: 5.3
+    version: '5.3'
   search:
-    version: 5.10
+    version: '5.10'

--- a/_data/projects/orm/releases/4.2/series.yml
+++ b/_data/projects/orm/releases/4.2/series.yml
@@ -40,7 +40,7 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
+      - '6'
+      - '7'
   java_ee_jpa:
-    version: 2.0
+    version: '2.0'

--- a/_data/projects/orm/releases/4.3/series.yml
+++ b/_data/projects/orm/releases/4.3/series.yml
@@ -41,7 +41,7 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
+      - '6'
+      - '7'
   java_ee_jpa:
-    version: 2.1
+    version: '2.1'

--- a/_data/projects/orm/releases/5.0/series.yml
+++ b/_data/projects/orm/releases/5.0/series.yml
@@ -44,10 +44,10 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
-      - 8
+      - '6'
+      - '7'
+      - '8'
   java_ee_jpa:
-    version: 2.1
+    version: '2.1'
   spring_boot:
     version: '1.5'

--- a/_data/projects/orm/releases/5.1/series.yml
+++ b/_data/projects/orm/releases/5.1/series.yml
@@ -48,7 +48,7 @@ integration_constraints:
         comment: "up to 5.1.16"
       - value: 8
   java_ee_jpa:
-    version: 2.1
+    version: '2.1'
   wildfly:
     version:
       - '12'

--- a/_data/projects/orm/releases/5.2/series.yml
+++ b/_data/projects/orm/releases/5.2/series.yml
@@ -37,9 +37,9 @@ maven:
       summary: Ehcache second-level caching
 integration_constraints:
   java:
-    version: 8
+    version: '8'
   java_ee_jpa:
-    version: 2.1
+    version: '2.1'
   spring_boot:
     version: '2.0'
 

--- a/_data/projects/orm/releases/5.3/series.yml
+++ b/_data/projects/orm/releases/5.3/series.yml
@@ -38,14 +38,14 @@ links:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
+      - '8'
+      - '11'
       - value: 17
         comment: "with 5.3.22+"
   java_ee_jpa:
-    version: 2.2
+    version: '2.2'
   java_ee:
-    version: 8
+    version: '8'
   spring_boot:
     version: '2.1'
   wildfly:

--- a/_data/projects/orm/releases/5.4/series.yml
+++ b/_data/projects/orm/releases/5.4/series.yml
@@ -40,14 +40,14 @@ links:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
+      - '8'
+      - '11'
       - value: 17
         comment: "with 5.4.32+"
   java_ee_jpa:
-    version: 2.2
+    version: '2.2'
   java_ee:
-    version: 8
+    version: '8'
   quarkus:
     version:
       from: '1.0'

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -54,5 +54,5 @@ integration_constraints:
   quarkus:
     version:
       from: '2.0'
-      to: '2.3.0'
+      to: '2.2'
 

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -40,17 +40,17 @@ links:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
-      - 17
+      - '8'
+      - '11'
+      - '17'
   java_ee_jpa:
-    version: 2.2
+    version: '2.2'
   jakarta_ee_jpa:
-    version: 3.0
+    version: '3.0'
   java_ee:
-    version: 8
+    version: '8'
   jakarta_ee:
-    version: 9
+    version: '9'
   quarkus:
     version:
       from: '2.0'

--- a/_data/projects/orm/releases/5.6/series.yml
+++ b/_data/projects/orm/releases/5.6/series.yml
@@ -38,16 +38,16 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
-      - 17
-      - 18
+      - '8'
+      - '11'
+      - '17'
+      - '18'
   java_ee_jpa:
-    version: 2.2
+    version: '2.2'
   jakarta_ee_jpa:
-    version: 3.0
+    version: '3.0'
   jakarta_ee:
-    version: 9
+    version: '9'
   quarkus:
     version:
       from: '2.3'

--- a/_data/projects/orm/releases/5.6/series.yml
+++ b/_data/projects/orm/releases/5.6/series.yml
@@ -50,8 +50,9 @@ integration_constraints:
     version: 9
   quarkus:
     version:
-      value: '2.3'
-      comment: excluding 2.3.0
+      from: '2.3'
+      to: '2.16'
+      comment: 'excluding 2.3.0'
   spring_boot:
     version:
       from: '2.6'

--- a/_data/projects/orm/releases/6.0/series.yml
+++ b/_data/projects/orm/releases/6.0/series.yml
@@ -26,15 +26,15 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 18
+      - '11'
+      - '17'
+      - '18'
   jakarta_ee_jpa:
     version:
-      - 3.1
-      - 3.0
+      - '3.1'
+      - '3.0'
   jakarta_ee:
     version:
-      - 10
-      - 9
+      - '10'
+      - '9'
 

--- a/_data/projects/orm/releases/6.1/series.yml
+++ b/_data/projects/orm/releases/6.1/series.yml
@@ -24,17 +24,17 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 18
+      - '11'
+      - '17'
+      - '18'
   jakarta_ee_jpa:
     version:
-      - 3.1
-      - 3.0
+      - '3.1'
+      - '3.0'
   jakarta_ee:
     version:
-      - 10
-      - 9
+      - '10'
+      - '9'
   spring_boot:
     version: '3.0'
   wildfly:

--- a/_data/projects/orm/releases/6.2/series.yml
+++ b/_data/projects/orm/releases/6.2/series.yml
@@ -25,14 +25,14 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 20
-      - 21
+      - '11'
+      - '17'
+      - '20'
+      - '21'
   jakarta_ee_jpa:
-    version: 3.1
+    version: '3.1'
   jakarta_ee:
-    version: 10
+    version: '10'
   quarkus:
     version:
       from: '3.0'

--- a/_data/projects/orm/releases/6.3/series.yml
+++ b/_data/projects/orm/releases/6.3/series.yml
@@ -24,10 +24,10 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 21
+      - '11'
+      - '17'
+      - '21'
   jakarta_ee_jpa:
-    version: 3.1
+    version: '3.1'
   jakarta_ee:
-    version: 10
+    version: '10'

--- a/_data/projects/orm/releases/6.4/series.yml
+++ b/_data/projects/orm/releases/6.4/series.yml
@@ -24,13 +24,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 21
+      - '11'
+      - '17'
+      - '21'
   jakarta_ee_jpa:
-    version: 3.1
+    version: '3.1'
   jakarta_ee:
-    version: 10
+    version: '10'
   quarkus:
     version:
       from: '3.7'

--- a/_data/projects/orm/releases/6.5/series.yml
+++ b/_data/projects/orm/releases/6.5/series.yml
@@ -24,13 +24,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 21
+      - '11'
+      - '17'
+      - '21'
   jakarta_ee_jpa:
-    version: 3.1
+    version: '3.1'
   jakarta_ee:
-    version: 10
+    version: '10'
   quarkus:
     version:
       from: '3.11'

--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -24,19 +24,19 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 21
+      - '11'
+      - '17'
+      - '21'
       - value: 25
         comment: "6.6.40+"
   jakarta_ee_jpa:
-    version: 3.1
+    version: '3.1'
   jakarta_ee_data:
-    version: 1.0
+    version: '1.0'
   jakarta_ee:
-    version: 10
+    version: '10'
   dialect_mongodb:
-    version: 1.0
+    version: '1.0'
   quarkus:
     version:
       from: '3.14'

--- a/_data/projects/orm/releases/7.0/series.yml
+++ b/_data/projects/orm/releases/7.0/series.yml
@@ -30,15 +30,15 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 23
+      - '17'
+      - '21'
+      - '23'
   jakarta_ee_jpa:
-    version: 3.2
+    version: '3.2'
   jakarta_ee_data:
-    version: 1.0
+    version: '1.0'
   jakarta_ee:
-    version: 11
+    version: '11'
   quarkus:
     version:
       from: '3.24'

--- a/_data/projects/orm/releases/7.1/series.yml
+++ b/_data/projects/orm/releases/7.1/series.yml
@@ -30,15 +30,15 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
+      - '17'
+      - '21'
+      - '25'
   jakarta_ee_jpa:
-    version: 3.2
+    version: '3.2'
   jakarta_ee_data:
-    version: 1.0
+    version: '1.0'
   jakarta_ee:
-    version: 11
+    version: '11'
   quarkus:
     version:
       from: '3.26'

--- a/_data/projects/orm/releases/7.2/series.yml
+++ b/_data/projects/orm/releases/7.2/series.yml
@@ -35,15 +35,15 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
+      - '17'
+      - '21'
+      - '25'
   jakarta_ee_jpa:
-    version: 3.2
+    version: '3.2'
   jakarta_ee_data:
-    version: 1.0
+    version: '1.0'
   jakarta_ee:
-    version: 11
+    version: '11'
   quarkus:
     version:
       from: '3.31'

--- a/_data/projects/orm/releases/7.3/series.yml
+++ b/_data/projects/orm/releases/7.3/series.yml
@@ -34,16 +34,16 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
-      - 26
+      - '17'
+      - '21'
+      - '25'
+      - '26'
   jakarta_ee_jpa:
-    version: 3.2
+    version: '3.2'
   jakarta_ee_data:
-    version: 1.0
+    version: '1.0'
   jakarta_ee:
-    version: 11
+    version: '11'
 subprojects:
   repositories:
     summary: Compatibility with Hibernate ORM 7.3

--- a/_data/projects/orm/releases/8.0/series.yml
+++ b/_data/projects/orm/releases/8.0/series.yml
@@ -31,15 +31,15 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
+      - '17'
+      - '21'
+      - '25'
   jakarta_ee_jpa:
-    version: 4.0
+    version: '4.0'
   jakarta_ee_data:
-    version: 1.0
+    version: '1.0'
   jakarta_ee:
-    version: 12
+    version: '12'
 subprojects:
   repositories:
     summary: Compatibility with Hibernate ORM 8.0

--- a/_data/projects/reactive/releases/1.0/series.yml
+++ b/_data/projects/reactive/releases/1.0/series.yml
@@ -6,13 +6,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 16
-      - 17
+      - '11'
+      - '16'
+      - '17'
   orm:
-    version: 5.6
+    version: '5.6'
   vertx:
-    version: 4.1
+    version: '4.1'
   quarkus:
     version:
       from: '1.0'

--- a/_data/projects/reactive/releases/1.1/series.yml
+++ b/_data/projects/reactive/releases/1.1/series.yml
@@ -7,13 +7,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 16
-      - 17
+      - '11'
+      - '16'
+      - '17'
   orm:
-    version: 5.6
+    version: '5.6'
   vertx:
-    version: 4.2
+    version: '4.2'
   quarkus:
     version:
       from: '2.5'

--- a/_data/projects/reactive/releases/2.0/series.yml
+++ b/_data/projects/reactive/releases/2.0/series.yml
@@ -6,14 +6,14 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 20
-      - 21
+      - '11'
+      - '17'
+      - '20'
+      - '21'
   orm:
-    version: 6.2
+    version: '6.2'
   vertx:
-    version: 4.4
+    version: '4.4'
   quarkus:
     version:
       from: '3.0'

--- a/_data/projects/reactive/releases/2.1/series.yml
+++ b/_data/projects/reactive/releases/2.1/series.yml
@@ -6,11 +6,11 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 20
-      - 21
+      - '11'
+      - '17'
+      - '20'
+      - '21'
   orm:
-    version: 6.3
+    version: '6.3'
   vertx:
-    version: 4.5
+    version: '4.5'

--- a/_data/projects/reactive/releases/2.1/series.yml
+++ b/_data/projects/reactive/releases/2.1/series.yml
@@ -14,7 +14,3 @@ integration_constraints:
     version: 6.3
   vertx:
     version: 4.5
-  quarkus:
-    version:
-      from: '3.0'
-      to: '3.6'

--- a/_data/projects/reactive/releases/2.2/series.yml
+++ b/_data/projects/reactive/releases/2.2/series.yml
@@ -6,14 +6,14 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 20
-      - 21
+      - '11'
+      - '17'
+      - '20'
+      - '21'
   orm:
-    version: 6.4
+    version: '6.4'
   vertx:
-    version: 4.5
+    version: '4.5'
   quarkus:
     version:
       from: '3.7'

--- a/_data/projects/reactive/releases/2.3/series.yml
+++ b/_data/projects/reactive/releases/2.3/series.yml
@@ -6,14 +6,14 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 20
-      - 21
+      - '11'
+      - '17'
+      - '20'
+      - '21'
   orm:
-    version: 6.5
+    version: '6.5'
   vertx:
-    version: 4.5
+    version: '4.5'
   quarkus:
     version:
       from: '3.11'

--- a/_data/projects/reactive/releases/2.4/series.yml
+++ b/_data/projects/reactive/releases/2.4/series.yml
@@ -6,14 +6,14 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 21
-      - 25
+      - '11'
+      - '17'
+      - '21'
+      - '25'
   orm:
-    version: 6.6
+    version: '6.6'
   vertx:
-    version: 4.5
+    version: '4.5'
   quarkus:
     version:
       from: '3.14'

--- a/_data/projects/reactive/releases/3.0/series.yml
+++ b/_data/projects/reactive/releases/3.0/series.yml
@@ -6,13 +6,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 24
+      - '17'
+      - '21'
+      - '24'
   orm:
-    version: 7.0
+    version: '7.0'
   vertx:
-    version: 4.5
+    version: '4.5'
   quarkus:
     version:
       from: '3.24'

--- a/_data/projects/reactive/releases/3.1/series.yml
+++ b/_data/projects/reactive/releases/3.1/series.yml
@@ -6,13 +6,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
+      - '17'
+      - '21'
+      - '25'
   orm:
-    version: 7.1
+    version: '7.1'
   vertx:
-    version: 4.5
+    version: '4.5'
   quarkus:
     version:
       from: '3.26'

--- a/_data/projects/reactive/releases/3.2/series.yml
+++ b/_data/projects/reactive/releases/3.2/series.yml
@@ -6,13 +6,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
+      - '17'
+      - '21'
+      - '25'
   orm:
-    version: 7.2
+    version: '7.2'
   vertx:
-    version: 4.5 
+    version: '4.5 '
   quarkus:
     version:
       from: '3.31'

--- a/_data/projects/reactive/releases/3.3/series.yml
+++ b/_data/projects/reactive/releases/3.3/series.yml
@@ -7,11 +7,11 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
-      - 26
+      - '17'
+      - '21'
+      - '25'
+      - '26'
   orm:
-    version: 7.3
+    version: '7.3'
   vertx:
-    version: 4.5 
+    version: '4.5 '

--- a/_data/projects/reactive/releases/4.0/series.yml
+++ b/_data/projects/reactive/releases/4.0/series.yml
@@ -6,10 +6,10 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 24
+      - '17'
+      - '21'
+      - '24'
   orm:
-    version: 7.0
+    version: '7.0'
   vertx:
-    version: 5.0
+    version: '5.0'

--- a/_data/projects/reactive/releases/4.1/series.yml
+++ b/_data/projects/reactive/releases/4.1/series.yml
@@ -6,10 +6,10 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
+      - '17'
+      - '21'
+      - '25'
   orm:
-    version: 7.1
+    version: '7.1'
   vertx:
-    version: 5.0
+    version: '5.0'

--- a/_data/projects/reactive/releases/4.2/series.yml
+++ b/_data/projects/reactive/releases/4.2/series.yml
@@ -6,10 +6,10 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
+      - '17'
+      - '21'
+      - '25'
   orm:
-    version: 7.2
+    version: '7.2'
   vertx:
-    version: 5.0
+    version: '5.0'

--- a/_data/projects/reactive/releases/4.3/series.yml
+++ b/_data/projects/reactive/releases/4.3/series.yml
@@ -6,11 +6,11 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
-      - 26
+      - '17'
+      - '21'
+      - '25'
+      - '26'
   orm:
-    version: 7.3
+    version: '7.3'
   vertx:
-    version: 5.0
+    version: '5.0'

--- a/_data/projects/search/releases/4.4/series.yml
+++ b/_data/projects/search/releases/4.4/series.yml
@@ -31,10 +31,10 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
-      - 8
+      - '6'
+      - '7'
+      - '8'
   orm:
-    version: 4.2
+    version: '4.2'
   lucene:
-    version: 3.6
+    version: '3.6'

--- a/_data/projects/search/releases/4.5/series.yml
+++ b/_data/projects/search/releases/4.5/series.yml
@@ -31,10 +31,10 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
-      - 8
+      - '6'
+      - '7'
+      - '8'
   orm:
-    version: 4.3
+    version: '4.3'
   lucene:
-    version: 3.6
+    version: '3.6'

--- a/_data/projects/search/releases/5.0/series.yml
+++ b/_data/projects/search/releases/5.0/series.yml
@@ -29,9 +29,9 @@ maven:
 integration_constraints:
   java:
     version:
-      - 7
-      - 8
+      - '7'
+      - '8'
   orm:
-    version: 4.3
+    version: '4.3'
   lucene:
-    version: 4.10
+    version: '4.10'

--- a/_data/projects/search/releases/5.1/series.yml
+++ b/_data/projects/search/releases/5.1/series.yml
@@ -29,9 +29,9 @@ maven:
 integration_constraints:
   java:
     version:
-      - 7
-      - 8
+      - '7'
+      - '8'
   orm:
-    version: 4.3
+    version: '4.3'
   lucene:
-    version: 4.10
+    version: '4.10'

--- a/_data/projects/search/releases/5.10/series.yml
+++ b/_data/projects/search/releases/5.10/series.yml
@@ -42,19 +42,19 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
+      - '8'
       - value: 11
         comment: "with 5.10.7+"
       - value: 17
         comment: "with 5.10.11+"
   orm:
-    version: 5.3
+    version: '5.3'
   elasticsearch:
     version:
-      from: 2.0
-      to: 5.6
+      from: '2.0'
+      to: '5.6'
   lucene:
-    version: 5.5
+    version: '5.5'
   wildfly:
     version:
       from: '14'

--- a/_data/projects/search/releases/5.11/series.yml
+++ b/_data/projects/search/releases/5.11/series.yml
@@ -45,15 +45,15 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
+      - '8'
+      - '11'
       - value: 17
         comment: "with 5.11.9+"
   orm:
-    version: 5.4
+    version: '5.4'
   elasticsearch:
     version:
-      from: 2.0
-      to: 5.6
+      from: '2.0'
+      to: '5.6'
   lucene:
-    version: 5.5
+    version: '5.5'

--- a/_data/projects/search/releases/5.2/series.yml
+++ b/_data/projects/search/releases/5.2/series.yml
@@ -29,9 +29,9 @@ maven:
 integration_constraints:
   java:
     version:
-      - 7
-      - 8
+      - '7'
+      - '8'
   orm:
-    version: 4.3
+    version: '4.3'
   lucene:
-    version: 4.10
+    version: '4.10'

--- a/_data/projects/search/releases/5.3/series.yml
+++ b/_data/projects/search/releases/5.3/series.yml
@@ -29,9 +29,9 @@ maven:
 integration_constraints:
   java:
     version:
-      - 7
-      - 8
+      - '7'
+      - '8'
   orm:
-    version: 5.0
+    version: '5.0'
   lucene:
-    version: 4.10
+    version: '4.10'

--- a/_data/projects/search/releases/5.4/series.yml
+++ b/_data/projects/search/releases/5.4/series.yml
@@ -29,9 +29,9 @@ maven:
 integration_constraints:
   java:
     version:
-      - 7
-      - 8
+      - '7'
+      - '8'
   orm:
-    version: 5.0
+    version: '5.0'
   lucene:
-    version: 4.10
+    version: '4.10'

--- a/_data/projects/search/releases/5.5/series.yml
+++ b/_data/projects/search/releases/5.5/series.yml
@@ -29,17 +29,17 @@ maven:
 integration_constraints:
   java:
     version:
-      - 7
-      - 8
+      - '7'
+      - '8'
   orm:
     version:
-      from: 5.0
-      to: 5.1
+      from: '5.0'
+      to: '5.1'
   lucene:
     version:
-      from: 5.2
-      to: 5.4
+      from: '5.2'
+      to: '5.4'
   wildfly:
     version:
-      from: 11
-      to: 13
+      from: '11'
+      to: '13'

--- a/_data/projects/search/releases/5.6/series.yml
+++ b/_data/projects/search/releases/5.6/series.yml
@@ -31,15 +31,15 @@ maven:
 integration_constraints:
   java:
     version:
-      - 7
-      - 8
+      - '7'
+      - '8'
   orm:
     version:
-      from: 5.0
-      to: 5.1
+      from: '5.0'
+      to: '5.1'
   elasticsearch:
     version:
-      from: 2.0
-      to: 2.4
+      from: '2.0'
+      to: '2.4'
   lucene:
-    version: 5.5
+    version: '5.5'

--- a/_data/projects/search/releases/5.7/series.yml
+++ b/_data/projects/search/releases/5.7/series.yml
@@ -30,14 +30,14 @@ maven:
       summary: JMS backend
 integration_constraints:
   java:
-    version: 8
+    version: '8'
   orm:
     version:
-      value: 5.2
+      value: '5.2'
       comment: ">= 5.2.3.Final"
   elasticsearch:
     version:
-      from: 2.0
-      to: 2.4
+      from: '2.0'
+      to: '2.4'
   lucene:
-    version: 5.5
+    version: '5.5'

--- a/_data/projects/search/releases/5.8/series.yml
+++ b/_data/projects/search/releases/5.8/series.yml
@@ -32,14 +32,14 @@ maven:
       summary: JMS backend
 integration_constraints:
   java:
-    version: 8
+    version: '8'
   orm:
     version:
-      value: 5.2
+      value: '5.2'
       comment: ">= 5.2.3.Final"
   elasticsearch:
     version:
-      from: 2.0
-      to: 5.6
+      from: '2.0'
+      to: '5.6'
   lucene:
-    version: 5.5
+    version: '5.5'

--- a/_data/projects/search/releases/5.9/series.yml
+++ b/_data/projects/search/releases/5.9/series.yml
@@ -44,14 +44,14 @@ maven:
       summary: WildFly feature pack - Amazon IAM authentication for Elasticsearch
 integration_constraints:
   java:
-    version: 8
+    version: '8'
   orm:
     version:
-      value: 5.2
+      value: '5.2'
       comment: ">= 5.2.3.Final"
   elasticsearch:
     version:
-      from: 2.0
-      to: 5.6
+      from: '2.0'
+      to: '5.6'
   lucene:
-    version: 5.5
+    version: '5.5'

--- a/_data/projects/search/releases/6.0/series.yml
+++ b/_data/projects/search/releases/6.0/series.yml
@@ -34,21 +34,21 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
-      - 17
+      - '8'
+      - '11'
+      - '17'
   orm:
     version:
       - value: 5.4
         comment: ">= 5.4.4.Final"
-      - 5.5
-      - 5.6
+      - '5.5'
+      - '5.6'
   elasticsearch:
     version:
-      from: 5.6
-      to: 7.10
+      from: '5.6'
+      to: '7.10'
   lucene:
-    version: 8.7
+    version: '8.7'
   quarkus:
     version:
       from: '1.0'

--- a/_data/projects/search/releases/6.1/series.yml
+++ b/_data/projects/search/releases/6.1/series.yml
@@ -46,28 +46,28 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
-      - 17
-      - 18
+      - '8'
+      - '11'
+      - '17'
+      - '18'
   orm:
     version:
       - value: 5.6
         comment: in the main artifacts
       - from: 6.0
-        to: 6.2
+        to: '6.2'
         comment: >-
           https://docs.hibernate.org/search/6.1/reference/en-US/html_single/#other-integrations-orm6[through `*-orm6` artifacts]
   elasticsearch:
     version:
-      from: 5.6
-      to: 7.16
+      from: '5.6'
+      to: '7.16'
   opensearch:
     version:
-      from: 1.0
-      to: 1.2
+      from: '1.0'
+      to: '1.2'
   lucene:
-    version: 8.11
+    version: '8.11'
   quarkus:
     version:
       from: '2.7'

--- a/_data/projects/search/releases/6.2/series.yml
+++ b/_data/projects/search/releases/6.2/series.yml
@@ -43,28 +43,28 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
-      - 17
-      - 21
+      - '8'
+      - '11'
+      - '17'
+      - '21'
   orm:
     version:
       - value: 5.6
         comment: in the main artifacts
       - from: 6.2
-        to: 6.3
+        to: '6.3'
         comment: >-
           https://docs.hibernate.org/search/6.2/reference/en-US/html_single/#other-integrations-orm6[through `*-orm6` artifacts]
   elasticsearch:
     version:
-      from: 5.6
-      to: 8.10
+      from: '5.6'
+      to: '8.10'
   opensearch:
     version:
-      from: 1.0
-      to: 2.11
+      from: '1.0'
+      to: '2.11'
   lucene:
-    version: 8.11
+    version: '8.11'
   quarkus:
     version:
       from: '3.2'

--- a/_data/projects/search/releases/7.0/series.yml
+++ b/_data/projects/search/releases/7.0/series.yml
@@ -35,21 +35,21 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 21
+      - '11'
+      - '17'
+      - '21'
   orm:
-    version: 6.4
+    version: '6.4'
   elasticsearch:
     version:
-      from: 7.10
-      to: 8.12
+      from: '7.10'
+      to: '8.12'
   opensearch:
     version:
-      from: 1.3
-      to: 2.11
+      from: '1.3'
+      to: '2.11'
   lucene:
-    version: 9.8
+    version: '9.8'
   quarkus:
     version:
       from: '3.7'

--- a/_data/projects/search/releases/7.1/series.yml
+++ b/_data/projects/search/releases/7.1/series.yml
@@ -36,23 +36,23 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 21
+      - '11'
+      - '17'
+      - '21'
   orm:
     version:
-      - 6.4
-      - 6.5
+      - '6.4'
+      - '6.5'
   elasticsearch:
     version:
-      from: 7.10
-      to: 8.13
+      from: '7.10'
+      to: '8.13'
   opensearch:
     version:
-      from: 1.3
-      to: 2.13
+      from: '1.3'
+      to: '2.13'
   lucene:
-    version: 9.9
+    version: '9.9'
   quarkus:
     version:
       from: '3.9'

--- a/_data/projects/search/releases/7.2/series.yml
+++ b/_data/projects/search/releases/7.2/series.yml
@@ -30,23 +30,23 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 21
-      - 23
-      - 25
+      - '11'
+      - '17'
+      - '21'
+      - '23'
+      - '25'
   orm:
-    version: 6.6
+    version: '6.6'
   elasticsearch:
     version:
-      from: 7.10
-      to: 8.18
+      from: '7.10'
+      to: '8.18'
   opensearch:
     version:
-      from: 1.3
-      to: 2.16
+      from: '1.3'
+      to: '2.16'
   lucene:
-    version: 9.11
+    version: '9.11'
   quarkus:
     version:
       from: '3.14'

--- a/_data/projects/search/releases/8.0/series.yml
+++ b/_data/projects/search/releases/8.0/series.yml
@@ -39,22 +39,22 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 23
+      - '17'
+      - '21'
+      - '23'
   orm:
-    version: 7.0
+    version: '7.0'
   elasticsearch:
     version:
-      from: 7.10
-      to: 9.0
+      from: '7.10'
+      to: '9.0'
   opensearch:
     version:
-      from: 1.3
-      to: 3.0
+      from: '1.3'
+      to: '3.0'
   lucene:
     version:
-      - 9.12
+      - '9.12'
       - value: 10.2
         comment: >-
           https://docs.hibernate.org/search/8.0/reference/en-US/html_single/#other-integrations-lucene-next[through `*-backend-lucene-next`]

--- a/_data/projects/search/releases/8.1/series.yml
+++ b/_data/projects/search/releases/8.1/series.yml
@@ -40,22 +40,22 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
+      - '17'
+      - '21'
+      - '25'
   orm:
-    version: 7.1
+    version: '7.1'
   elasticsearch:
     version:
-      from: 7.10
-      to: 9.1
+      from: '7.10'
+      to: '9.1'
   opensearch:
     version:
-      from: 1.3
-      to: 3.1
+      from: '1.3'
+      to: '3.1'
   lucene:
     version:
-      - 9.12
+      - '9.12'
       - value: 10.2
         comment: >-
           https://docs.hibernate.org/search/8.1/reference/en-US/html_single/#other-integrations-lucene-next[through `*-backend-lucene-next`]

--- a/_data/projects/search/releases/8.2/series.yml
+++ b/_data/projects/search/releases/8.2/series.yml
@@ -42,22 +42,22 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
+      - '17'
+      - '21'
+      - '25'
   orm:
-    version: 7.2
+    version: '7.2'
   elasticsearch:
     version:
-      from: 7.10
-      to: 9.2
+      from: '7.10'
+      to: '9.2'
   opensearch:
     version:
-      from: 1.3
-      to: 3.4
+      from: '1.3'
+      to: '3.4'
   lucene:
     version:
-      - 9.12
+      - '9.12'
       - value: 10.3
         comment: >-
           https://docs.hibernate.org/search/8.2/reference/en-US/html_single/#other-integrations-lucene-next[through `*-backend-lucene-next`]

--- a/_data/projects/search/releases/8.3/series.yml
+++ b/_data/projects/search/releases/8.3/series.yml
@@ -41,23 +41,23 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
-      - 26
+      - '17'
+      - '21'
+      - '25'
+      - '26'
   orm:
-    version: 7.3
+    version: '7.3'
   elasticsearch:
     version:
-      from: 7.10
-      to: 9.3
+      from: '7.10'
+      to: '9.3'
   opensearch:
     version:
-      from: 1.3
-      to: 3.5
+      from: '1.3'
+      to: '3.5'
   lucene:
     version:
-      - 9.12
+      - '9.12'
       - value: 10.4
         comment: >-
           https://docs.hibernate.org/search/8.3/reference/en-US/html_single/#other-integrations-lucene-next[through `*-backend-lucene-next`]

--- a/_data/projects/validator/releases/4.3/series.yml
+++ b/_data/projects/validator/releases/4.3/series.yml
@@ -21,6 +21,6 @@ maven:
       summary: Annotation processor
 integration_constraints:
   java:
-    version: 6
+    version: '6'
   java_ee_bv:
-    version: 1.0
+    version: '1.0'

--- a/_data/projects/validator/releases/5.0/series.yml
+++ b/_data/projects/validator/releases/5.0/series.yml
@@ -24,7 +24,7 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
+      - '6'
+      - '7'
   java_ee_bv:
-    version: 1.1
+    version: '1.1'

--- a/_data/projects/validator/releases/5.1/series.yml
+++ b/_data/projects/validator/releases/5.1/series.yml
@@ -24,7 +24,7 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
+      - '6'
+      - '7'
   java_ee_bv:
-    version: 1.1
+    version: '1.1'

--- a/_data/projects/validator/releases/5.2/series.yml
+++ b/_data/projects/validator/releases/5.2/series.yml
@@ -26,9 +26,9 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
-      - 8
+      - '6'
+      - '7'
+      - '8'
   java_ee_bv:
-    version: 1.1
+    version: '1.1'
 

--- a/_data/projects/validator/releases/5.3/series.yml
+++ b/_data/projects/validator/releases/5.3/series.yml
@@ -26,11 +26,11 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
-      - 8
+      - '6'
+      - '7'
+      - '8'
   java_ee_bv:
-    version: 1.1
+    version: '1.1'
   spring_boot:
     version: '1.5'
   wildfly:

--- a/_data/projects/validator/releases/5.4/series.yml
+++ b/_data/projects/validator/releases/5.4/series.yml
@@ -26,8 +26,8 @@ maven:
 integration_constraints:
   java:
     version:
-      - 6
-      - 7
-      - 8
+      - '6'
+      - '7'
+      - '8'
   java_ee_bv:
-    version: 1.1
+    version: '1.1'

--- a/_data/projects/validator/releases/6.0/series.yml
+++ b/_data/projects/validator/releases/6.0/series.yml
@@ -20,13 +20,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
-      - 17
+      - '8'
+      - '11'
+      - '17'
   java_ee_bv:
-    version: 2.0
+    version: '2.0'
   java_ee:
-    version: 8
+    version: '8'
   spring_boot:
     version:
       from: '2.0'

--- a/_data/projects/validator/releases/6.1/series.yml
+++ b/_data/projects/validator/releases/6.1/series.yml
@@ -22,13 +22,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
-      - 17
+      - '8'
+      - '11'
+      - '17'
   jakarta_ee_bv:
-    version: 2.0
+    version: '2.0'
   jakarta_ee:
-    version: 8
+    version: '8'
   quarkus:
     version:
       from: '1.0'

--- a/_data/projects/validator/releases/6.2/series.yml
+++ b/_data/projects/validator/releases/6.2/series.yml
@@ -17,13 +17,13 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
-      - 17
+      - '8'
+      - '11'
+      - '17'
   jakarta_ee_bv:
-    version: 2.0
+    version: '2.0'
   jakarta_ee:
-    version: 8
+    version: '8'
   quarkus:
     version:
       from: '1.12'

--- a/_data/projects/validator/releases/7.0/series.yml
+++ b/_data/projects/validator/releases/7.0/series.yml
@@ -18,10 +18,10 @@ maven:
 integration_constraints:
   java:
     version:
-      - 8
-      - 11
-      - 17
+      - '8'
+      - '11'
+      - '17'
   jakarta_ee_bv:
-    version: 3.0
+    version: '3.0'
   jakarta_ee:
-    version: 9
+    version: '9'

--- a/_data/projects/validator/releases/8.0/series.yml
+++ b/_data/projects/validator/releases/8.0/series.yml
@@ -15,15 +15,15 @@ maven:
 integration_constraints:
   java:
     version:
-      - 11
-      - 17
-      - 21
-      - 22
-      - 23
+      - '11'
+      - '17'
+      - '21'
+      - '22'
+      - '23'
   jakarta_ee_bv:
-    version: 3.0
+    version: '3.0'
   jakarta_ee:
-    version: 10
+    version: '10'
   quarkus:
     version:
       from: '3.0'

--- a/_data/projects/validator/releases/9.0/series.yml
+++ b/_data/projects/validator/releases/9.0/series.yml
@@ -35,7 +35,9 @@ integration_constraints:
   jakarta_ee:
     version: 11
   quarkus:
-    version: '3.29'
+    version:
+      from: '3.24'
+      to: '3.29'
   spring_boot:
     version: '4.0'
   wildfly:

--- a/_data/projects/validator/releases/9.0/series.yml
+++ b/_data/projects/validator/releases/9.0/series.yml
@@ -26,14 +26,14 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 23
-      - 24
+      - '17'
+      - '21'
+      - '23'
+      - '24'
   jakarta_ee_bv:
-    version: 3.1
+    version: '3.1'
   jakarta_ee:
-    version: 11
+    version: '11'
   quarkus:
     version:
       from: '3.24'

--- a/_data/projects/validator/releases/9.1/series.yml
+++ b/_data/projects/validator/releases/9.1/series.yml
@@ -19,14 +19,14 @@ maven:
 integration_constraints:
   java:
     version:
-      - 17
-      - 21
-      - 25
-      - 26
+      - '17'
+      - '21'
+      - '25'
+      - '26'
   jakarta_ee_bv:
-    version: 3.1
+    version: '3.1'
   jakarta_ee:
-    version: 11
+    version: '11'
   quarkus:
     version:
       from: '3.30'

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require_relative 'version'
 
 module Awestruct
   module Extensions
@@ -40,6 +41,9 @@ module Awestruct
           end
           findReleaseFiles(project)
         end
+
+        # After parsing all projects, compute integration compatibility tables
+        computeIntegrationCompatibility()
       end
 
       def findReleaseFiles(project)
@@ -306,87 +310,280 @@ module Awestruct
         project[:older_release_series] = project[:release_series].nil? ? nil
             : project[:release_series].values.select{|s| !s[:displayed].nil? ? !s.displayed : s[:status] == 'end-of-life'}
       end
-    end
 
-    # Custom version class able to understand and compare the project versions of Hibernate projects
-    class Version
-      include Comparable
+      # Compute integration compatibility tables for all downstream integrations
+      # This creates a reverse mapping: for each integration version, which project versions are compatible
+      def computeIntegrationCompatibility()
+        return if @site.integrations.nil?
 
-      attr_reader :major, :minor, :micro, :suffix
+        @site.integrations.each do |integration_id, integration|
+          # Collect all constraint versions from all projects for this integration
+          constraint_versions = []
+          @projects_hash.each do |project_id, project|
+            next if project[:release_series].nil?
 
-      def initialize(version="")
-        version_str = version.is_a?(Hash) ? (version[:value] || version['value']) : version
-        v = version_str.to_s.split(".")
-        @major = v[0].to_i
-        @minor = v[1].to_i
-        @micro = v[2].to_i
-        @suffix = v[3] == nil ? nil : VersionSuffix.new(v[3])
-      end
+            project[:release_series].each do |series_version, series|
+              next if series[:integration_constraints].nil?
+              constraint = series[:integration_constraints][integration_id]
+              next if constraint.nil? || constraint[:version].nil?
 
-      def <=>(other)
-        return @major <=> other.major if ((@major <=> other.major) != 0)
-        return @minor <=> other.minor if ((@minor <=> other.minor) != 0)
-        return @micro <=> other.micro if ((@micro <=> other.micro) != 0)
-        return @suffix <=> other.suffix
-      end
-
-      def matches?(constraint)
-        if constraint.is_a?(Array)
-          constraint.each do |c|
-            if self.matches?(c)
-              return true
+              constraint_versions << constraint[:version]
             end
           end
-        elsif constraint.is_a?(Hash) && constraint.key?(:from)
-          from_version = Version.new(constraint[:from])
-          to_version = constraint[:to] ? Version.new(constraint[:to]) : nil
-          return self >= from_version && (to_version.nil? || self <= to_version)
-        else
-          constraint_version = Version.new(constraint)
-          # Constraint "7" matches "7.1", "7.2", etc.
-          # Constraint "7.0" matches "7.0.1", "7.0.2", etc.
-          return false if @major != constraint_version.major
-          return true if constraint_version.minor == 0 && constraint_version.micro == 0
 
-          return false if @minor != constraint_version.minor
-          return true if constraint_version.micro == 0
+          # Expand all integration versions
+          integration_versions = Version.expand_from_constraints(constraint_versions)
 
-          return @micro == constraint_version.micro
+          # For each integration version, find compatible project versions
+          project_compatibility = Hash.new
+
+          integration_versions.each do |integration_version|
+            version_compatibility = Hash.new
+
+            @projects_hash.each do |project_id, project|
+              next if project[:release_series].nil?
+
+              matches = []
+              project[:release_series].each do |series_version, series|
+                next if series[:integration_constraints].nil?
+                constraint = series[:integration_constraints][integration_id]
+                next if constraint.nil? || constraint[:version].nil?
+
+                if Version.new(integration_version).matches?(constraint[:version])
+                  comment = extractCommentFromConstraint(constraint[:version], integration_version)
+                  matches << { :version => series_version, :comment => comment, :status => constraint[:status] }
+                end
+              end
+
+              # Sort matches from lowest to highest version
+              matches.sort_by! { |m| Version.new(m[:version]) }
+
+              # Pack consecutive versions with the same status into ranges
+              version_compatibility[project_id] = packProjectVersionsIntoRanges(matches)
+            end
+
+            project_compatibility[integration_version] = version_compatibility
+          end
+
+          integration[:project_compatibility] = project_compatibility
+          integration[:versions] = integration_versions
+
+          # Pack consecutive versions with identical compatibility into ranges
+          integration[:version_ranges] = packVersionsIntoRanges(integration_versions, project_compatibility, integration, @projects_hash)
+
+          # Mark if there are any older series
+          integration[:has_older_series] = integration[:version_ranges].any? { |vr| !vr[:displayed] }
         end
+      end
+
+      # Pack consecutive integration versions with identical project compatibility into ranges
+      # Returns an array of hashes with :display (string) and :compatibility (hash)
+      def packVersionsIntoRanges(integration_versions, project_compatibility, integration, projects_hash)
+        return [] if integration_versions.empty?
+
+        ranges = []
+        current_range_start = integration_versions.first
+        current_range_versions = [current_range_start]
+        current_compatibility = project_compatibility[current_range_start]
+        current_displayed = computeVersionDisplayed(current_range_start, current_compatibility, integration, projects_hash)
+
+        integration_versions[1..-1].each do |version|
+          version_compatibility = project_compatibility[version]
+          version_displayed = computeVersionDisplayed(version, version_compatibility, integration, projects_hash)
+
+          # Check if this version has identical compatibility and displayed status to the current range
+          if compatibilitiesEqual?(current_compatibility, version_compatibility) && current_displayed == version_displayed
+            current_range_versions << version
+          else
+            # Different compatibility or displayed status - close current range and start new one
+            ranges << createVersionRange(current_range_start, current_range_versions.last, current_compatibility, current_displayed)
+            current_range_start = version
+            current_range_versions = [version]
+            current_compatibility = version_compatibility
+            current_displayed = version_displayed
+          end
+        end
+
+        # Close the last range
+        ranges << createVersionRange(current_range_start, current_range_versions.last, current_compatibility, current_displayed)
+
+        ranges
+      end
+
+      # Pack consecutive project versions with the same status into ranges
+      # Returns an array of hashes with :version (string or hash with :from/:to), :comment, :status
+      def packProjectVersionsIntoRanges(matches)
+        return [] if matches.empty?
+
+        packed = []
+        current_range_start = matches.first
+        current_range_versions = [current_range_start]
+        current_status = current_range_start[:status]
+        current_comment = current_range_start[:comment]
+
+        matches[1..-1].each do |match|
+          # Check if this version can be merged with the current range
+          # Conditions: same status, same comment, and consecutive versions
+          if match[:status] == current_status &&
+             match[:comment] == current_comment &&
+             areConsecutiveVersions?(current_range_versions.last[:version], match[:version])
+            current_range_versions << match
+          else
+            # Different status/comment or not consecutive - close current range and start new one
+            packed << createProjectVersionRange(current_range_start[:version], current_range_versions.last[:version], current_comment, current_status)
+            current_range_start = match
+            current_range_versions = [match]
+            current_status = match[:status]
+            current_comment = match[:comment]
+          end
+        end
+
+        # Close the last range
+        packed << createProjectVersionRange(current_range_start[:version], current_range_versions.last[:version], current_comment, current_status)
+
+        packed
+      end
+
+      # Check if two versions are consecutive (e.g., 6.4 and 6.5, or 6.5.0 and 6.5.1)
+      def areConsecutiveVersions?(version1_str, version2_str)
+        v1 = Version.new(version1_str)
+        v2 = Version.new(version2_str)
+
+        # Same major version
+        return false if v1.major != v2.major
+
+        # Check if minor versions are consecutive
+        if v1.minor + 1 == v2.minor && v1.micro == 0 && v2.micro == 0
+          return true
+        end
+
+        # Check if micro versions are consecutive (same major and minor)
+        if v1.minor == v2.minor && v1.micro + 1 == v2.micro
+          return true
+        end
+
         false
       end
 
-      def self.sort
-        self.sort!{|a,b| a <=> b}
+      # Create a project version range object
+      def createProjectVersionRange(from_version, to_version, comment, status)
+        version = if from_version == to_version
+                    from_version
+                  else
+                    { :from => from_version, :to => to_version }
+                  end
+
+        result = { :version => version, :status => status }
+        result[:comment] = comment if comment
+        result
       end
 
-      def to_s
-        @major.to_s + "." + @minor.to_s + "." + @micro.to_s + "." + @suffix.to_s
-      end
-    end
+      # Check if two compatibility hashes are equal
+      def compatibilitiesEqual?(compat1, compat2)
+        return false if compat1.keys.sort != compat2.keys.sort
 
-    class VersionSuffix
-      include Comparable
+        compat1.each do |project_id, matches1|
+          matches2 = compat2[project_id]
+          return false if matches1.length != matches2.length
 
-      attr_reader :prefix, :number
+          # Compare each match (version and comment, but not status)
+          matches1.each_with_index do |match1, i|
+            match2 = matches2[i]
+            # Compare version (can be string or hash with :from/:to)
+            return false if !versionsEqual?(match1[:version], match2[:version])
+            return false if match1[:comment] != match2[:comment]
+          end
+        end
 
-      def initialize(bugfix="")
-        split = bugfix.scan(/^([A-Za-z\-_]+)([0-9]+)?$/)
-        @prefix = split.first[0]
-        @number = split.first[1]&.to_i
-      end
-
-      def <=>(other)
-        return @prefix <=> other.prefix if ((@prefix <=> other.prefix) != 0)
-        return @number <=> other.number
-      end
-
-      def self.sort
-        self.sort!{|a,b| a <=> b}
+        true
       end
 
-      def to_s
-        @bugfix + @number&.to_s
+      # Check if two version values are equal (handles both string and range formats)
+      def versionsEqual?(v1, v2)
+        if v1.is_a?(Hash) && v2.is_a?(Hash)
+          v1[:from] == v2[:from] && v1[:to] == v2[:to]
+        else
+          v1 == v2
+        end
+      end
+
+      # Create a version range object
+      def createVersionRange(from_version, to_version, compatibility, displayed)
+        version = if from_version == to_version
+                    from_version
+                  else
+                    # Ensure range is displayed as smaller → larger
+                    v1 = Version.new(from_version)
+                    v2 = Version.new(to_version)
+                    if v1 < v2
+                      { :from => from_version, :to => to_version }
+                    else
+                      { :from => to_version, :to => from_version }
+                    end
+                  end
+
+        { :version => version, :compatibility => compatibility, :displayed => displayed }
+      end
+
+      # Compute whether a version should be displayed based on integration settings and compatibility
+      def computeVersionDisplayed(integration_version, compatibility, integration, projects_hash)
+        has_active_or_els = integration[:active_series]&.any? || integration[:els_series]&.any?
+
+        if has_active_or_els
+          # If there are active or els series, check if this integration version is in those lists
+          return true if integration[:active_series]&.include?(integration_version)
+          return true if integration[:els_series]&.include?(integration_version)
+          false
+        else
+          # If there are no active or els series, check if compatible with at least one displayed project series
+          isCompatibleWithDisplayedSeries(compatibility, projects_hash)
+        end
+      end
+
+      # Check if a version is compatible with at least one displayed project series
+      def isCompatibleWithDisplayedSeries(compatibility, projects_hash)
+        compatibility&.each do |project_id, matches|
+          project = projects_hash[project_id]
+          next if project.nil? || project[:release_series].nil?
+
+          matches.each do |match|
+            # Handle both packed (range) and unpacked (string) versions
+            version_value = match[:version]
+            series_versions = if version_value.is_a?(Hash) && version_value.key?(:from)
+                                # For ranges, check both from and to versions
+                                [version_value[:from], version_value[:to]]
+                              else
+                                [version_value]
+                              end
+
+            series_versions.each do |series_version|
+              series = project[:release_series][series_version]
+              next if series.nil?
+
+              # A series is displayed if: displayed is nil/true, or status is not 'end-of-life'
+              is_displayed = series[:displayed].nil? ? series[:status] != 'end-of-life' : series[:displayed]
+              return true if is_displayed
+            end
+          end
+        end
+
+        false
+      end
+
+      # Extract comment from a constraint for a specific version
+      def extractCommentFromConstraint(constraint_version, target_version)
+        if constraint_version.is_a?(Hash)
+          if constraint_version.key?(:comment)
+            return constraint_version[:comment]
+          end
+        elsif constraint_version.is_a?(Array)
+          constraint_version.each do |v|
+            if v.is_a?(Hash) && v.key?(:value) && v[:value].to_s == target_version.to_s && v.key?(:comment)
+              return v[:comment]
+            end
+          end
+        end
+        nil
       end
     end
   end

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -332,7 +332,7 @@ module Awestruct
           end
 
           # Expand all integration versions
-          integration_versions = Version.expand_from_constraints(constraint_versions)
+          integration_versions = Version.expand_from_constraints(constraint_versions, integration_id, integration)
 
           # For each integration version, find compatible project versions
           project_compatibility = Hash.new

--- a/_ext/releases.rb
+++ b/_ext/releases.rb
@@ -54,7 +54,7 @@ module Awestruct
       def integration_constraint_version(version, includeComment = true)
         if version.is_a?(Hash)
           if version.key?(:from)
-            "#{integration_constraint_version(version.from, includeComment)} &rarr; #{integration_constraint_version(version.to, includeComment)}" +
+            "#{integration_constraint_version(version.from, includeComment)}&nbsp;&rarr;&nbsp;#{integration_constraint_version(version.to, includeComment)}" +
               (includeComment && version.key?(:comment) ? " (#{version.comment})" : "")
           else
             version.value.to_s + (includeComment && version.key?(:comment) ? " (#{version.comment})" : "")

--- a/_ext/version.rb
+++ b/_ext/version.rb
@@ -1,0 +1,157 @@
+module Awestruct
+  module Extensions
+    # Custom version class able to understand and compare the project versions of Hibernate projects
+    class Version
+      include Comparable
+
+      attr_reader :major, :minor, :micro, :suffix
+
+      def initialize(version="")
+        version_str = version.is_a?(Hash) ? (version[:value] || version['value']) : version
+        v = version_str.to_s.split(".")
+        @major = v[0].to_i
+        @minor = v[1].to_i
+        @micro = v[2].to_i
+        @suffix = v[3] == nil ? nil : VersionSuffix.new(v[3])
+        # Track how many components were in the original version string
+        # This helps distinguish "8" (1 component) from "8.0" (2 components)
+        @component_count = v.length
+      end
+
+      def <=>(other)
+        return @major <=> other.major if ((@major <=> other.major) != 0)
+        return @minor <=> other.minor if ((@minor <=> other.minor) != 0)
+        return @micro <=> other.micro if ((@micro <=> other.micro) != 0)
+        return @suffix <=> other.suffix
+      end
+
+      def matches?(constraint)
+        if constraint.is_a?(Array)
+          constraint.each do |c|
+            if self.matches?(c)
+              return true
+            end
+          end
+        elsif constraint.is_a?(Hash) && constraint.key?(:from)
+          from_version = Version.new(constraint[:from])
+          to_version = constraint[:to] ? Version.new(constraint[:to]) : nil
+          return self >= from_version && (to_version.nil? || self <= to_version)
+        else
+          constraint_version = Version.new(constraint)
+          # Constraint "7" (1 component) matches "7.0", "7.1", "7.2", etc.
+          # Constraint "7.0" (2 components) matches "7.0.0", "7.0.1", etc., but NOT "7.1"
+          # Constraint "7.0.0" (3+ components) matches exactly "7.0.0"
+          return false if @major != constraint_version.major
+          return true if constraint_version.instance_variable_get(:@component_count) == 1
+
+          return false if @minor != constraint_version.minor
+          return true if constraint_version.instance_variable_get(:@component_count) == 2
+
+          return @micro == constraint_version.micro
+        end
+        false
+      end
+
+      # Expand all integration versions from a list of constraint values
+      # Returns an array of version strings, sorted with latest first
+      #
+      # @param constraint_versions [Array] Array of constraint version values (can be strings, hashes, arrays, ranges)
+      # @return [Array<String>] Sorted array of version strings with latest first
+      def self.expand_from_constraints(constraint_versions)
+        versions_set = Set.new
+
+        constraint_versions.each do |constraint_version|
+          extract_versions_from_constraint(constraint_version, versions_set)
+        end
+
+        # Convert to array and sort with latest first
+        versions_set.to_a.sort_by { |v| Version.new(v) }.reverse
+      end
+
+      private
+
+      def self.extract_versions_from_constraint(version, versions_set)
+        if version.is_a?(Array)
+          # Array of versions or ranges
+          version.each do |v|
+            extract_versions_from_constraint(v, versions_set)
+          end
+        elsif version.is_a?(Hash) && version.key?(:from)
+          # Range: expand from X to Y
+          expand_range(version[:from], version[:to], versions_set)
+        elsif version.is_a?(Hash) && version.key?(:value)
+          # Single value with comment
+          versions_set.add(version[:value].to_s)
+        else
+          # Simple value
+          versions_set.add(version.to_s)
+        end
+      end
+
+      def self.expand_range(from_str, to_str, versions_set)
+        from_version = Version.new(from_str)
+        to_version = to_str ? Version.new(to_str) : nil
+
+        # Add the from version
+        versions_set.add(from_str.to_s)
+
+        # If there's a to version, add it as well
+        if to_version
+          versions_set.add(to_str.to_s)
+
+          # Only try to expand intermediate versions if they're in the same major version
+          # This is a heuristic - we can only reliably expand within the same major version
+          if from_version.major == to_version.major
+            current = from_version
+            # Safety limit to prevent infinite loops
+            max_iterations = 100
+            iterations = 0
+
+            loop do
+              iterations += 1
+              break if iterations > max_iterations
+
+              next_minor = Version.new("#{current.major}.#{current.minor + 1}.0")
+              break if next_minor > to_version
+              versions_set.add("#{next_minor.major}.#{next_minor.minor}")
+              current = next_minor
+            end
+          end
+        end
+      end
+
+      def self.sort
+        self.sort!{|a,b| a <=> b}
+      end
+
+      def to_s
+        @major.to_s + "." + @minor.to_s + "." + @micro.to_s + "." + @suffix.to_s
+      end
+    end
+
+    class VersionSuffix
+      include Comparable
+
+      attr_reader :prefix, :number
+
+      def initialize(bugfix="")
+        split = bugfix.scan(/^([A-Za-z\-_]+)([0-9]+)?$/)
+        @prefix = split.first[0]
+        @number = split.first[1]&.to_i
+      end
+
+      def <=>(other)
+        return @prefix <=> other.prefix if ((@prefix <=> other.prefix) != 0)
+        return @number <=> other.number
+      end
+
+      def self.sort
+        self.sort!{|a,b| a <=> b}
+      end
+
+      def to_s
+        @bugfix + @number&.to_s
+      end
+    end
+  end
+end

--- a/_ext/version.rb
+++ b/_ext/version.rb
@@ -56,12 +56,17 @@ module Awestruct
       # Returns an array of version strings, sorted with latest first
       #
       # @param constraint_versions [Array] Array of constraint version values (can be strings, hashes, arrays, ranges)
+      # @param integration_id [String] Integration ID (for error messages)
+      # @param integration [Hash] Integration data (may contain :latest_minors)
       # @return [Array<String>] Sorted array of version strings with latest first
-      def self.expand_from_constraints(constraint_versions)
+      def self.expand_from_constraints(constraint_versions, integration_id = nil, integration = nil)
         versions_set = Set.new
 
+        # First pass: collect all explicitly mentioned versions to determine bounds
+        max_minor_by_major = collect_version_bounds(constraint_versions)
+
         constraint_versions.each do |constraint_version|
-          extract_versions_from_constraint(constraint_version, versions_set)
+          extract_versions_from_constraint(constraint_version, versions_set, max_minor_by_major, integration_id, integration)
         end
 
         # Convert to array and sort with latest first
@@ -70,15 +75,60 @@ module Awestruct
 
       private
 
-      def self.extract_versions_from_constraint(version, versions_set)
+      # Collect the maximum minor version for each major version from all constraints
+      # This helps us know when to transition to the next major version when expanding ranges
+      # Returns a hash where keys are major versions and values are either:
+      # - An integer (the max minor version seen)
+      # - '*' (no explicit bound, expand generously)
+      def self.collect_version_bounds(constraint_versions)
+        max_minor_by_major = Hash.new('*')
+
+        constraint_versions.each do |constraint_version|
+          collect_bounds_from_constraint(constraint_version, max_minor_by_major)
+        end
+
+        max_minor_by_major
+      end
+
+      def self.collect_bounds_from_constraint(version, max_minor_by_major)
+        if version.is_a?(Array)
+          version.each do |v|
+            collect_bounds_from_constraint(v, max_minor_by_major)
+          end
+        elsif version.is_a?(Hash) && version.key?(:from)
+          # Range bounds
+          update_max_minor(version[:from], max_minor_by_major)
+          update_max_minor(version[:to], max_minor_by_major) if version[:to]
+        elsif version.is_a?(Hash) && version.key?(:value)
+          # Single value with comment
+          update_max_minor(version[:value], max_minor_by_major)
+        else
+          # Simple value
+          update_max_minor(version, max_minor_by_major)
+        end
+      end
+
+      def self.update_max_minor(version_str, max_minor_by_major)
+        return if version_str.nil?
+        v = Version.new(version_str)
+        current_max = max_minor_by_major[v.major]
+        # If current is '*', keep the numeric value; otherwise take the max
+        if current_max == '*'
+          max_minor_by_major[v.major] = v.minor
+        else
+          max_minor_by_major[v.major] = [current_max, v.minor].max
+        end
+      end
+
+      def self.extract_versions_from_constraint(version, versions_set, max_minor_by_major, integration_id, integration)
         if version.is_a?(Array)
           # Array of versions or ranges
           version.each do |v|
-            extract_versions_from_constraint(v, versions_set)
+            extract_versions_from_constraint(v, versions_set, max_minor_by_major, integration_id, integration)
           end
         elsif version.is_a?(Hash) && version.key?(:from)
           # Range: expand from X to Y
-          expand_range(version[:from], version[:to], versions_set)
+          expand_range(version[:from], version[:to], versions_set, max_minor_by_major, integration_id, integration)
         elsif version.is_a?(Hash) && version.key?(:value)
           # Single value with comment
           versions_set.add(version[:value].to_s)
@@ -88,7 +138,7 @@ module Awestruct
         end
       end
 
-      def self.expand_range(from_str, to_str, versions_set)
+      def self.expand_range(from_str, to_str, versions_set, max_minor_by_major, integration_id, integration)
         from_version = Version.new(from_str)
         to_version = to_str ? Version.new(to_str) : nil
 
@@ -99,25 +149,69 @@ module Awestruct
         if to_version
           versions_set.add(to_str.to_s)
 
-          # Only try to expand intermediate versions if they're in the same major version
-          # This is a heuristic - we can only reliably expand within the same major version
-          if from_version.major == to_version.major
-            current = from_version
+          # Check if this range uses single-component versions (e.g., "13", "16" for WildFly)
+          # If so, only increment major versions, not minors
+          from_component_count = from_version.instance_variable_get(:@component_count)
+          to_component_count = to_version.instance_variable_get(:@component_count)
+          single_component_range = (from_component_count == 1 && to_component_count == 1)
+
+          if single_component_range
+            # Just increment major versions
+            current_major = from_version.major + 1
+            while current_major < to_version.major
+              versions_set.add(current_major.to_s)
+              current_major += 1
+            end
+          else
+            # Expand intermediate versions by incrementing through the range
             # Safety limit to prevent infinite loops
-            max_iterations = 100
+            max_iterations = 500
             iterations = 0
+
+            current_major = from_version.major
+            current_minor = from_version.minor
 
             loop do
               iterations += 1
               break if iterations > max_iterations
 
-              next_minor = Version.new("#{current.major}.#{current.minor + 1}.0")
-              break if next_minor > to_version
-              versions_set.add("#{next_minor.major}.#{next_minor.minor}")
-              current = next_minor
+              # Increment to next minor version
+              current_minor += 1
+
+              # Determine the limit for this major version
+              limit = get_limit_for_major(current_major, max_minor_by_major)
+
+              if limit.nil?
+                # No bound found - skip this major version entirely
+                # This handles gaps in version sequences (e.g., Elasticsearch 2.x -> 5.x skipping 3.x, 4.x)
+                current_major += 1
+                current_minor = 0
+                next
+              end
+
+              if current_minor > limit
+                # Move to the next major version
+                current_major += 1
+                current_minor = 0
+              end
+
+              next_version = Version.new("#{current_major}.#{current_minor}")
+
+              # Stop if we've reached or passed the target version
+              break if next_version >= to_version
+
+              versions_set.add("#{current_major}.#{current_minor}")
             end
           end
         end
+      end
+
+      # Get the limit (max minor version) for a given major version from collected bounds
+      # Returns nil if no bound is defined for this major version
+      def self.get_limit_for_major(major_version, max_minor_by_major, _unused_latest_minors = nil)
+        bound = max_minor_by_major[major_version]
+        return nil if bound == '*'
+        bound
       end
 
       def self.sort

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -101,6 +101,8 @@ project_hero_partial: project/hero-series.html.haml
           %td.left.aligned
             %a{:href => "#{integration&.url}"}
               = integration&.name
+            %a.ui.mini.icon.button{:href => "/community/integrations/##{integration_id}", :title => "See all compatible versions"}
+              %i.icon.list
           %td
             :asciidoc
               :doctype: inline

--- a/_layouts/project/project-releases.html.haml
+++ b/_layouts/project/project-releases.html.haml
@@ -110,6 +110,8 @@ project_buttons_partial: project/releases-buttons.html.haml
             %td.left.aligned
               %a{:href => "#{integration['url']}"}
                 = integration["name"]
+              %a.ui.mini.icon.button{:href => "/community/integrations/##{integration_id}", :title => "See all compatible versions"}
+                %i.icon.list
               - project_description.active_release_series.each do |series|
                 - constraint = series.integration_constraints[integration_id]
                 - if constraint == nil

--- a/_partials/menu/desktop-left-community.html.haml
+++ b/_partials/menu/desktop-left-community.html.haml
@@ -87,3 +87,9 @@
   %a.item{:href => href, :class => "#{(active ? "active" : "")}"}
     %i.grid.icon.key
     Keys
+
+  - href = "/community/integrations/"
+  - active = (href == current_path)
+  %a.item{:href => href, :class => "#{(active ? "active" : "")}"}
+    %i.grid.icon.puzzle.piece
+    Integrations

--- a/_partials/menu/mobile-section-community.html.haml
+++ b/_partials/menu/mobile-section-community.html.haml
@@ -74,3 +74,7 @@
       %a.item(href="/community/keys/"){:class => "#{(item_active ? "active" : "")}"}
         %i.grid.icon.key
         Keys
+      - href = "/community/integrations/"
+      %a.item{:href => href, :class => "#{(current_path == href ? "active" : "")}"}
+        %i.grid.icon.puzzle.piece
+        Integrations

--- a/_spec/version_spec.rb
+++ b/_spec/version_spec.rb
@@ -1,4 +1,5 @@
-require_relative '../_ext/release_file_parser'
+require_relative '../_ext/version'
+require 'set'
 
 describe Awestruct::Extensions::Version do
 
@@ -46,6 +47,56 @@ describe Awestruct::Extensions::Version do
 				break if index == (@versions.length - 2)
 				expect((version <=> @versions[index + 1] )).to eq -1
 			end
+		end
+	end
+
+	describe ".expand_from_constraints" do
+		it "expands simple versions" do
+			constraint_versions = ['3.20', '3.27']
+			versions = Awestruct::Extensions::Version.expand_from_constraints(constraint_versions)
+			expect(versions).to eq(['3.27', '3.20'])
+		end
+
+		it "expands version ranges" do
+			constraint_versions = [{ :from => '3.14', :to => '3.23' }]
+			versions = Awestruct::Extensions::Version.expand_from_constraints(constraint_versions)
+			# Should include at minimum the from and to versions
+			expect(versions).to include('3.14', '3.23')
+			# Should be sorted with latest first
+			expect(versions.first).to eq('3.23')
+			expect(versions.last).to eq('3.14')
+		end
+
+		it "handles arrays of versions" do
+			constraint_versions = [[11, 17, 21]]
+			versions = Awestruct::Extensions::Version.expand_from_constraints(constraint_versions)
+			expect(versions).to eq(['21', '17', '11'])
+		end
+
+		it "handles hash values with comments" do
+			constraint_versions = [[
+				21,
+				{ :value => 25, :comment => '6.6.40+' }
+			]]
+			versions = Awestruct::Extensions::Version.expand_from_constraints(constraint_versions)
+			expect(versions).to eq(['25', '21'])
+		end
+
+		it "returns empty array when no constraints provided" do
+			constraint_versions = []
+			versions = Awestruct::Extensions::Version.expand_from_constraints(constraint_versions)
+			expect(versions).to eq([])
+		end
+
+		it "handles multiple constraints from different projects" do
+			constraint_versions = [
+				'3.20',
+				{ :from => '3.14', :to => '3.23' },
+				[11, 17, 21]
+			]
+			versions = Awestruct::Extensions::Version.expand_from_constraints(constraint_versions)
+			# Should deduplicate and sort
+			expect(versions).to include('3.20', '3.14', '3.23', '21', '17', '11')
 		end
 	end
 end

--- a/_spec/version_spec.rb
+++ b/_spec/version_spec.rb
@@ -98,5 +98,35 @@ describe Awestruct::Extensions::Version do
 			# Should deduplicate and sort
 			expect(versions).to include('3.20', '3.14', '3.23', '21', '17', '11')
 		end
+
+		it "expands ranges across major versions" do
+			# Include explicit versions to provide bounds for each major version
+			constraint_versions = [
+				{ :from => '5.6', :to => '7.16' },
+				'5.50',  # Establishes max minor for major 5
+				'6.50',  # Establishes max minor for major 6
+				'7.50'   # Establishes max minor for major 7
+			]
+			versions = Awestruct::Extensions::Version.expand_from_constraints(constraint_versions, 'test_integration', nil)
+			# Should include endpoints
+			expect(versions).to include('5.6', '7.16')
+			# Should include intermediate minor versions in starting major
+			expect(versions).to include('5.7', '5.8', '5.9', '5.10')
+			# Should include versions in intermediate major
+			expect(versions).to include('6.0', '6.1', '6.2')
+			# Should include versions in ending major
+			expect(versions).to include('7.0', '7.1', '7.10', '7.15')
+			# Should be sorted with latest first
+			expect(versions.first).to eq('7.50')
+			expect(versions.last).to eq('5.6')
+		end
+
+		it "expands single-component version ranges" do
+			# WildFly-style single-component versions (just major, no minor)
+			constraint_versions = [{ :from => '13', :to => '16' }]
+			versions = Awestruct::Extensions::Version.expand_from_constraints(constraint_versions, 'test_integration', nil)
+			# Should include all major versions in range
+			expect(versions).to eq(['16', '15', '14', '13'])
+		end
 	end
 end

--- a/community/integrations.html.haml
+++ b/community/integrations.html.haml
@@ -1,0 +1,102 @@
+---
+layout: community-standard
+title: Integrations
+---
+
+#preamble
+  .sectionbody
+    %p
+      This page shows the compatibility between Hibernate projects and integrations: dependencies or downstream frameworks/platforms.
+      Each table shows which versions of Hibernate projects are compatible with each version of the integration.
+
+%h2{:id => integration_id}
+  Table of contents
+
+.ui.horizontal.list
+  - site.integrations.each do |integration_id, integration|
+    - next if site.projects.key?(integration_id)
+    - next if integration.version_ranges.nil? || integration.version_ranges.empty?
+    - integration_projects = integration.version_ranges.flat_map { |vr| vr[:compatibility]&.select { |_, matches| !matches.nil? && !matches.empty? }&.keys || [] }.uniq.sort.reject { |project_id| site.projects[project_id]&.deprecation_notice }
+    - next if integration_projects.empty?
+    .item
+      %a.ui.primary.label{:href => "##{integration_id}"}
+        = integration.name
+
+- site.integrations.each do |integration_id, integration|
+  - next if site.projects.key?(integration_id)
+  - next if integration.version_ranges.nil? || integration.version_ranges.empty?
+
+  - integration_projects = integration.version_ranges.flat_map { |vr| vr[:compatibility]&.select { |_, matches| !matches.nil? && !matches.empty? }&.keys || [] }.uniq.sort.reject { |project_id| site.projects[project_id]&.deprecation_notice }
+  - next if integration_projects.empty?
+
+  %h2{:id => integration_id}
+    %a{:href => integration.url}
+      = integration.name
+
+  - has_older_series = integration.has_older_series
+  - table_id = "integration-table-#{integration_id}"
+  - table_classes = has_older_series ? "has-older-series" : ""
+
+  %table.ui.definition.table.unstackable.celled.center.aligned{:id => table_id, :classes => table_classes}
+    %thead
+      %tr
+        %th
+          = integration.name
+          Version
+        - integration_projects.each do |project_id|
+          - project = site.projects[project_id]
+          - next if project.nil?
+          - project_integration = site.integrations[project_id]
+          %th
+            %a{:href => project_integration&.url || "/#{project_id}/"}
+              = project.name
+    %tbody
+      - integration.version_ranges.each do |version_range|
+        - displayed = version_range[:displayed]
+        - row_class = has_older_series && !displayed ? 'older-series' : ''
+        %tr{:class => row_class}
+          %td.left.aligned
+            = integration_constraint_version(version_range[:version], false)
+          - integration_projects.each do |project_id|
+            - project = site.projects[project_id]
+            - next if project.nil?
+            - results = version_range[:compatibility][project_id]
+            - if results.nil? || results.empty?
+              %td.disabled
+                N/A
+            - else
+              %td
+                - results.each_with_index do |result, index|
+                  - if index > 0
+                    = ', '
+                  - if result[:version].is_a?(Hash)
+                    %a{:href => "/#{project_id}/releases/#{result[:version][:from]}/"}
+                      = result[:version][:from]
+                    = ' &rarr; '
+                    %a{:href => "/#{project_id}/releases/#{result[:version][:to]}/"}
+                      = result[:version][:to]
+                  - else
+                    %a{:href => "/#{project_id}/releases/#{result[:version]}/"}
+                      = result[:version]
+                  - if result[:comment]
+                    :asciidoc
+                      :doctype: inline
+                      (#{result[:comment]})
+    - if has_older_series
+      %tfoot.full-width
+        %tr
+          %th{:colspan => integration_projects.length + 1}
+            %a.ui.right.floated.small.labeled.icon.button{:href => "javascript: void(0)", :id => "older-series-button-#{integration_id}"}
+              %i.icon.snowflake
+              %span See older series
+  - if has_older_series
+    :javascript
+      $(document).ready(function() {
+        $('#older-series-button-#{integration_id}').click(function() {
+          $('#integration-table-#{integration_id} tr.older-series').slideToggle(400);
+          var buttonText = $('#older-series-button-#{integration_id} span');
+          buttonText.text() == 'See older series' ?
+            buttonText.text("Hide older series") :
+            buttonText.text("See older series");
+        });
+      });

--- a/community/integrations.html.haml
+++ b/community/integrations.html.haml
@@ -70,11 +70,7 @@ title: Integrations
                   - if index > 0
                     = ', '
                   - if result[:version].is_a?(Hash)
-                    %a{:href => "/#{project_id}/releases/#{result[:version][:from]}/"}
-                      = result[:version][:from]
-                    = ' &rarr; '
-                    %a{:href => "/#{project_id}/releases/#{result[:version][:to]}/"}
-                      = result[:version][:to]
+                    = "<a href=\"/#{project_id}/releases/#{result[:version][:from]}/\">#{result[:version][:from]}</a>&nbsp;&rarr;&nbsp;<a href=\"/#{project_id}/releases/#{result[:version][:to]}/\">#{result[:version][:to]}</a>"
                   - else
                     %a{:href => "/#{project_id}/releases/#{result[:version]}/"}
                       = result[:version]

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -518,12 +518,24 @@ code, kbd, samp {
 		}
 	}
 
-	#older-series {
+	#older-series, .older-series {
 		display: none;
 	}
 
 	.ui.grid.download-options {
 		margin-bottom: 25px;
+	}
+}
+
+/**
+ * Integrations
+ */
+
+#content {
+	.table.has-older-series {
+		.older-series {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Sort of similar to compatibility matrices, but focused on integrations, one by one.

By default we only show versions of integrations that are in that integrations' list of "active series" or "els series", or if there is no such thing, we show all versions of the integration that are compatible with at least one non-end-of-lifed project series.

<img width="1003" height="700" alt="image" src="https://github.com/user-attachments/assets/acf4e3d9-ca64-4914-a917-6ecadb58d93c" />

<img width="1597" height="6951" alt="image" src="https://github.com/user-attachments/assets/2ade70e8-63b4-4309-95fc-2bc225e0c729" />
