### PR TITLE
Make integration tables use more fixed column style

### DIFF
--- a/community/integrations.html.haml
+++ b/community/integrations.html.haml
@@ -37,7 +37,7 @@ title: Integrations
   - table_id = "integration-table-#{integration_id}"
   - table_classes = has_older_series ? "has-older-series" : ""
 
-  %table.ui.definition.table.unstackable.celled.center.aligned{:id => table_id, :classes => table_classes}
+  %table.ui.definition.table.unstackable.celled.center.aligned.integration{:id => table_id, :classes => table_classes}
     %thead
       %tr
         %th

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -537,6 +537,12 @@ code, kbd, samp {
 			display: none;
 		}
 	}
+	table.ui.definition.table.unstackable.celled.center.aligned.integration {
+		table-layout: fixed;
+		th:first-child {
+			width: 150px;
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
I noticed that those tables are rendered a bit "random" in terms of column width, maybe we can make them more consistent, WDYT ?

<img width="1905" height="7401" alt="4242_community_integrations_" src="https://github.com/user-attachments/assets/1d06c430-b7e5-4cfc-8c78-8426769dc29d" />
