### PR TITLE
Add warnings about Tools being moved to ORM and Eclipse tooling being retired.

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -358,6 +358,10 @@ projects:
     icon: 'icon-wrench'
     description: |
       Reverse engineer Java entities from an existing SQL database schema.
+    deprecation_notice: |
+      Hibernate Tools' Maven/Ant/Gradle plugins have been integrated into Hibernate ORM starting with version 7.4.
+      Hibernate Eclipse tooling has been retired. 
+      See <a href='https://in.relation.to/2026/05/04/hibernate-tools-moves-to-orm/'>the announcement</a> for details and migration.
     blog_tag: Hibernate Tools
     blog_tag_url: hibernate-tools
     license:

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -361,7 +361,7 @@ projects:
     deprecation_notice: |
       Hibernate Tools' Maven/Ant/Gradle plugins have been integrated into Hibernate ORM starting with version 7.4.
       Hibernate Eclipse tooling has been retired. 
-      See <a href='https://in.relation.to/2026/05/04/hibernate-tools-moves-to-orm/'>the announcement</a> for details and migration.
+      See link:https://in.relation.to/2026/05/04/hibernate-tools-moves-to-orm/[the announcement] for details and migration.
     blog_tag: Hibernate Tools
     blog_tag_url: hibernate-tools
     license:
@@ -502,7 +502,7 @@ projects:
   ogm:
     name: Hibernate OGM
     description: "The power and simplicity of JPA for NoSQL datastores. Including support for associations, sub-classes, queries and much more."
-    deprecation_notice: "Hibernate OGM is not maintained anymore."
+    deprecation_notice: "Hibernate OGM has not been kept up to date with the latest Hibernate ORM versions and is not maintained anymore."
     icon: 'icon-sitemap'
     links:
       reference_doc:

--- a/_layouts/community/community-contributors.html.haml
+++ b/_layouts/community/community-contributors.html.haml
@@ -5,8 +5,11 @@ layout: community-standard
 
 - if project_description.deprecation_notice
   .ui.warning.message.icon
-    %i.icon.inbox.exclamation.triangle
-    = project_description.deprecation_notice
+    %i.icon.exclamation.triangle
+    .content
+      :asciidoc
+        :doctype: inline
+        #{project_description.deprecation_notice}
 
 .ui.icon.message
   %i.icon.users

--- a/_partials/project/deprecation-notice.html.haml
+++ b/_partials/project/deprecation-notice.html.haml
@@ -5,4 +5,6 @@
   .ui.container
     %h4
       %i.icon.exclamation.triangle
-      = project_description.deprecation_notice
+      :asciidoc
+        :doctype: inline
+        #{project_description.deprecation_notice}

--- a/others/index.adoc
+++ b/others/index.adoc
@@ -19,7 +19,6 @@ You will find some of these experiments here.
 [role="ui message warning"]
 Hibernate OGM has not been kept up to date with the latest Hibernate ORM versions
 and is not maintained anymore.
-If community members have interest in maintaining it, please link:/community/[contact us].
 
 ++++
 <a class="ui button right labeled icon a primary" href="/ogm/">
@@ -32,8 +31,6 @@ If community members have interest in maintaining it, please link:/community/[co
 
 [role="ui message warning"]
 Hibernate Shards has not been kept up to date with the latest Hibernate ORM versions.
-Some community members have interest in making it catch up.
-If you are interested, link:/community/[contact us].
 
 You can't always put all your relational data in a single relational database:
 

--- a/others/index.adoc
+++ b/others/index.adoc
@@ -1,11 +1,15 @@
 = Other Hibernate projects
 Emmanuel Bernard
 :awestruct-layout: news-and-no-menu
+:page-interpolate: true
 
 We always have new ideas to solve data related problems.
 You will find some of these experiments here.
 
 == Hibernate Tools
+
+[role="ui message warning"]
+#{site.projects['tools'].deprecation_notice}
 
 ++++
 <a class="ui button right labeled icon a primary" href="/tools/">
@@ -17,8 +21,7 @@ You will find some of these experiments here.
 == Hibernate OGM
 
 [role="ui message warning"]
-Hibernate OGM has not been kept up to date with the latest Hibernate ORM versions
-and is not maintained anymore.
+#{site.projects['ogm'].deprecation_notice}
 
 ++++
 <a class="ui button right labeled icon a primary" href="/ogm/">


### PR DESCRIPTION
With a link to https://in.relation.to/2026/05/04/hibernate-tools-moves-to-orm/ .

Result:

<img width="1597" height="1008" alt="image" src="https://github.com/user-attachments/assets/7424d72e-6917-4a84-a7eb-333d4635dfbf" />

<img width="1597" height="1008" alt="image" src="https://github.com/user-attachments/assets/ddffbe5d-efc2-4e0d-844f-0ee50b78863d" />

<img width="1597" height="1008" alt="image" src="https://github.com/user-attachments/assets/4898f0c6-2561-402d-a779-7c3d392dad58" />
