### PR TITLE
[HR] Don't forcefully force 3.x versions as stable

### DIFF
--- a/_data/projects/reactive/releases/3.3/series.yml
+++ b/_data/projects/reactive/releases/3.3/series.yml
@@ -1,5 +1,4 @@
 summary: Release compatible with Hibernate ORM 7.3 and Vert.x 4.5
-status: stable
 maven:
   artifacts:
     - artifact_id: hibernate-reactive-core

--- a/_data/projects/reactive/releases/3.4/series.yml
+++ b/_data/projects/reactive/releases/3.4/series.yml
@@ -1,5 +1,4 @@
 summary: Release compatible with Hibernate ORM 7.4 and Vert.x 4.5
-status: stable
 maven:
   artifacts:
     - artifact_id: hibernate-reactive-core


### PR DESCRIPTION
Because this leads to situation like the one we have here, where we forget to unset them.

Let's just advertise these versions as limited-support, that'll be fine. And hopefully we only have to do this for a few months (until Quarkus 4.0).