### PR TITLE
Adjust which series are displayed by default + improve ORM Docs submenu

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -73,6 +73,8 @@ projects:
     description: |
       Idiomatic persistence for Java and relational databases.
     links:
+      doc:
+        html: /orm/documentation/{series.version}/
       reference_doc:
         html: https://docs.hibernate.org/orm/{series.version}/userguide/html_single/
         latest_stable:
@@ -288,6 +290,8 @@ projects:
       project_id: orm
       since_series: 6.6
     links:
+      doc:
+        html: /repositories/documentation/{series.version}/
       reference_doc:
         html: https://docs.hibernate.org/orm/{series.version}/repositories/html_single/
         latest_stable:

--- a/_data/projects/orm/releases/6.2/series.yml
+++ b/_data/projects/orm/releases/6.2/series.yml
@@ -5,7 +5,6 @@ license:
 links:
   whats_new:
     html: "/orm/releases/{series.version}/#whats-new"
-displayed: false
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_ext/link_resolver.rb
+++ b/_ext/link_resolver.rb
@@ -10,7 +10,7 @@ module Awestruct
             project[:release_series]&.each_value do |series|
               links = series['links'] || Hash.new
               series['links'] = links
-              ['reference_doc', 'javadoc', 'migration_guide', 'short_guide', 'whats_new'].each do |key|
+              ['doc', 'reference_doc', 'javadoc', 'migration_guide', 'short_guide', 'whats_new'].each do |key|
                 links[key] = DocumentRef.from_patterns(project, series, key)
               end
               ['getting_started_guide'].each do |key|

--- a/_ext/links.rb
+++ b/_ext/links.rb
@@ -8,6 +8,10 @@ module Awestruct
         @site = site
       end
 
+      def doc(project, series)
+        return series&.[](:links)&.[](:doc)
+      end
+
       def reference_doc(project, series)
         return series&.[](:links)&.[](:reference_doc)
       end

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -306,10 +306,57 @@ module Awestruct
             series.latest_scm_ref = series[:scm_branch] || series.releases&.first&.scm_tag
           end
         end
+        # Determine which series should be displayed
+        # A series is displayed by default if:
+        # 1. It's in development
+        # 2. OR it's stable/latest-stable
+        # 3. OR it's in limited support and there's no later limited-support series in the same major
         project[:active_release_series] = project[:release_series].nil? ? nil
-            : project[:release_series].values.select{|s| !s[:displayed].nil? ? s.displayed : s[:status] != 'end-of-life'}
+            : project[:release_series].values.select{|s|
+                if !s[:displayed].nil?
+                  s.displayed
+                else
+                  status = s[:status]
+                  if status == 'development' || status == 'stable' || status == 'latest-stable'
+                    true
+                  elsif status == 'limited-support'
+                    # Check if there's a later limited-support series in the same major
+                    series_version = Version.new(s[:version])
+                    has_later_limited_support = project[:release_series].values.any? { |other|
+                      other[:status] == 'limited-support' &&
+                      other != s &&
+                      Version.new(other[:version]) > series_version &&
+                      Version.new(other[:version]).major == series_version.major
+                    }
+                    !has_later_limited_support
+                  else
+                    false
+                  end
+                end
+              }
         project[:older_release_series] = project[:release_series].nil? ? nil
-            : project[:release_series].values.select{|s| !s[:displayed].nil? ? !s.displayed : s[:status] == 'end-of-life'}
+            : project[:release_series].values.select{|s|
+                if !s[:displayed].nil?
+                  !s.displayed
+                else
+                  status = s[:status]
+                  if status == 'development' || status == 'stable' || status == 'latest-stable'
+                    false
+                  elsif status == 'limited-support'
+                    # Check if there's a later limited-support series in the same major
+                    series_version = Version.new(s[:version])
+                    has_later_limited_support = project[:release_series].values.any? { |other|
+                      other[:status] == 'limited-support' &&
+                      other != s &&
+                      Version.new(other[:version]) > series_version &&
+                      Version.new(other[:version]).major == series_version.major
+                    }
+                    has_later_limited_support
+                  else
+                    true
+                  end
+                end
+              }
       end
 
       # Compute integration compatibility tables for all downstream integrations

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -536,13 +536,13 @@ module Awestruct
           return true if integration[:els_series]&.include?(integration_version)
           false
         else
-          # If there are no active or els series, check if compatible with at least one displayed project series
-          isCompatibleWithDisplayedSeries(compatibility, projects_hash)
+          # If there are no active or els series, check if compatible with at least one non-EOL project series
+          isCompatibleWithNonEolSeries(compatibility, projects_hash)
         end
       end
 
-      # Check if a version is compatible with at least one displayed project series
-      def isCompatibleWithDisplayedSeries(compatibility, projects_hash)
+      # Check if a version is compatible with at least one non-EOL project series
+      def isCompatibleWithNonEolSeries(compatibility, projects_hash)
         compatibility&.each do |project_id, matches|
           project = projects_hash[project_id]
           next if project.nil? || project[:release_series].nil?
@@ -561,9 +561,8 @@ module Awestruct
               series = project[:release_series][series_version]
               next if series.nil?
 
-              # A series is displayed if: displayed is nil/true, or status is not 'end-of-life'
-              is_displayed = series[:displayed].nil? ? series[:status] != 'end-of-life' : series[:displayed]
-              return true if is_displayed
+              # Check if the series is not end-of-life
+              return true if series[:status] != 'end-of-life'
             end
           end
         end

--- a/_partials/menu/desktop-left-project.html.haml
+++ b/_partials/menu/desktop-left-project.html.haml
@@ -31,6 +31,9 @@
         #{menu.name}
         %i.icon.dropdown
         .menu
+          - overview_active = current_path == menu.href
+          %a.item{:href => menu.href, :class => "#{(overview_active ? "selected" : "")}"}
+            Overview
           - documentation_displayed_series.each do |series|
             - submenu_href = "#{menu.href}#{series.version}/"
             - submenu_active = current_path.start_with?(submenu_href)

--- a/_partials/menu/desktop-left-project.html.haml
+++ b/_partials/menu/desktop-left-project.html.haml
@@ -25,8 +25,8 @@
               &nbsp;&nbsp;
               = partial( 'project/series-status-label.html.haml', { "series" => series, "tooltipPosition" => "right center" } )
     - elsif menu.documentation_submenu
-      // Here we want to display all the known versions
-      - documentation_displayed_series = project_description.release_series.values
+      // Here we want to display only non-EOL versions
+      - documentation_displayed_series = project_description.active_release_series
       .ui.dropdown.link.item{:class => "#{(active ? "selected" : "")}"}
         #{menu.name}
         %i.icon.dropdown

--- a/_partials/menu/desktop-left-project.html.haml
+++ b/_partials/menu/desktop-left-project.html.haml
@@ -39,12 +39,8 @@
             - submenu_active = current_path.start_with?(submenu_href)
             %a.item{:href => "#{submenu_href}", :class => "#{(submenu_active ? "selected" : "")}"}
               #{series.version}
-              - if !series.stable
-                &nbsp;&nbsp;
-                %span.ui.label.orange development
-              - elsif series.latest_stable
-                &nbsp;&nbsp;
-                %span.ui.label.green latest stable
+              &nbsp;&nbsp;
+              = partial( 'project/series-status-label.html.haml', { "series" => series, "tooltipPosition" => "right center" } )
     - else
       %a.item{:href => menu.href, :class => "#{(active ? "selected" : "")}"}
         %i.grid.icon{:class => "#{menu.css_class}"}

--- a/_partials/project/series-documentation.html.haml
+++ b/_partials/project/series-documentation.html.haml
@@ -77,3 +77,9 @@
   %a.ui.right.labeled.icon.button.small(href="#{javadoc.html_url}")
     %i.icon.code.outline
     API (Javadoc)
+- doc = doc(project_description, series)
+- if not doc.nil?
+  %p
+    %a.ui.right.labeled.icon.button(href="#{doc.html_url}")
+      %i.icon.book
+      More documentation for #{series.version}

--- a/orm/documentation/index.adoc
+++ b/orm/documentation/index.adoc
@@ -1,20 +1,15 @@
-= Hibernate ORM Downloads
-:awestruct-layout: project-stable-releases
+= Documentation
+:awestruct-layout: project-documentation
 :awestruct-project: orm
 :page-interpolate: true
 
-++++
-<script>
-    var versionTokens = stable_releases[0].split(".");
-    var latestVersionPath = versionTokens[0] + "." + versionTokens[1] + "/";
+== Other resources
 
-    var meta = document.createElement('meta');
-    meta.httpEquiv = "refresh";
-    meta.content = "5; url=" + latestVersionPath;
-    document.getElementsByTagName('head')[0].appendChild(meta);
-    
-    window.location = latestVersionPath;
-</script>
-++++
-
-
+link:/orm/tooling/[Tooling]::
+Tools to help with Hibernate development.
+link:/orm/envers/[Envers]::
+Auditing and versioning of entities.
+link:/orm/faq/[FAQ]::
+Frequently asked questions.
+link:/orm/books/[Books]::
+Books about Hibernate ORM.

--- a/survival-guide.adoc
+++ b/survival-guide.adoc
@@ -231,6 +231,7 @@ By default, an end-of-life series is considered "older" and not displayed with t
 it is not displayed in the drop-down "Releases" submenu,
 it is moved to its own "Older series" section in the page listing all series,
 and it is not displayed in the project's compatibility matrix.
+The same is true for limited-support series when a later limited-support series exists in the same major.
 
 You can override this behavior, to hide a non-EOL'd series or display an EOL'd series,
 by editing the `_data/<project ID>/releases/<series version>/series.yml` file


### PR DESCRIPTION
First commit is a bugfix that shouldn't have much impact.

Second commit makes sure that we move `limited-support` series to "older series" when there is a newer `limited-support` series in the same major. E.g. 6.2 will be considered older, because 6.6 is in limited support.

The next commit make sure that the Documentation dropdown in the Hibernate ORM submenu doesn't get crazy long:

<p float="left">
    <img width="45%" alt="image" src="https://github.com/user-attachments/assets/9494aaa1-1068-4177-a293-107fecea3022" />
    <img width="45%" height="830" alt="image" src="https://github.com/user-attachments/assets/cdbbabdc-2cd5-499e-84e1-a0f751595e3a" />

That also involves adding an Overview page for documentation of Hibernate ORM, since otherwise there is no link to older documentation:

<img width="1597" height="1008" alt="image" src="https://github.com/user-attachments/assets/45c0cc27-493e-483f-8f6b-93007b5c537d" />
