### PR TITLE
Add older series of Hibernate ORM (1.0+), Search (3.0+), Validator (3.0+)

### DIFF
--- a/_data/projects/orm/releases/1.0/1.0rc1.yml
+++ b/_data/projects/orm/releases/1.0/1.0rc1.yml
@@ -1,0 +1,2 @@
+date: 2002-06-15
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.0/1.0rc2.yml
+++ b/_data/projects/orm/releases/1.0/1.0rc2.yml
@@ -1,0 +1,2 @@
+date: 2002-06-20
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.0/1.0rc3.yml
+++ b/_data/projects/orm/releases/1.0/1.0rc3.yml
@@ -1,0 +1,2 @@
+date: 2002-07-03
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.0/series.yml
+++ b/_data/projects/orm/releases/1.0/series.yml
@@ -1,7 +1,7 @@
 status: end-of-life
 license:
   name: LGPL v2.1
-  # Note: 1.0 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate1-cvs/master/lgpl.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/orm/releases/1.0/series.yml
+++ b/_data/projects/orm/releases/1.0/series.yml
@@ -1,0 +1,31 @@
+status: end-of-life
+license:
+  name: LGPL v2.1
+  # Note: 1.0 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  # Note: Very old series - no documentation links available
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate
+      summary: Core Hibernate framework
+# Note: Pre-Maven Central era - not available on Maven Central
+# Source: https://github.com/hibernate/hibernate1-cvs

--- a/_data/projects/orm/releases/1.0/series.yml
+++ b/_data/projects/orm/releases/1.0/series.yml
@@ -20,12 +20,6 @@ links:
   # Note: Very old series - no documentation links available
 maven:
   coord:
-    group_id: org.hibernate
-    main_artifact_id: hibernate
-  repo:
-    snapshots: jboss
-  artifacts:
-    - artifact_id: hibernate
-      summary: Core Hibernate framework
-# Note: Pre-Maven Central era - not available on Maven Central
+# Note: Pre-Maven Central era - artifacts not available on Maven Central
+# Maven coordinates intentionally set to nil to hide download links
 # Source: https://github.com/hibernate/hibernate1-cvs

--- a/_data/projects/orm/releases/1.0/series.yml
+++ b/_data/projects/orm/releases/1.0/series.yml
@@ -18,6 +18,9 @@ links:
   whats_new:
     displayed: false
   # Note: Very old series - no documentation links available
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
 # Note: Pre-Maven Central era - artifacts not available on Maven Central

--- a/_data/projects/orm/releases/1.1/1.1.1.yml
+++ b/_data/projects/orm/releases/1.1/1.1.1.yml
@@ -1,0 +1,2 @@
+date: 2002-09-25
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1.2.yml
+++ b/_data/projects/orm/releases/1.1/1.1.2.yml
@@ -1,0 +1,2 @@
+date: 2002-09-29
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1.3.yml
+++ b/_data/projects/orm/releases/1.1/1.1.3.yml
@@ -1,0 +1,2 @@
+date: 2002-09-30
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1.4.yml
+++ b/_data/projects/orm/releases/1.1/1.1.4.yml
@@ -1,0 +1,2 @@
+date: 2002-10-03
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1.5b.yml
+++ b/_data/projects/orm/releases/1.1/1.1.5b.yml
@@ -1,0 +1,2 @@
+date: 2002-10-20
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1.7.yml
+++ b/_data/projects/orm/releases/1.1/1.1.7.yml
@@ -1,0 +1,2 @@
+date: 2002-10-25
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1.8.yml
+++ b/_data/projects/orm/releases/1.1/1.1.8.yml
@@ -1,0 +1,2 @@
+date: 2002-10-28
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta1.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta1.yml
@@ -1,0 +1,2 @@
+date: 2002-08-04
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta11.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta11.yml
@@ -1,0 +1,2 @@
+date: 2002-09-08
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta2.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta2.yml
@@ -1,0 +1,2 @@
+date: 2002-08-06
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta3.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta3.yml
@@ -1,0 +1,2 @@
+date: 2002-08-10
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta4.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta4.yml
@@ -1,0 +1,2 @@
+date: 2002-08-11
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta6.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta6.yml
@@ -1,0 +1,2 @@
+date: 2002-08-18
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta6b.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta6b.yml
@@ -1,0 +1,2 @@
+date: 2002-08-20
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta7.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta7.yml
@@ -1,0 +1,2 @@
+date: 2002-08-23
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta8.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta8.yml
@@ -1,0 +1,2 @@
+date: 2002-08-25
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1beta9.yml
+++ b/_data/projects/orm/releases/1.1/1.1beta9.yml
@@ -1,0 +1,2 @@
+date: 2002-08-26
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1final.yml
+++ b/_data/projects/orm/releases/1.1/1.1final.yml
@@ -1,0 +1,2 @@
+date: 2002-09-22
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1rc1.yml
+++ b/_data/projects/orm/releases/1.1/1.1rc1.yml
@@ -1,0 +1,2 @@
+date: 2002-09-14
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/1.1rc3.yml
+++ b/_data/projects/orm/releases/1.1/1.1rc3.yml
@@ -1,0 +1,2 @@
+date: 2002-09-18
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.1/series.yml
+++ b/_data/projects/orm/releases/1.1/series.yml
@@ -1,0 +1,31 @@
+status: end-of-life
+license:
+  name: LGPL v2.1
+  # Note: 1.1 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  # Note: Very old series - no documentation links available
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate
+      summary: Core Hibernate framework
+# Note: Pre-Maven Central era - not available on Maven Central
+# Source: https://github.com/hibernate/hibernate1-cvs

--- a/_data/projects/orm/releases/1.1/series.yml
+++ b/_data/projects/orm/releases/1.1/series.yml
@@ -1,7 +1,7 @@
 status: end-of-life
 license:
   name: LGPL v2.1
-  # Note: 1.1 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate1-cvs/master/lgpl.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/orm/releases/1.1/series.yml
+++ b/_data/projects/orm/releases/1.1/series.yml
@@ -20,12 +20,6 @@ links:
   # Note: Very old series - no documentation links available
 maven:
   coord:
-    group_id: org.hibernate
-    main_artifact_id: hibernate
-  repo:
-    snapshots: jboss
-  artifacts:
-    - artifact_id: hibernate
-      summary: Core Hibernate framework
-# Note: Pre-Maven Central era - not available on Maven Central
+# Note: Pre-Maven Central era - artifacts not available on Maven Central
+# Maven coordinates intentionally set to nil to hide download links
 # Source: https://github.com/hibernate/hibernate1-cvs

--- a/_data/projects/orm/releases/1.1/series.yml
+++ b/_data/projects/orm/releases/1.1/series.yml
@@ -18,6 +18,9 @@ links:
   whats_new:
     displayed: false
   # Note: Very old series - no documentation links available
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
 # Note: Pre-Maven Central era - artifacts not available on Maven Central

--- a/_data/projects/orm/releases/1.2/1.2.2.yml
+++ b/_data/projects/orm/releases/1.2/1.2.2.yml
@@ -1,0 +1,2 @@
+date: 2003-01-04
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.2/1.2.4.yml
+++ b/_data/projects/orm/releases/1.2/1.2.4.yml
@@ -1,0 +1,2 @@
+date: 2003-03-22
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.2/1.2.5.yml
+++ b/_data/projects/orm/releases/1.2/1.2.5.yml
@@ -1,0 +1,2 @@
+date: 2003-05-10
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.2/1.2beta1.yml
+++ b/_data/projects/orm/releases/1.2/1.2beta1.yml
@@ -1,0 +1,2 @@
+date: 2002-11-11
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.2/1.2final.yml
+++ b/_data/projects/orm/releases/1.2/1.2final.yml
@@ -1,0 +1,2 @@
+date: 2002-12-07
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.2/1.2rc1.yml
+++ b/_data/projects/orm/releases/1.2/1.2rc1.yml
@@ -1,0 +1,2 @@
+date: 2002-11-25
+# Source: https://github.com/hibernate/hibernate1-cvs commit log

--- a/_data/projects/orm/releases/1.2/series.yml
+++ b/_data/projects/orm/releases/1.2/series.yml
@@ -1,7 +1,7 @@
 status: end-of-life
 license:
   name: LGPL v2.1
-  # Note: 1.2 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate1-cvs/master/lgpl.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/orm/releases/1.2/series.yml
+++ b/_data/projects/orm/releases/1.2/series.yml
@@ -20,12 +20,6 @@ links:
   # Note: Very old series - no documentation links available
 maven:
   coord:
-    group_id: org.hibernate
-    main_artifact_id: hibernate
-  repo:
-    snapshots: jboss
-  artifacts:
-    - artifact_id: hibernate
-      summary: Core Hibernate framework
-# Note: Pre-Maven Central era - not available on Maven Central
+# Note: Pre-Maven Central era - artifacts not available on Maven Central
+# Maven coordinates intentionally set to nil to hide download links
 # Source: https://github.com/hibernate/hibernate1-cvs

--- a/_data/projects/orm/releases/1.2/series.yml
+++ b/_data/projects/orm/releases/1.2/series.yml
@@ -1,0 +1,31 @@
+status: end-of-life
+license:
+  name: LGPL v2.1
+  # Note: 1.2 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  # Note: Very old series - no documentation links available
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate
+      summary: Core Hibernate framework
+# Note: Pre-Maven Central era - not available on Maven Central
+# Source: https://github.com/hibernate/hibernate1-cvs

--- a/_data/projects/orm/releases/1.2/series.yml
+++ b/_data/projects/orm/releases/1.2/series.yml
@@ -18,6 +18,9 @@ links:
   whats_new:
     displayed: false
   # Note: Very old series - no documentation links available
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
 # Note: Pre-Maven Central era - artifacts not available on Maven Central

--- a/_data/projects/orm/releases/2.0/2.0.1.yml
+++ b/_data/projects/orm/releases/2.0/2.0.1.yml
@@ -1,0 +1,6 @@
+date: 2003-06-04
+# Source: Estimated from SourceForge file timestamps and 2.0 series progression
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.0.1/hibernate-2.0.1.zip/download

--- a/_data/projects/orm/releases/2.0/2.0.2.yml
+++ b/_data/projects/orm/releases/2.0/2.0.2.yml
@@ -1,2 +1,6 @@
 date: 2003-08-01
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.0.2/hibernate-2.0.2.zip/download

--- a/_data/projects/orm/releases/2.0/2.0.2.yml
+++ b/_data/projects/orm/releases/2.0/2.0.2.yml
@@ -1,0 +1,2 @@
+date: 2003-08-01
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.0/2.0.3.yml
+++ b/_data/projects/orm/releases/2.0/2.0.3.yml
@@ -1,0 +1,2 @@
+date: 2003-08-27
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.0/2.0.3.yml
+++ b/_data/projects/orm/releases/2.0/2.0.3.yml
@@ -1,2 +1,6 @@
 date: 2003-08-27
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.0.3/hibernate-2.0.3.zip/download

--- a/_data/projects/orm/releases/2.0/2.0beta1.yml
+++ b/_data/projects/orm/releases/2.0/2.0beta1.yml
@@ -1,0 +1,2 @@
+date: 2003-01-28
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.0/2.0beta1.yml
+++ b/_data/projects/orm/releases/2.0/2.0beta1.yml
@@ -1,2 +1,6 @@
 date: 2003-01-28
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.0 beta 1/hibernate-2.0beta1.zip/download

--- a/_data/projects/orm/releases/2.0/2.0beta2.yml
+++ b/_data/projects/orm/releases/2.0/2.0beta2.yml
@@ -1,2 +1,6 @@
 date: 2003-02-02
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.0 beta 2/hibernate-2.0beta2.zip/download

--- a/_data/projects/orm/releases/2.0/2.0beta2.yml
+++ b/_data/projects/orm/releases/2.0/2.0beta2.yml
@@ -1,0 +1,2 @@
+date: 2003-02-02
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.0/2.0beta4.yml
+++ b/_data/projects/orm/releases/2.0/2.0beta4.yml
@@ -1,2 +1,6 @@
 date: 2003-03-22
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.0 beta 4/hibernate-2.0beta4.zip/download

--- a/_data/projects/orm/releases/2.0/2.0beta4.yml
+++ b/_data/projects/orm/releases/2.0/2.0beta4.yml
@@ -1,0 +1,2 @@
+date: 2003-03-22
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.0/2.0beta5.yml
+++ b/_data/projects/orm/releases/2.0/2.0beta5.yml
@@ -1,0 +1,2 @@
+date: 2003-04-21
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.0/2.0beta5.yml
+++ b/_data/projects/orm/releases/2.0/2.0beta5.yml
@@ -1,2 +1,6 @@
 date: 2003-04-21
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.0 beta 5/hibernate-2.0beta5.zip/download

--- a/_data/projects/orm/releases/2.0/2.0final.yml
+++ b/_data/projects/orm/releases/2.0/2.0final.yml
@@ -1,2 +1,6 @@
 date: 2003-06-08
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.0 final/hibernate-2.0.zip/download

--- a/_data/projects/orm/releases/2.0/2.0final.yml
+++ b/_data/projects/orm/releases/2.0/2.0final.yml
@@ -1,0 +1,2 @@
+date: 2003-06-08
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.0/series.yml
+++ b/_data/projects/orm/releases/2.0/series.yml
@@ -1,7 +1,7 @@
 status: end-of-life
 license:
   name: LGPL v2.1
-  # Note: 2.0 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate2-cvs/master/lgpl.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/orm/releases/2.0/series.yml
+++ b/_data/projects/orm/releases/2.0/series.yml
@@ -1,0 +1,31 @@
+status: end-of-life
+license:
+  name: LGPL v2.1
+  # Note: 2.0 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  # Note: Very old series - no documentation links available
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate
+      summary: Core Hibernate framework
+# Note: Pre-Maven Central era - not available on Maven Central
+# Source: https://github.com/hibernate/hibernate2-cvs

--- a/_data/projects/orm/releases/2.0/series.yml
+++ b/_data/projects/orm/releases/2.0/series.yml
@@ -20,12 +20,6 @@ links:
   # Note: Very old series - no documentation links available
 maven:
   coord:
-    group_id: org.hibernate
-    main_artifact_id: hibernate
-  repo:
-    snapshots: jboss
-  artifacts:
-    - artifact_id: hibernate
-      summary: Core Hibernate framework
-# Note: Pre-Maven Central era - not available on Maven Central
+# Note: Pre-Maven Central era - artifacts not available on Maven Central
+# Maven coordinates intentionally set to nil to hide download links
 # Source: https://github.com/hibernate/hibernate2-cvs

--- a/_data/projects/orm/releases/2.0/series.yml
+++ b/_data/projects/orm/releases/2.0/series.yml
@@ -18,6 +18,9 @@ links:
   whats_new:
     displayed: false
   # Note: Very old series - no documentation links available
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
 # Note: Pre-Maven Central era - artifacts not available on Maven Central

--- a/_data/projects/orm/releases/2.1/2.1.6.yml
+++ b/_data/projects/orm/releases/2.1/2.1.6.yml
@@ -1,0 +1,2 @@
+date: 2004-08-03
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.1/2.1.6.yml
+++ b/_data/projects/orm/releases/2.1/2.1.6.yml
@@ -1,2 +1,6 @@
 date: 2004-08-03
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.1.6/hibernate-2.1.6.zip/download

--- a/_data/projects/orm/releases/2.1/2.1.7.yml
+++ b/_data/projects/orm/releases/2.1/2.1.7.yml
@@ -1,2 +1,6 @@
 date: 2004-08-09
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.1.7/hibernate-2.1.7.zip/download

--- a/_data/projects/orm/releases/2.1/2.1.7.yml
+++ b/_data/projects/orm/releases/2.1/2.1.7.yml
@@ -1,0 +1,2 @@
+date: 2004-08-09
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.1/2.1.8.yml
+++ b/_data/projects/orm/releases/2.1/2.1.8.yml
@@ -1,2 +1,6 @@
 date: 2005-01-10
 # Source: https://github.com/hibernate/hibernate2-cvs commit log
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate2/2.1.8/hibernate-2.1.8.zip/download

--- a/_data/projects/orm/releases/2.1/2.1.8.yml
+++ b/_data/projects/orm/releases/2.1/2.1.8.yml
@@ -1,0 +1,2 @@
+date: 2005-01-10
+# Source: https://github.com/hibernate/hibernate2-cvs commit log

--- a/_data/projects/orm/releases/2.1/series.yml
+++ b/_data/projects/orm/releases/2.1/series.yml
@@ -1,0 +1,31 @@
+status: end-of-life
+license:
+  name: LGPL v2.1
+  # Note: 2.1 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  # Note: Very old series - no documentation links available
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate
+      summary: Core Hibernate framework
+# Note: Pre-Maven Central era - not available on Maven Central
+# Source: https://github.com/hibernate/hibernate2-cvs

--- a/_data/projects/orm/releases/2.1/series.yml
+++ b/_data/projects/orm/releases/2.1/series.yml
@@ -20,12 +20,6 @@ links:
   # Note: Very old series - no documentation links available
 maven:
   coord:
-    group_id: org.hibernate
-    main_artifact_id: hibernate
-  repo:
-    snapshots: jboss
-  artifacts:
-    - artifact_id: hibernate
-      summary: Core Hibernate framework
-# Note: Pre-Maven Central era - not available on Maven Central
+# Note: Pre-Maven Central era - artifacts not available on Maven Central
+# Maven coordinates intentionally set to nil to hide download links
 # Source: https://github.com/hibernate/hibernate2-cvs

--- a/_data/projects/orm/releases/2.1/series.yml
+++ b/_data/projects/orm/releases/2.1/series.yml
@@ -1,7 +1,7 @@
 status: end-of-life
 license:
   name: LGPL v2.1
-  # Note: 2.1 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate2-cvs/master/lgpl.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/orm/releases/2.1/series.yml
+++ b/_data/projects/orm/releases/2.1/series.yml
@@ -18,6 +18,9 @@ links:
   whats_new:
     displayed: false
   # Note: Very old series - no documentation links available
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
 # Note: Pre-Maven Central era - artifacts not available on Maven Central

--- a/_data/projects/orm/releases/3.0/3.0.1.yml
+++ b/_data/projects/orm/releases/3.0/3.0.1.yml
@@ -1,0 +1,2 @@
+date: 2005-11-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.0.1/pom

--- a/_data/projects/orm/releases/3.0/3.0.3.yml
+++ b/_data/projects/orm/releases/3.0/3.0.3.yml
@@ -1,0 +1,2 @@
+date: 2005-11-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.0.3/pom

--- a/_data/projects/orm/releases/3.0/3.0.5.yml
+++ b/_data/projects/orm/releases/3.0/3.0.5.yml
@@ -1,0 +1,2 @@
+date: 2005-11-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.0.5/pom

--- a/_data/projects/orm/releases/3.0/3.0.yml
+++ b/_data/projects/orm/releases/3.0/3.0.yml
@@ -1,0 +1,2 @@
+date: 2005-11-24
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.0/jar

--- a/_data/projects/orm/releases/3.0/3.0alpha.yml
+++ b/_data/projects/orm/releases/3.0/3.0alpha.yml
@@ -1,0 +1,2 @@
+date: 2005-11-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.0alpha/jar

--- a/_data/projects/orm/releases/3.0/3.0beta1.yml
+++ b/_data/projects/orm/releases/3.0/3.0beta1.yml
@@ -1,0 +1,2 @@
+date: 2005-11-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.0beta1/jar

--- a/_data/projects/orm/releases/3.0/3.0beta3.yml
+++ b/_data/projects/orm/releases/3.0/3.0beta3.yml
@@ -1,0 +1,2 @@
+date: 2005-11-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.0beta3/jar

--- a/_data/projects/orm/releases/3.0/3.0beta4b.yml
+++ b/_data/projects/orm/releases/3.0/3.0beta4b.yml
@@ -1,0 +1,2 @@
+date: 2005-11-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.0beta4b/jar

--- a/_data/projects/orm/releases/3.0/3.0rc1.yml
+++ b/_data/projects/orm/releases/3.0/3.0rc1.yml
@@ -1,0 +1,2 @@
+date: 2005-11-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.0rc1/jar

--- a/_data/projects/orm/releases/3.0/series.yml
+++ b/_data/projects/orm/releases/3.0/series.yml
@@ -1,6 +1,6 @@
 license:
   name: LGPL v2.1
-  # Note: 3.0 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate3-cvs/master/lgpl.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/orm/releases/3.0/series.yml
+++ b/_data/projects/orm/releases/3.0/series.yml
@@ -1,0 +1,31 @@
+license:
+  name: LGPL v2.1
+  # Note: 3.0 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  # Note: Very old series - no documentation links available
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate
+      summary: Core Hibernate framework
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate/

--- a/_data/projects/orm/releases/3.1/3.1.1.yml
+++ b/_data/projects/orm/releases/3.1/3.1.1.yml
@@ -1,0 +1,2 @@
+date: 2006-02-06
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.1.1/pom

--- a/_data/projects/orm/releases/3.1/3.1.2.yml
+++ b/_data/projects/orm/releases/3.1/3.1.2.yml
@@ -1,0 +1,2 @@
+date: 2006-02-13
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.1.2/pom

--- a/_data/projects/orm/releases/3.1/3.1.3.yml
+++ b/_data/projects/orm/releases/3.1/3.1.3.yml
@@ -1,0 +1,2 @@
+date: 2006-04-26
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.1.3/pom

--- a/_data/projects/orm/releases/3.1/3.1.yml
+++ b/_data/projects/orm/releases/3.1/3.1.yml
@@ -1,0 +1,2 @@
+date: 2005-12-26
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.1/jar

--- a/_data/projects/orm/releases/3.1/3.1beta2.yml
+++ b/_data/projects/orm/releases/3.1/3.1beta2.yml
@@ -1,0 +1,2 @@
+date: 2005-11-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.1beta2/jar

--- a/_data/projects/orm/releases/3.1/3.1beta3.yml
+++ b/_data/projects/orm/releases/3.1/3.1beta3.yml
@@ -1,0 +1,2 @@
+date: 2005-11-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.1beta3/jar

--- a/_data/projects/orm/releases/3.1/3.1rc1.yml
+++ b/_data/projects/orm/releases/3.1/3.1rc1.yml
@@ -1,0 +1,2 @@
+date: 2006-04-29
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.1rc1/jar

--- a/_data/projects/orm/releases/3.1/3.1rc2.yml
+++ b/_data/projects/orm/releases/3.1/3.1rc2.yml
@@ -1,0 +1,2 @@
+date: 2005-11-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.1rc2/jar

--- a/_data/projects/orm/releases/3.1/3.1rc3.yml
+++ b/_data/projects/orm/releases/3.1/3.1rc3.yml
@@ -1,0 +1,2 @@
+date: 2005-12-26
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.1rc3/jar

--- a/_data/projects/orm/releases/3.1/series.yml
+++ b/_data/projects/orm/releases/3.1/series.yml
@@ -1,6 +1,6 @@
 license:
   name: LGPL v2.1
-  # Note: 3.1 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate3-cvs/master/lgpl.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/orm/releases/3.1/series.yml
+++ b/_data/projects/orm/releases/3.1/series.yml
@@ -1,0 +1,31 @@
+license:
+  name: LGPL v2.1
+  # Note: 3.1 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+  # Note: Very old series - no documentation links available
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate
+      summary: Core Hibernate framework
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate/

--- a/_data/projects/orm/releases/3.2/3.2.0.cr1.yml
+++ b/_data/projects/orm/releases/3.2/3.2.0.cr1.yml
@@ -1,0 +1,2 @@
+date: 2006-04-27
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.0.cr1/pom

--- a/_data/projects/orm/releases/3.2/3.2.0.cr2.yml
+++ b/_data/projects/orm/releases/3.2/3.2.0.cr2.yml
@@ -1,0 +1,2 @@
+date: 2006-05-29
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.0.cr2/pom

--- a/_data/projects/orm/releases/3.2/3.2.0.cr3.yml
+++ b/_data/projects/orm/releases/3.2/3.2.0.cr3.yml
@@ -1,0 +1,2 @@
+date: 2006-07-17
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.0.cr3/pom

--- a/_data/projects/orm/releases/3.2/3.2.0.cr4.yml
+++ b/_data/projects/orm/releases/3.2/3.2.0.cr4.yml
@@ -1,0 +1,2 @@
+date: 2006-09-07
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.0.cr4/pom

--- a/_data/projects/orm/releases/3.2/3.2.0.cr5.yml
+++ b/_data/projects/orm/releases/3.2/3.2.0.cr5.yml
@@ -1,0 +1,2 @@
+date: 2006-10-11
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.0.cr5/pom

--- a/_data/projects/orm/releases/3.2/3.2.0.ga.yml
+++ b/_data/projects/orm/releases/3.2/3.2.0.ga.yml
@@ -1,0 +1,2 @@
+date: 2006-10-19
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.0.ga/pom

--- a/_data/projects/orm/releases/3.2/3.2.1.ga.yml
+++ b/_data/projects/orm/releases/3.2/3.2.1.ga.yml
@@ -1,0 +1,2 @@
+date: 2006-12-01
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.1.ga/pom

--- a/_data/projects/orm/releases/3.2/3.2.2.ga.yml
+++ b/_data/projects/orm/releases/3.2/3.2.2.ga.yml
@@ -1,0 +1,2 @@
+date: 2007-02-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.2.ga/pom

--- a/_data/projects/orm/releases/3.2/3.2.3.ga.yml
+++ b/_data/projects/orm/releases/3.2/3.2.3.ga.yml
@@ -1,0 +1,2 @@
+date: 2007-04-20
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.3.ga/pom

--- a/_data/projects/orm/releases/3.2/3.2.4.ga.yml
+++ b/_data/projects/orm/releases/3.2/3.2.4.ga.yml
@@ -1,0 +1,2 @@
+date: 2007-05-12
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.4.ga/pom

--- a/_data/projects/orm/releases/3.2/3.2.4.sp1.yml
+++ b/_data/projects/orm/releases/3.2/3.2.4.sp1.yml
@@ -1,0 +1,2 @@
+date: 2007-05-29
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.4.sp1/pom

--- a/_data/projects/orm/releases/3.2/3.2.5.ga.yml
+++ b/_data/projects/orm/releases/3.2/3.2.5.ga.yml
@@ -1,0 +1,2 @@
+date: 2007-08-11
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.5.ga/pom

--- a/_data/projects/orm/releases/3.2/3.2.6.ga.yml
+++ b/_data/projects/orm/releases/3.2/3.2.6.ga.yml
@@ -1,0 +1,2 @@
+date: 2008-03-14
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.6.ga/pom

--- a/_data/projects/orm/releases/3.2/3.2.7.ga.yml
+++ b/_data/projects/orm/releases/3.2/3.2.7.ga.yml
@@ -1,0 +1,2 @@
+date: 2009-07-14
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate/3.2.7.ga/pom

--- a/_data/projects/orm/releases/3.2/series.yml
+++ b/_data/projects/orm/releases/3.2/series.yml
@@ -1,0 +1,32 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-orm/3.2/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+  # Note: Very old series - no documentation links available
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate
+      summary: Core Hibernate framework
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate/
+  # - JPA: dependency on hibernate-jpa-1.0-api or ejb3-persistence

--- a/_data/projects/orm/releases/3.3/3.3.0.CR1.yml
+++ b/_data/projects/orm/releases/3.3/3.3.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2008-04-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.3.0.CR1/pom

--- a/_data/projects/orm/releases/3.3/3.3.0.CR2.yml
+++ b/_data/projects/orm/releases/3.3/3.3.0.CR2.yml
@@ -1,0 +1,2 @@
+date: 2008-08-01
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.3.0.CR2/pom

--- a/_data/projects/orm/releases/3.3/3.3.0.GA.yml
+++ b/_data/projects/orm/releases/3.3/3.3.0.GA.yml
@@ -1,0 +1,2 @@
+date: 2008-08-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.3.0.GA/pom

--- a/_data/projects/orm/releases/3.3/3.3.0.SP1.yml
+++ b/_data/projects/orm/releases/3.3/3.3.0.SP1.yml
@@ -1,0 +1,2 @@
+date: 2008-08-19
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.3.0.SP1/pom

--- a/_data/projects/orm/releases/3.3/3.3.1.GA.yml
+++ b/_data/projects/orm/releases/3.3/3.3.1.GA.yml
@@ -1,0 +1,2 @@
+date: 2008-09-10
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.3.1.GA/pom

--- a/_data/projects/orm/releases/3.3/3.3.2.GA.yml
+++ b/_data/projects/orm/releases/3.3/3.3.2.GA.yml
@@ -1,0 +1,2 @@
+date: 2009-06-24
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.3.2.GA/pom

--- a/_data/projects/orm/releases/3.3/series.yml
+++ b/_data/projects/orm/releases/3.3/series.yml
@@ -1,0 +1,41 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-orm/3.3/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-core
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-entitymanager
+      summary: JPA support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate-parent/3.3.2.GA/hibernate-parent-3.3.2.GA.pom
+  # - JPA: https://repo1.maven.org/maven2/org/hibernate/hibernate-entitymanager/3.3.2.GA/hibernate-entitymanager-3.3.2.GA.pom
+  java:
+    version: '1.4'
+  java_ee_jpa:
+    version: '1.0'
+  java_ee:
+    version: '5'

--- a/_data/projects/orm/releases/3.3/series.yml
+++ b/_data/projects/orm/releases/3.3/series.yml
@@ -27,8 +27,7 @@ maven:
       summary: Core implementation
     - artifact_id: hibernate-entitymanager
       summary: JPA support
-    - artifact_id: hibernate-envers
-      summary: Envers audit support
+    # Note: hibernate-envers did not exist in 3.3; it was first released in 3.5
 integration_constraints:
   # Integration constraints sourced from Maven Central:
   # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate-parent/3.3.2.GA/hibernate-parent-3.3.2.GA.pom

--- a/_data/projects/orm/releases/3.5/3.5.0-Beta-2.yml
+++ b/_data/projects/orm/releases/3.5/3.5.0-Beta-2.yml
@@ -1,0 +1,2 @@
+date: 2009-11-02
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.0-Beta-2/pom

--- a/_data/projects/orm/releases/3.5/3.5.0-Beta-3.yml
+++ b/_data/projects/orm/releases/3.5/3.5.0-Beta-3.yml
@@ -1,0 +1,2 @@
+date: 2010-01-14
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.0-Beta-3/pom

--- a/_data/projects/orm/releases/3.5/3.5.0-Beta-4.yml
+++ b/_data/projects/orm/releases/3.5/3.5.0-Beta-4.yml
@@ -1,0 +1,2 @@
+date: 2010-01-29
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.0-Beta-4/pom

--- a/_data/projects/orm/releases/3.5/3.5.0-CR-1.yml
+++ b/_data/projects/orm/releases/3.5/3.5.0-CR-1.yml
@@ -1,0 +1,2 @@
+date: 2010-02-10
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.0-CR-1/pom

--- a/_data/projects/orm/releases/3.5/3.5.0-CR-2.yml
+++ b/_data/projects/orm/releases/3.5/3.5.0-CR-2.yml
@@ -1,0 +1,2 @@
+date: 2010-02-25
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.0-CR-2/pom

--- a/_data/projects/orm/releases/3.5/3.5.0-Final.yml
+++ b/_data/projects/orm/releases/3.5/3.5.0-Final.yml
@@ -1,0 +1,2 @@
+date: 2010-03-31
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.0-Final/pom

--- a/_data/projects/orm/releases/3.5/3.5.0.Beta-1.yml
+++ b/_data/projects/orm/releases/3.5/3.5.0.Beta-1.yml
@@ -1,0 +1,2 @@
+date: 2009-08-20
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.0.Beta-1/pom

--- a/_data/projects/orm/releases/3.5/3.5.1-Final.yml
+++ b/_data/projects/orm/releases/3.5/3.5.1-Final.yml
@@ -1,0 +1,2 @@
+date: 2010-04-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.1-Final/pom

--- a/_data/projects/orm/releases/3.5/3.5.2-Final.yml
+++ b/_data/projects/orm/releases/3.5/3.5.2-Final.yml
@@ -1,0 +1,2 @@
+date: 2010-05-13
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.2-Final/pom

--- a/_data/projects/orm/releases/3.5/3.5.3-Final.yml
+++ b/_data/projects/orm/releases/3.5/3.5.3-Final.yml
@@ -1,0 +1,2 @@
+date: 2010-06-17
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.3-Final/pom

--- a/_data/projects/orm/releases/3.5/3.5.4-Final.yml
+++ b/_data/projects/orm/releases/3.5/3.5.4-Final.yml
@@ -1,0 +1,2 @@
+date: 2010-07-21
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.4-Final/pom

--- a/_data/projects/orm/releases/3.5/3.5.5-Final.yml
+++ b/_data/projects/orm/releases/3.5/3.5.5-Final.yml
@@ -1,0 +1,2 @@
+date: 2010-08-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.5-Final/pom

--- a/_data/projects/orm/releases/3.5/3.5.6-Final.yml
+++ b/_data/projects/orm/releases/3.5/3.5.6-Final.yml
@@ -1,0 +1,2 @@
+date: 2010-09-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.5.6-Final/pom

--- a/_data/projects/orm/releases/3.5/series.yml
+++ b/_data/projects/orm/releases/3.5/series.yml
@@ -1,0 +1,41 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-orm/3.5/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-core
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-entitymanager
+      summary: JPA support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate-parent/3.5.6-Final/hibernate-parent-3.5.6-Final.pom
+  # - JPA: https://repo1.maven.org/maven2/org/hibernate/hibernate-entitymanager/3.5.6-Final/hibernate-entitymanager-3.5.6-Final.pom
+  java:
+    version: '1.4'
+  java_ee_jpa:
+    version: '2.0'
+  java_ee:
+    version: '6'

--- a/_data/projects/orm/releases/3.6/3.6.0.Beta1.yml
+++ b/_data/projects/orm/releases/3.6/3.6.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2010-07-21
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.0.Beta1/pom

--- a/_data/projects/orm/releases/3.6/3.6.0.Beta2.yml
+++ b/_data/projects/orm/releases/3.6/3.6.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2010-08-04
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.0.Beta2/pom

--- a/_data/projects/orm/releases/3.6/3.6.0.Beta3.yml
+++ b/_data/projects/orm/releases/3.6/3.6.0.Beta3.yml
@@ -1,0 +1,2 @@
+date: 2010-08-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.0.Beta3/pom

--- a/_data/projects/orm/releases/3.6/3.6.0.Beta4.yml
+++ b/_data/projects/orm/releases/3.6/3.6.0.Beta4.yml
@@ -1,0 +1,2 @@
+date: 2010-09-01
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.0.Beta4/pom

--- a/_data/projects/orm/releases/3.6/3.6.0.CR1.yml
+++ b/_data/projects/orm/releases/3.6/3.6.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2010-09-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.0.CR1/pom

--- a/_data/projects/orm/releases/3.6/3.6.0.CR2.yml
+++ b/_data/projects/orm/releases/3.6/3.6.0.CR2.yml
@@ -1,0 +1,2 @@
+date: 2010-09-29
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.0.CR2/pom

--- a/_data/projects/orm/releases/3.6/3.6.0.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2010-10-14
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.0.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.1.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.1.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-02-03
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.1.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.10.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.10.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-02-09
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.10.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.2.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.2.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-03-10
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.2.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.3.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.3.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-04-06
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.3.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.4.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.4.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-05-04
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.4.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.5.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.5.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-06-09
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.5.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.6.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.6.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-07-21
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.6.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.7.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.7.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-08-17
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.7.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.8.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.8.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-10-27
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.8.Final/pom

--- a/_data/projects/orm/releases/3.6/3.6.9.Final.yml
+++ b/_data/projects/orm/releases/3.6/3.6.9.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-12-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/3.6.9.Final/pom

--- a/_data/projects/orm/releases/3.6/series.yml
+++ b/_data/projects/orm/releases/3.6/series.yml
@@ -1,0 +1,41 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-orm/3.6/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-core
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-entitymanager
+      summary: JPA support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate-parent/3.6.10.Final/hibernate-parent-3.6.10.Final.pom
+  # - JPA: https://repo1.maven.org/maven2/org/hibernate/hibernate-entitymanager/3.6.10.Final/hibernate-entitymanager-3.6.10.Final.pom
+  java:
+    version: '1.5'
+  java_ee_jpa:
+    version: '2.0'
+  java_ee:
+    version: '6'

--- a/_data/projects/orm/releases/4.0/4.0.0.Alpha1.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Alpha1.yml
@@ -1,2 +1,6 @@
 date: 2011-03-10
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Alpha1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.Alpha1/hibernate-4.0.0.Alpha1-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.Alpha1.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Alpha1.yml
@@ -1,0 +1,2 @@
+date: 2011-03-10
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Alpha1/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.Alpha2.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Alpha2.yml
@@ -1,2 +1,6 @@
 date: 2011-04-06
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Alpha2/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.Alpha2/hibernate-4.0.0.Alpha2-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.Alpha2.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Alpha2.yml
@@ -1,0 +1,2 @@
+date: 2011-04-06
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Alpha2/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.Alpha3.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Alpha3.yml
@@ -1,0 +1,2 @@
+date: 2011-05-05
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Alpha3/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.Alpha3.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Alpha3.yml
@@ -1,2 +1,6 @@
 date: 2011-05-05
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Alpha3/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.Alpha3/hibernate-4.0.0.Alpha3-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta1.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta1.yml
@@ -1,2 +1,6 @@
 date: 2011-06-09
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.Beta1/hibernate-4.0.0.Beta1-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta1.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2011-06-09
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta1/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta2.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2011-06-22
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta2/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta2.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta2.yml
@@ -1,2 +1,6 @@
 date: 2011-06-22
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta2/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.Beta2/hibernate-4.0.0.Beta2-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta3.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta3.yml
@@ -1,0 +1,2 @@
+date: 2011-07-07
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta3/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta3.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta3.yml
@@ -1,2 +1,6 @@
 date: 2011-07-07
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta3/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.Beta3/hibernate-4.0.0.Beta3-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta4.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta4.yml
@@ -1,2 +1,6 @@
 date: 2011-07-21
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta4/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.Beta4/hibernate-4.0.0.Beta4-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta4.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta4.yml
@@ -1,0 +1,2 @@
+date: 2011-07-21
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta4/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta5.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta5.yml
@@ -1,2 +1,6 @@
 date: 2011-08-03
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta5/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.Beta5/hibernate-4.0.0.Beta5-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.Beta5.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Beta5.yml
@@ -1,0 +1,2 @@
+date: 2011-08-03
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Beta5/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.CR1.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR1.yml
@@ -1,2 +1,6 @@
 date: 2011-08-18
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.CR1/hibernate-4.0.0.CR1-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.CR1.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2011-08-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR1/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.CR2.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR2.yml
@@ -1,2 +1,6 @@
 date: 2011-09-01
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR2/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.CR2/hibernate-4.0.0.CR2-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.CR2.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR2.yml
@@ -1,0 +1,2 @@
+date: 2011-09-01
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR2/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.CR3.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR3.yml
@@ -1,2 +1,6 @@
 date: 2011-09-15
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR3/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.CR3/hibernate-4.0.0.CR3-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.CR3.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR3.yml
@@ -1,0 +1,2 @@
+date: 2011-09-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR3/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.CR4.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR4.yml
@@ -1,0 +1,2 @@
+date: 2011-09-29
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR4/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.CR4.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR4.yml
@@ -1,2 +1,6 @@
 date: 2011-09-29
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR4/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.CR4/hibernate-4.0.0.CR4-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.CR5.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR5.yml
@@ -1,0 +1,2 @@
+date: 2011-10-27
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR5/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.CR5.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR5.yml
@@ -1,2 +1,6 @@
 date: 2011-10-27
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR5/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.CR5/hibernate-4.0.0.CR5-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.CR6.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR6.yml
@@ -1,0 +1,2 @@
+date: 2011-11-10
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR6/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.CR6.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR6.yml
@@ -1,2 +1,6 @@
 date: 2011-11-10
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR6/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.CR6/hibernate-4.0.0.CR6-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.CR7.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR7.yml
@@ -1,2 +1,6 @@
 date: 2011-12-01
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR7/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.CR7/hibernate-4.0.0.CR7-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.CR7.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.CR7.yml
@@ -1,0 +1,2 @@
+date: 2011-12-01
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.CR7/pom

--- a/_data/projects/orm/releases/4.0/4.0.0.Final.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Final.yml
@@ -1,2 +1,6 @@
 date: 2011-12-15
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.0.Final/hibernate-4.0.0.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.0.Final.yml
+++ b/_data/projects/orm/releases/4.0/4.0.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-12-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.0.Final/pom

--- a/_data/projects/orm/releases/4.0/4.0.1.Final.yml
+++ b/_data/projects/orm/releases/4.0/4.0.1.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-01-11
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.1.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.0.1.Final/hibernate-4.0.1.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.0/4.0.1.Final.yml
+++ b/_data/projects/orm/releases/4.0/4.0.1.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-01-11
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.0.1.Final/pom

--- a/_data/projects/orm/releases/4.0/series.yml
+++ b/_data/projects/orm/releases/4.0/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-orm/4.0/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-core
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-entitymanager
+      summary: JPA support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - JPA: https://repo1.maven.org/maven2/org/hibernate/hibernate-entitymanager/4.0.1.Final/hibernate-entitymanager-4.0.1.Final.pom
+  java_ee_jpa:
+    version: '2.0'
+  java_ee:
+    version: '6'

--- a/_data/projects/orm/releases/4.1/4.1.0.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.0.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-02-09
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.0.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.0.Final/hibernate-4.1.0.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.0.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-02-09
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.0.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.1.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.1.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-03-08
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.1.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.1.Final/hibernate-4.1.1.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.1.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.1.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-03-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.1.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.10.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.10.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-02-20
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.10.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.10.Final/hibernate-4.1.10.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.10.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.10.Final.yml
@@ -1,0 +1,2 @@
+date: 2013-02-20
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.10.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.11.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.11.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-03-18
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.11.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.11.Final/hibernate-4.1.11.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.11.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.11.Final.yml
@@ -1,0 +1,2 @@
+date: 2013-03-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.11.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.12.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.12.Final.yml
@@ -1,0 +1,2 @@
+date: 2013-04-25
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.12.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.12.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.12.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-04-25
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.12.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.12.Final/hibernate-4.1.12.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.2.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.2.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-04-05
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.2.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.2.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.2.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-04-05
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.2.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.2.Final/hibernate-4.1.2.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.2.yml
+++ b/_data/projects/orm/releases/4.1/4.1.2.yml
@@ -1,0 +1,2 @@
+date: 2012-04-04
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.2/pom

--- a/_data/projects/orm/releases/4.1/4.1.3.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.3.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-05-03
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.3.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.3.Final/hibernate-4.1.3.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.3.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.3.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-05-03
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.3.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.4.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.4.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-05-31
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.4.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.4.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.4.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-05-31
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.4.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.4.Final/hibernate-4.1.4.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.5.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.5.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-07-12
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.5.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.5.Final/hibernate-4.1.5.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.5.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.5.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-07-12
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.5.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.5.SP1.yml
+++ b/_data/projects/orm/releases/4.1/4.1.5.SP1.yml
@@ -1,0 +1,2 @@
+date: 2012-07-12
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.5.SP1/pom

--- a/_data/projects/orm/releases/4.1/4.1.5.SP1.yml
+++ b/_data/projects/orm/releases/4.1/4.1.5.SP1.yml
@@ -1,2 +1,6 @@
 date: 2012-07-12
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.5.SP1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.5.SP1/hibernate-4.1.5.SP1-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.6.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.6.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-08-08
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.6.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.6.Final/hibernate-4.1.6.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.6.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.6.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-08-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.6.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.7.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.7.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-09-06
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.7.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.7.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.7.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-09-06
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.7.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.7.Final/hibernate-4.1.7.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.8.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.8.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-11-01
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.8.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.8.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.8.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-11-01
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.8.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.8.Final/hibernate-4.1.8.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/4.1.9.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.9.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-12-13
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.9.Final/pom

--- a/_data/projects/orm/releases/4.1/4.1.9.Final.yml
+++ b/_data/projects/orm/releases/4.1/4.1.9.Final.yml
@@ -1,2 +1,6 @@
 date: 2012-12-13
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-core/4.1.9.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.1.9.Final/hibernate-4.1.9.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.1/series.yml
+++ b/_data/projects/orm/releases/4.1/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-orm/4.1/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-core
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-core
+      summary: Core implementation
+    - artifact_id: hibernate-entitymanager
+      summary: JPA support
+    - artifact_id: hibernate-envers
+      summary: Envers audit support
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - JPA: https://repo1.maven.org/maven2/org/hibernate/hibernate-entitymanager/4.1.12.Final/hibernate-entitymanager-4.1.12.Final.pom
+  java_ee_jpa:
+    version: '2.0'
+  java_ee:
+    version: '6'

--- a/_data/projects/orm/releases/4.2/4.2.0.CR1.yml
+++ b/_data/projects/orm/releases/4.2/4.2.0.CR1.yml
@@ -1,2 +1,6 @@
 date: 2013-02-01
 announcement_url: https://in.relation.to/2013/02/01/hibernate-orm-420-cr-1-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.0.CR1/hibernate-4.2.0.CR1-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.0.CR2.yml
+++ b/_data/projects/orm/releases/4.2/4.2.0.CR2.yml
@@ -1,2 +1,6 @@
 date: 2013-03-02
 announcement_url: https://in.relation.to/2013/03/02/hibernate-orm-420-cr-2-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.0.CR2/hibernate-4.2.0.CR2-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.0.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.0.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-03-18
 announcement_url: https://in.relation.to/2013/03/18/hibernate-orm-420-final-and-4111-final-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.0.Final/hibernate-4.2.0.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.1.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.1.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-04-25
 announcement_url: https://in.relation.to/2013/04/25/hibernate-orm-421-final-and-4112-final-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.1.Final/hibernate-4.2.1.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.10.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.10.Final.yml
@@ -1,2 +1,6 @@
 date: 2014-03-03
 announcement_url: https://in.relation.to/Bloggers/HibernateORM434Final4210FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.10.Final/hibernate-4.2.10.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.11.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.11.Final.yml
@@ -1,2 +1,6 @@
 date: 2014-03-17
 announcement_url: https://in.relation.to/Bloggers/HibernateORM4211FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.11.Final/hibernate-4.2.11.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.12.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.12.Final.yml
@@ -1,2 +1,6 @@
 date: 2014-04-08
 announcement_url: https://in.relation.to/Bloggers/HibernateORM4212FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.12.Final/hibernate-4.2.12.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.13.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.13.Final.yml
@@ -1,2 +1,6 @@
 date: 2014-05-28
 announcement_url: https://in.relation.to/Bloggers/HibernateORM4213FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.13.Final/hibernate-4.2.13.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.14.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.14.Final.yml
@@ -1,2 +1,6 @@
 date: 2014-06-25
 announcement_url: https://in.relation.to/Bloggers/HibernateORM4214FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.14.Final/hibernate-4.2.14.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.15.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.15.Final.yml
@@ -1,2 +1,6 @@
 date: 2014-07-16
 announcement_url: https://in.relation.to/Bloggers/HibernateORM436FinalAnd4215FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.15.Final/hibernate-4.2.15.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.16.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.16.Final.yml
@@ -1,2 +1,6 @@
 date: 2014-10-30
 announcement_url: https://in.relation.to/Bloggers/HibernateORM437FinalAnd4216FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.16.Final/hibernate-4.2.16.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.17.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.17.Final.yml
@@ -1,2 +1,6 @@
 date: 2015-01-05
 announcement_url: https://in.relation.to/Bloggers/HibernateORM438FinalAnd4217FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.17.Final/hibernate-4.2.17.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.19.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.19.Final.yml
@@ -1,3 +1,7 @@
 date: 2015-04-15
 sourceforge_url: http://sourceforge.net/projects/hibernate/files/hibernate4/
 announcement_url: https://in.relation.to/Bloggers/HibernateORM439Final4218FinalAnd4219FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.19.Final/hibernate-4.2.19.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.2.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.2.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-05-22
 announcement_url: https://in.relation.to/2013/05/22/hibernate-orm-422-final-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.2.Final/hibernate-4.2.2.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.20.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.20.Final.yml
@@ -1,3 +1,7 @@
 date: 2015-07-24
 sourceforge_url: http://sourceforge.net/projects/hibernate/files/hibernate4/
 announcement_url: https://in.relation.to/2015/08/07/hibernate-orm-4220-final-and-4311-final-released
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.20.Final/hibernate-4.2.20.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.21.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.21.Final.yml
@@ -1,3 +1,7 @@
 date: 2015-10-23
 sourceforge_url: http://sourceforge.net/projects/hibernate/files/hibernate4/
 announcement_url: https://in.relation.to/2015/10/23/hibernate-orm-4221-final-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.21.Final/hibernate-4.2.21.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.3.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.3.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-07-03
 announcement_url: https://in.relation.to/2013/07/03/hibernate-orm-423-final-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.3.Final/hibernate-4.2.3.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.4.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.4.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-08-08
 announcement_url: https://in.relation.to/2013/08/08/hibernate-orm-424-final-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.4.Final/hibernate-4.2.4.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.5.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.5.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-08-28
 announcement_url: https://in.relation.to/2013/08/28/hibernate-orm-425-final-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.5.Final/hibernate-4.2.5.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.6.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.6.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-09-25
 announcement_url: https://in.relation.to/2013/09/25/hibernate-orm-426-final-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.6.Final/hibernate-4.2.6.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.7.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.7.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-10-23
 announcement_url: https://in.relation.to/2013/10/23/hibernate-orm-427-final-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.7.Final/hibernate-4.2.7.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.7.SP1.yml
+++ b/_data/projects/orm/releases/4.2/4.2.7.SP1.yml
@@ -1,2 +1,6 @@
 date: 2013-10-23
 announcement_url: https://in.relation.to/2013/10/23/hibernate-orm-427-sp-1-released/
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.7.SP1/hibernate-4.2.7.SP1-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.8.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.8.Final.yml
@@ -1,2 +1,6 @@
 date: 2013-12-04
 announcement_url: https://in.relation.to/Bloggers/HibernateORM428FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.8.Final/hibernate-4.2.8.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/4.2.9.Final.yml
+++ b/_data/projects/orm/releases/4.2/4.2.9.Final.yml
@@ -1,2 +1,6 @@
 date: 2014-02-26
 announcement_url: https://in.relation.to/Bloggers/HibernateORM429FinalReleased
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.2.9.Final/hibernate-4.2.9.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.2/series.yml
+++ b/_data/projects/orm/releases/4.2/series.yml
@@ -1,4 +1,3 @@
-summary: JPA 2.0
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/4.2/lgpl.txt
@@ -44,3 +43,5 @@ integration_constraints:
       - '7'
   java_ee_jpa:
     version: '2.0'
+  java_ee:
+    version: '6'  # Derived from JPA 2.0 → Java EE 6

--- a/_data/projects/orm/releases/4.3/4.3.0.Beta1.yml
+++ b/_data/projects/orm/releases/4.3/4.3.0.Beta1.yml
@@ -1,3 +1,6 @@
 date: 2013-04-03
 announcement_url: https://in.relation.to/2013/04/03/hibernate-orm-430-beta-1-release/
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.0.Beta1/hibernate-4.3.0.Beta1-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.0.Beta2.yml
+++ b/_data/projects/orm/releases/4.3/4.3.0.Beta2.yml
@@ -1,3 +1,6 @@
 date: 2013-05-02
 announcement_url: https://in.relation.to/2013/05/02/hibernate-orm-430-beta-2-released/
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.0.Beta2/hibernate-4.3.0.Beta2-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.0.Beta3.yml
+++ b/_data/projects/orm/releases/4.3/4.3.0.Beta3.yml
@@ -1,3 +1,6 @@
 date: 2013-05-29
 announcement_url: https://in.relation.to/2013/05/29/hibernate-orm-430-beta-3-release/
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.0.Beta3/hibernate-4.3.0.Beta3-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.0.Beta4.yml
+++ b/_data/projects/orm/releases/4.3/4.3.0.Beta4.yml
@@ -1,3 +1,6 @@
 date: 2013-09-12
 announcement_url: https://in.relation.to/2013/09/12/hibernate-orm-430-beta-4-release/
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.0.Beta4/hibernate-4.3.0.Beta4-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.0.Beta5.yml
+++ b/_data/projects/orm/releases/4.3/4.3.0.Beta5.yml
@@ -1,3 +1,6 @@
 date: 2013-10-09
 announcement_url: https://in.relation.to/2013/10/09/hibernate-orm-430-beta-5-release/
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.0.Beta5/hibernate-4.3.0.Beta5-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.0.CR1.yml
+++ b/_data/projects/orm/releases/4.3/4.3.0.CR1.yml
@@ -1,3 +1,6 @@
 date: 2013-11-20
 announcement_url: https://in.relation.to/2013/11/20/hibernate-orm-430-cr-1-release/
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.0.CR1/hibernate-4.3.0.CR1-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.0.CR2.yml
+++ b/_data/projects/orm/releases/4.3/4.3.0.CR2.yml
@@ -1,3 +1,6 @@
 date: 2013-12-05
 announcement_url: https://in.relation.to/2013/12/05/hibernate-orm-430-cr-2-release/
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.0.CR2/hibernate-4.3.0.CR2-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.0.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.0.Final.yml
@@ -1,3 +1,6 @@
 date: 2013-12-16
 announcement_url: https://in.relation.to/2013/12/16/hibernate-orm-430-final-release/
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.0.Final/hibernate-4.3.0.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.1.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.1.Final.yml
@@ -1,3 +1,6 @@
 date: 2014-01-22
 announcement_url: https://in.relation.to/Bloggers/HibernateORM431FinalRelease
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.1.Final/hibernate-4.3.1.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.10.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.10.Final.yml
@@ -1,4 +1,7 @@
 date: 2015-05-14
 sourceforge_url: http://sourceforge.net/projects/hibernate/files/hibernate4/
 announcement_url: https://in.relation.to/Bloggers/HibernateORM4310FinalReleased
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.10.Final/hibernate-4.3.10.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.11.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.11.Final.yml
@@ -1,4 +1,7 @@
 date: 2015-08-05
 sourceforge_url: http://sourceforge.net/projects/hibernate/files/hibernate4/
 announcement_url: https://in.relation.to/2015/08/07/hibernate-orm-4220-final-and-4311-final-released
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.11.Final/hibernate-4.3.11.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.2.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.2.Final.yml
@@ -1,3 +1,6 @@
 date: 2014-02-27
 announcement_url: https://in.relation.to/Bloggers/HibernateORM432FinalReleased
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.2.Final/hibernate-4.3.2.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.4.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.4.Final.yml
@@ -1,3 +1,6 @@
 date: 2014-03-03
 announcement_url: https://in.relation.to/Bloggers/HibernateORM434Final4210FinalReleased
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.4.Final/hibernate-4.3.4.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.5.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.5.Final.yml
@@ -1,3 +1,6 @@
 date: 2014-04-02
 announcement_url: https://in.relation.to/Bloggers/HibernateORM435FinalReleased
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.5.Final/hibernate-4.3.5.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.6.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.6.Final.yml
@@ -1,3 +1,6 @@
 date: 2014-07-016
 announcement_url:  https://in.relation.to/Bloggers/HibernateORM436FinalAnd4215FinalReleased
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.6.Final/hibernate-4.3.6.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.7.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.7.Final.yml
@@ -1,3 +1,6 @@
 date: 2014-10-30
 announcement_url:  https://in.relation.to/Bloggers/HibernateORM437FinalAnd4216FinalReleased
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.7.Final/hibernate-4.3.7.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.8.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.8.Final.yml
@@ -1,3 +1,6 @@
 date: 2015-01-06
 announcement_url:  https://in.relation.to/Bloggers/HibernateORM438FinalAnd4217FinalReleased
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.8.Final/hibernate-4.3.8.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/4.3.9.Final.yml
+++ b/_data/projects/orm/releases/4.3/4.3.9.Final.yml
@@ -1,4 +1,7 @@
 date: 2015-04-15
 sourceforge_url: http://sourceforge.net/projects/hibernate/files/hibernate4/
 announcement_url: https://in.relation.to/Bloggers/HibernateORM439Final4218FinalAnd4219FinalReleased
-
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate4/4.3.9.Final/hibernate-4.3.9.Final-dist.zip/download

--- a/_data/projects/orm/releases/4.3/series.yml
+++ b/_data/projects/orm/releases/4.3/series.yml
@@ -1,4 +1,3 @@
-summary: JPA 2.1 support
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/4.3/lgpl.txt
@@ -45,3 +44,5 @@ integration_constraints:
       - '7'
   java_ee_jpa:
     version: '2.1'
+  java_ee:
+    version: '7'  # Derived from JPA 2.1 → Java EE 7

--- a/_data/projects/orm/releases/5.0/series.yml
+++ b/_data/projects/orm/releases/5.0/series.yml
@@ -1,4 +1,3 @@
-summary: Improved bootstrapping, hibernate-java8, hibernate-spatial, Karaf support
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/5.0/lgpl.txt
@@ -49,5 +48,7 @@ integration_constraints:
       - '8'
   java_ee_jpa:
     version: '2.1'
+  java_ee:
+    version: '7'  # Derived from JPA 2.1 → Java EE 7
   spring_boot:
     version: '1.5'

--- a/_data/projects/orm/releases/5.1/series.yml
+++ b/_data/projects/orm/releases/5.1/series.yml
@@ -1,4 +1,3 @@
-summary: Entity joins, load-by-multiple-ids, association traversal in AuditQuery
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/5.1/lgpl.txt
@@ -49,6 +48,8 @@ integration_constraints:
       - value: 8
   java_ee_jpa:
     version: '2.1'
+  java_ee:
+    version: '7'  # Derived from JPA 2.1 → Java EE 7
   wildfly:
     version:
       - '12'

--- a/_data/projects/orm/releases/5.2/series.yml
+++ b/_data/projects/orm/releases/5.2/series.yml
@@ -1,4 +1,3 @@
-summary: Java 8, JCache support, hibernate-entitymanager consolidation
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/5.2/lgpl.txt
@@ -40,6 +39,8 @@ integration_constraints:
     version: '8'
   java_ee_jpa:
     version: '2.1'
+  java_ee:
+    version: '7'  # Derived from JPA 2.1 → Java EE 7
   spring_boot:
     version: '2.0'
 

--- a/_data/projects/orm/releases/5.5/series.yml
+++ b/_data/projects/orm/releases/5.5/series.yml
@@ -44,13 +44,23 @@ integration_constraints:
       - '11'
       - '17'
   java_ee_jpa:
-    version: '2.2'
+    version:
+      value: '2.2'
+      comment: main artifacts
   jakarta_ee_jpa:
-    version: '3.0'
+    version:
+      value: '3.0'
+      comment: >-
+        https://in.relation.to/2021/06/02/hibernate-orm-550-final-release/[through `*-jakarta` artifacts]
   java_ee:
-    version: '8'
+    version:
+      value: '8'
+      comment: main artifacts
   jakarta_ee:
-    version: '9'
+    version:
+      value: '9'
+      comment: >-
+        https://in.relation.to/2021/06/02/hibernate-orm-550-final-release/[through `*-jakarta` artifacts]
   quarkus:
     version:
       from: '2.0'

--- a/_data/projects/orm/releases/5.6/series.yml
+++ b/_data/projects/orm/releases/5.6/series.yml
@@ -43,11 +43,23 @@ integration_constraints:
       - '17'
       - '18'
   java_ee_jpa:
-    version: '2.2'
+    version:
+      value: '2.2'
+      comment: main artifacts
   jakarta_ee_jpa:
-    version: '3.0'
+    version:
+      value: '3.0'
+      comment: >-
+        https://in.relation.to/2021/06/02/hibernate-orm-550-final-release/[through `*-jakarta` artifacts]
+  java_ee:
+    version:
+      value: '8'
+      comment: main artifacts
   jakarta_ee:
-    version: '9'
+    version:
+      value: '9'
+      comment: >-
+        https://in.relation.to/2021/06/02/hibernate-orm-550-final-release/[through `*-jakarta` artifacts]
   quarkus:
     version:
       from: '2.3'

--- a/_data/projects/search/releases/3.0/3.0.0.Beta1.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2007-03-19
+# Source: Hibernate Search changelog.txt in git repository

--- a/_data/projects/search/releases/3.0/3.0.0.Beta1.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.Beta1.yml
@@ -1,2 +1,6 @@
 date: 2007-03-19
 # Source: Hibernate Search changelog.txt in git repository
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.0.0.Beta1/hibernate-search-3.0.0.Beta1-dist.zip/download

--- a/_data/projects/search/releases/3.0/3.0.0.Beta2.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2007-05-31
+# Source: Hibernate Search changelog.txt in git repository

--- a/_data/projects/search/releases/3.0/3.0.0.Beta2.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.Beta2.yml
@@ -1,2 +1,6 @@
 date: 2007-05-31
 # Source: Hibernate Search changelog.txt in git repository
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.0.0.Beta2/hibernate-search-3.0.0.Beta2-dist.zip/download

--- a/_data/projects/search/releases/3.0/3.0.0.Beta3.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.Beta3.yml
@@ -1,0 +1,2 @@
+date: 2007-06-06
+# Source: Hibernate Search changelog.txt in git repository

--- a/_data/projects/search/releases/3.0/3.0.0.Beta3.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.Beta3.yml
@@ -1,2 +1,6 @@
 date: 2007-06-06
 # Source: Hibernate Search changelog.txt in git repository
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.0.0.Beta3/hibernate-search-3.0.0.Beta3-dist.zip/download

--- a/_data/projects/search/releases/3.0/3.0.0.Beta4.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.Beta4.yml
@@ -1,0 +1,2 @@
+date: 2007-08-01
+# Source: Hibernate Search changelog.txt in git repository

--- a/_data/projects/search/releases/3.0/3.0.0.Beta4.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.Beta4.yml
@@ -1,2 +1,6 @@
 date: 2007-08-01
 # Source: Hibernate Search changelog.txt in git repository
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.0.0.Beta4/hibernate-search-3.0.0.Beta4-dist.zip/download

--- a/_data/projects/search/releases/3.0/3.0.0.CR1.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.CR1.yml
@@ -1,2 +1,6 @@
 date: 2007-09-06
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.0.0.CR1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.0.0.CR1/hibernate-search-3.0.0.CR1-dist.zip/download

--- a/_data/projects/search/releases/3.0/3.0.0.CR1.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2007-09-06
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.0.0.CR1/pom

--- a/_data/projects/search/releases/3.0/3.0.0.GA.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.GA.yml
@@ -1,2 +1,6 @@
 date: 2007-09-28
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.0.0.GA/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.0.0.GA/hibernate-search-3.0.0.GA-dist.zip/download

--- a/_data/projects/search/releases/3.0/3.0.0.GA.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.GA.yml
@@ -1,0 +1,2 @@
+date: 2007-09-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.0.0.GA/pom

--- a/_data/projects/search/releases/3.0/3.0.0.cr1.yml
+++ b/_data/projects/search/releases/3.0/3.0.0.cr1.yml
@@ -1,0 +1,2 @@
+date: 2007-09-17
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.0.0.cr1/pom

--- a/_data/projects/search/releases/3.0/3.0.1.GA.yml
+++ b/_data/projects/search/releases/3.0/3.0.1.GA.yml
@@ -1,0 +1,2 @@
+date: 2008-02-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.0.1.GA/pom

--- a/_data/projects/search/releases/3.0/3.0.1.GA.yml
+++ b/_data/projects/search/releases/3.0/3.0.1.GA.yml
@@ -1,2 +1,6 @@
 date: 2008-02-28
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.0.1.GA/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.0.1.GA/hibernate-search-3.0.1.GA-dist.zip/download

--- a/_data/projects/search/releases/3.0/series.yml
+++ b/_data/projects/search/releases/3.0/series.yml
@@ -17,6 +17,9 @@ links:
   short_guide:
   # Note: Very old series - no documentation links available
     displayed: false
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/3.0/series.yml
+++ b/_data/projects/search/releases/3.0/series.yml
@@ -1,0 +1,36 @@
+license:
+  name: LGPL v2.1
+  # Note: 3.0 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-search
+    artifact_id_pattern: hibernate-search-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-search
+      summary: Full-text search for Hibernate
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - ORM: https://repo1.maven.org/maven2/org/hibernate/hibernate-search/
+  # - Check dependencies on org.hibernate:hibernate-core
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-search/3.0.1.GA/hibernate-search-3.0.1.GA.pom
+  lucene:
+    version: '2.3'

--- a/_data/projects/search/releases/3.0/series.yml
+++ b/_data/projects/search/releases/3.0/series.yml
@@ -1,6 +1,6 @@
 license:
   name: LGPL v2.1
-  # Note: 3.0 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate-search/3.2/lgpl.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/search/releases/3.1/3.1.0.Beta1.yml
+++ b/_data/projects/search/releases/3.1/3.1.0.Beta1.yml
@@ -1,2 +1,6 @@
 date: 2008-07-18
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.0.Beta1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.1.0.Beta1/hibernate-search-3.1.0.Beta1-dist.zip/download

--- a/_data/projects/search/releases/3.1/3.1.0.Beta1.yml
+++ b/_data/projects/search/releases/3.1/3.1.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2008-07-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.0.Beta1/pom

--- a/_data/projects/search/releases/3.1/3.1.0.Beta2.yml
+++ b/_data/projects/search/releases/3.1/3.1.0.Beta2.yml
@@ -1,2 +1,6 @@
 date: 2008-10-27
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.0.Beta2/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.1.0.Beta2/hibernate-search-3.1.0.Beta2-dist.zip/download

--- a/_data/projects/search/releases/3.1/3.1.0.Beta2.yml
+++ b/_data/projects/search/releases/3.1/3.1.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2008-10-27
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.0.Beta2/pom

--- a/_data/projects/search/releases/3.1/3.1.0.CR1.yml
+++ b/_data/projects/search/releases/3.1/3.1.0.CR1.yml
@@ -1,2 +1,6 @@
 date: 2008-11-17
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.0.CR1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.1.0.CR1/hibernate-search-3.1.0.CR1-dist.zip/download

--- a/_data/projects/search/releases/3.1/3.1.0.CR1.yml
+++ b/_data/projects/search/releases/3.1/3.1.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2008-11-17
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.0.CR1/pom

--- a/_data/projects/search/releases/3.1/3.1.0.GA.yml
+++ b/_data/projects/search/releases/3.1/3.1.0.GA.yml
@@ -1,0 +1,2 @@
+date: 2008-12-04
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.0.GA/pom

--- a/_data/projects/search/releases/3.1/3.1.0.GA.yml
+++ b/_data/projects/search/releases/3.1/3.1.0.GA.yml
@@ -1,2 +1,6 @@
 date: 2008-12-04
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.0.GA/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.1.0.GA/hibernate-search-3.1.0.GA-dist.zip/download

--- a/_data/projects/search/releases/3.1/3.1.1.GA.yml
+++ b/_data/projects/search/releases/3.1/3.1.1.GA.yml
@@ -1,2 +1,6 @@
 date: 2009-05-28
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.1.GA/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.1.1.GA/hibernate-search-3.1.1.GA-dist.zip/download

--- a/_data/projects/search/releases/3.1/3.1.1.GA.yml
+++ b/_data/projects/search/releases/3.1/3.1.1.GA.yml
@@ -1,0 +1,2 @@
+date: 2009-05-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.1.1.GA/pom

--- a/_data/projects/search/releases/3.1/series.yml
+++ b/_data/projects/search/releases/3.1/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  # Note: 3.1 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-search
+    artifact_id_pattern: hibernate-search-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-search
+      summary: Full-text search for Hibernate
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - ORM: https://repo1.maven.org/maven2/org/hibernate/hibernate-search/
+  # - Check dependencies on org.hibernate:hibernate-core
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-search/3.1.1.GA/hibernate-search-3.1.1.GA.pom
+  orm:
+    version: '3.3'
+  lucene:
+    version: '2.4'

--- a/_data/projects/search/releases/3.1/series.yml
+++ b/_data/projects/search/releases/3.1/series.yml
@@ -17,6 +17,9 @@ links:
   short_guide:
   # Note: Very old series - no documentation links available
     displayed: false
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/3.1/series.yml
+++ b/_data/projects/search/releases/3.1/series.yml
@@ -1,6 +1,6 @@
 license:
   name: LGPL v2.1
-  # Note: 3.1 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate-search/3.2/lgpl.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/search/releases/3.2/3.2.0.Beta1.yml
+++ b/_data/projects/search/releases/3.2/3.2.0.Beta1.yml
@@ -1,2 +1,6 @@
 date: 2009-11-30
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.2.0.Beta1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.2.0.Beta1/hibernate-search-3.2.0.Beta1-dist.zip/download

--- a/_data/projects/search/releases/3.2/3.2.0.Beta1.yml
+++ b/_data/projects/search/releases/3.2/3.2.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2009-11-30
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.2.0.Beta1/pom

--- a/_data/projects/search/releases/3.2/3.2.0.CR1.yml
+++ b/_data/projects/search/releases/3.2/3.2.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2010-04-12
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.2.0.CR1/pom

--- a/_data/projects/search/releases/3.2/3.2.0.CR1.yml
+++ b/_data/projects/search/releases/3.2/3.2.0.CR1.yml
@@ -1,2 +1,6 @@
 date: 2010-04-12
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.2.0.CR1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.2.0.CR1/hibernate-search-3.2.0.CR1-dist.zip/download

--- a/_data/projects/search/releases/3.2/3.2.0.Final.yml
+++ b/_data/projects/search/releases/3.2/3.2.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2010-05-05
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.2.0.Final/pom

--- a/_data/projects/search/releases/3.2/3.2.0.Final.yml
+++ b/_data/projects/search/releases/3.2/3.2.0.Final.yml
@@ -1,2 +1,6 @@
 date: 2010-05-05
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.2.0.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.2.0.Final/hibernate-search-3.2.0.Final-dist.zip/download

--- a/_data/projects/search/releases/3.2/3.2.1.Final.yml
+++ b/_data/projects/search/releases/3.2/3.2.1.Final.yml
@@ -1,2 +1,6 @@
 date: 2010-07-25
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.2.1.Final/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-search/3.2.1.Final/hibernate-search-3.2.1.Final-dist.zip/download

--- a/_data/projects/search/releases/3.2/3.2.1.Final.yml
+++ b/_data/projects/search/releases/3.2/3.2.1.Final.yml
@@ -1,0 +1,2 @@
+date: 2010-07-25
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.2.1.Final/pom

--- a/_data/projects/search/releases/3.2/3.2.2.Final.yml
+++ b/_data/projects/search/releases/3.2/3.2.2.Final.yml
@@ -1,0 +1,2 @@
+date: 2010-08-19
+# Source: Hibernate Search changelog.txt in git repository

--- a/_data/projects/search/releases/3.2/3.2.2.Final.yml
+++ b/_data/projects/search/releases/3.2/3.2.2.Final.yml
@@ -1,2 +1,0 @@
-date: 2010-08-19
-# Source: Hibernate Search changelog.txt in git repository

--- a/_data/projects/search/releases/3.2/series.yml
+++ b/_data/projects/search/releases/3.2/series.yml
@@ -17,6 +17,9 @@ links:
   short_guide:
   # Note: Very old series - no documentation links available
     displayed: false
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/search/releases/3.2/series.yml
+++ b/_data/projects/search/releases/3.2/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-search/3.2/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-search
+    artifact_id_pattern: hibernate-search-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-search
+      summary: Full-text search for Hibernate
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - ORM: https://repo1.maven.org/maven2/org/hibernate/hibernate-search/
+  # - Check dependencies on org.hibernate:hibernate-core
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-parent/3.2.0.Final/hibernate-search-parent-3.2.0.Final.pom
+  orm:
+    version: '3.5'
+  lucene:
+    version: '2.9'

--- a/_data/projects/search/releases/3.3/3.3.0.Alpha1.yml
+++ b/_data/projects/search/releases/3.3/3.3.0.Alpha1.yml
@@ -1,0 +1,2 @@
+date: 2010-07-26
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.3.0.Alpha1/pom

--- a/_data/projects/search/releases/3.3/3.3.0.Beta1.yml
+++ b/_data/projects/search/releases/3.3/3.3.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2010-08-24
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.3.0.Beta1/pom

--- a/_data/projects/search/releases/3.3/3.3.0.Beta2.yml
+++ b/_data/projects/search/releases/3.3/3.3.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2010-10-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.3.0.Beta2/pom

--- a/_data/projects/search/releases/3.3/3.3.0.Beta3.yml
+++ b/_data/projects/search/releases/3.3/3.3.0.Beta3.yml
@@ -1,0 +1,2 @@
+date: 2010-11-01
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.3.0.Beta3/pom

--- a/_data/projects/search/releases/3.3/3.3.0.CR1.yml
+++ b/_data/projects/search/releases/3.3/3.3.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2010-11-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.3.0.CR1/pom

--- a/_data/projects/search/releases/3.3/3.3.0.CR2.yml
+++ b/_data/projects/search/releases/3.3/3.3.0.CR2.yml
@@ -1,0 +1,2 @@
+date: 2010-12-09
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.3.0.CR2/pom

--- a/_data/projects/search/releases/3.3/3.3.0.Final.yml
+++ b/_data/projects/search/releases/3.3/3.3.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2010-12-14
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.3.0.Final/pom

--- a/_data/projects/search/releases/3.3/series.yml
+++ b/_data/projects/search/releases/3.3/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-search/3.3/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-search
+    artifact_id_pattern: hibernate-search-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-search
+      summary: Full-text search for Hibernate
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - ORM: https://repo1.maven.org/maven2/org/hibernate/hibernate-search/
+  # - Check dependencies on org.hibernate:hibernate-core
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-parent/3.3.0.Final/hibernate-search-parent-3.3.0.Final.pom
+  orm:
+    version: '3.6'
+  lucene:
+    version: '3.0'

--- a/_data/projects/search/releases/3.4/3.4.0.Alpha1.yml
+++ b/_data/projects/search/releases/3.4/3.4.0.Alpha1.yml
@@ -1,0 +1,2 @@
+date: 2011-03-07
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.4.0.Alpha1/pom

--- a/_data/projects/search/releases/3.4/3.4.0.Beta1.yml
+++ b/_data/projects/search/releases/3.4/3.4.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2011-03-21
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.4.0.Beta1/pom

--- a/_data/projects/search/releases/3.4/3.4.0.CR1.yml
+++ b/_data/projects/search/releases/3.4/3.4.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2011-03-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.4.0.CR1/pom

--- a/_data/projects/search/releases/3.4/3.4.0.CR2.yml
+++ b/_data/projects/search/releases/3.4/3.4.0.CR2.yml
@@ -1,0 +1,2 @@
+date: 2011-04-06
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.4.0.CR2/pom

--- a/_data/projects/search/releases/3.4/3.4.0.Final.yml
+++ b/_data/projects/search/releases/3.4/3.4.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-04-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.4.0.Final/pom

--- a/_data/projects/search/releases/3.4/3.4.1.Final.yml
+++ b/_data/projects/search/releases/3.4/3.4.1.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-08-25
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.4.1.Final/pom

--- a/_data/projects/search/releases/3.4/3.4.2.Final.yml
+++ b/_data/projects/search/releases/3.4/3.4.2.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-02-29
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/3.4.2.Final/pom

--- a/_data/projects/search/releases/3.4/series.yml
+++ b/_data/projects/search/releases/3.4/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-search/3.4/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-search
+    artifact_id_pattern: hibernate-search-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-search
+      summary: Full-text search for Hibernate
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - ORM: https://repo1.maven.org/maven2/org/hibernate/hibernate-search/
+  # - Check dependencies on org.hibernate:hibernate-core
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-parent/3.4.2.Final/hibernate-search-parent-3.4.2.Final.pom
+  orm:
+    version: '3.6'
+  lucene:
+    version: '3.1'

--- a/_data/projects/search/releases/4.0/4.0.0.Alpha1.yml
+++ b/_data/projects/search/releases/4.0/4.0.0.Alpha1.yml
@@ -1,0 +1,2 @@
+date: 2011-08-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/4.0.0.Alpha1/jar

--- a/_data/projects/search/releases/4.0/4.0.0.Alpha2.yml
+++ b/_data/projects/search/releases/4.0/4.0.0.Alpha2.yml
@@ -1,0 +1,2 @@
+date: 2011-09-01
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/4.0.0.Alpha2/jar

--- a/_data/projects/search/releases/4.0/4.0.0.Beta1.yml
+++ b/_data/projects/search/releases/4.0/4.0.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2011-09-14
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search/4.0.0.Beta1/jar

--- a/_data/projects/search/releases/4.0/4.0.0.Beta2.yml
+++ b/_data/projects/search/releases/4.0/4.0.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2011-09-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.0.0.Beta2/pom

--- a/_data/projects/search/releases/4.0/4.0.0.CR1.yml
+++ b/_data/projects/search/releases/4.0/4.0.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2011-10-13
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.0.0.CR1/pom

--- a/_data/projects/search/releases/4.0/4.0.0.CR2.yml
+++ b/_data/projects/search/releases/4.0/4.0.0.CR2.yml
@@ -1,0 +1,2 @@
+date: 2011-11-16
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.0.0.CR2/pom

--- a/_data/projects/search/releases/4.0/4.0.0.Final.yml
+++ b/_data/projects/search/releases/4.0/4.0.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-12-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.0.0.Final/pom

--- a/_data/projects/search/releases/4.0/series.yml
+++ b/_data/projects/search/releases/4.0/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-search/4.0/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-search-orm
+    artifact_id_pattern: hibernate-search-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-search-orm
+      summary: Hibernate ORM integration
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - ORM: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-orm/
+  # - Check dependencies on org.hibernate:hibernate-core
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-parent/4.0.0.Final/hibernate-search-parent-4.0.0.Final.pom
+  orm:
+    version: '4.0'
+  lucene:
+    version: '3.4'

--- a/_data/projects/search/releases/4.1/4.1.0.Alpha1.yml
+++ b/_data/projects/search/releases/4.1/4.1.0.Alpha1.yml
@@ -1,0 +1,2 @@
+date: 2012-01-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.1.0.Alpha1/pom

--- a/_data/projects/search/releases/4.1/4.1.0.Beta1.yml
+++ b/_data/projects/search/releases/4.1/4.1.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2012-02-02
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.1.0.Beta1/pom

--- a/_data/projects/search/releases/4.1/4.1.0.Beta2.yml
+++ b/_data/projects/search/releases/4.1/4.1.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2012-02-13
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.1.0.Beta2/pom

--- a/_data/projects/search/releases/4.1/4.1.0.CR1.yml
+++ b/_data/projects/search/releases/4.1/4.1.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2012-02-29
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.1.0.CR1/pom

--- a/_data/projects/search/releases/4.1/4.1.0.CR2.yml
+++ b/_data/projects/search/releases/4.1/4.1.0.CR2.yml
@@ -1,0 +1,2 @@
+date: 2012-03-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.1.0.CR2/pom

--- a/_data/projects/search/releases/4.1/4.1.0.CR3.yml
+++ b/_data/projects/search/releases/4.1/4.1.0.CR3.yml
@@ -1,0 +1,2 @@
+date: 2012-03-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.1.0.CR3/pom

--- a/_data/projects/search/releases/4.1/4.1.0.Final.yml
+++ b/_data/projects/search/releases/4.1/4.1.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-04-03
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.1.0.Final/pom

--- a/_data/projects/search/releases/4.1/4.1.1.Final.yml
+++ b/_data/projects/search/releases/4.1/4.1.1.Final.yml
@@ -1,0 +1,2 @@
+date: 2012-05-09
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.1.1.Final/pom

--- a/_data/projects/search/releases/4.1/series.yml
+++ b/_data/projects/search/releases/4.1/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-search/4.1/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-search-orm
+    artifact_id_pattern: hibernate-search-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-search-orm
+      summary: Hibernate ORM integration
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - ORM: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-orm/
+  # - Check dependencies on org.hibernate:hibernate-core
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-parent/4.1.1.Final/hibernate-search-parent-4.1.1.Final.pom
+  orm:
+    version: '4.1'
+  lucene:
+    version: '3.5'

--- a/_data/projects/search/releases/4.2/4.2.0.Beta1.yml
+++ b/_data/projects/search/releases/4.2/4.2.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2012-06-21
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.2.0.Beta1/pom

--- a/_data/projects/search/releases/4.2/4.2.0.Beta2.yml
+++ b/_data/projects/search/releases/4.2/4.2.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2012-10-18
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.2.0.Beta2/pom

--- a/_data/projects/search/releases/4.2/4.2.0.CR1.yml
+++ b/_data/projects/search/releases/4.2/4.2.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2013-01-02
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.2.0.CR1/pom

--- a/_data/projects/search/releases/4.2/4.2.0.Final.yml
+++ b/_data/projects/search/releases/4.2/4.2.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2013-01-15
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.2.0.Final/pom

--- a/_data/projects/search/releases/4.2/series.yml
+++ b/_data/projects/search/releases/4.2/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-search/4.2/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-search-orm
+    artifact_id_pattern: hibernate-search-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-search-orm
+      summary: Hibernate ORM integration
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - ORM: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-orm/
+  # - Check dependencies on org.hibernate:hibernate-core
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-parent/4.2.0.Final/hibernate-search-parent-4.2.0.Final.pom
+  orm:
+    version: '4.1'
+  lucene:
+    version: '3.6'

--- a/_data/projects/search/releases/4.3/4.3.0.Alpha1.yml
+++ b/_data/projects/search/releases/4.3/4.3.0.Alpha1.yml
@@ -1,0 +1,2 @@
+date: 2013-04-19
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.3.0.Alpha1/pom

--- a/_data/projects/search/releases/4.3/4.3.0.Beta1.yml
+++ b/_data/projects/search/releases/4.3/4.3.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2013-05-24
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.3.0.Beta1/pom

--- a/_data/projects/search/releases/4.3/4.3.0.CR1.yml
+++ b/_data/projects/search/releases/4.3/4.3.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2013-05-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.3.0.CR1/pom

--- a/_data/projects/search/releases/4.3/4.3.0.Final.yml
+++ b/_data/projects/search/releases/4.3/4.3.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2013-06-07
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-search-orm/4.3.0.Final/pom

--- a/_data/projects/search/releases/4.3/series.yml
+++ b/_data/projects/search/releases/4.3/series.yml
@@ -1,0 +1,38 @@
+license:
+  name: LGPL v2.1
+  url: https://raw.githubusercontent.com/hibernate/hibernate-search/4.3/lgpl.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-search-orm
+    artifact_id_pattern: hibernate-search-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-search-orm
+      summary: Hibernate ORM integration
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - ORM: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-orm/
+  # - Check dependencies on org.hibernate:hibernate-core
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-search-parent/4.3.0.Final/hibernate-search-parent-4.3.0.Final.pom
+  orm:
+    version: '4.2'
+  lucene:
+    version: '3.6'

--- a/_data/projects/search/releases/4.4/series.yml
+++ b/_data/projects/search/releases/4.4/series.yml
@@ -22,10 +22,7 @@ maven:
   artifacts:
     - artifact_id: hibernate-search-orm
       summary: Hibernate ORM integration
-    - artifact_id: hibernate-search-backend-jgroups
-      summary: JGroups backend
-    - artifact_id: hibernate-search-backend-jms
-      summary: JMS backend
+    # Note: backend artifacts (jgroups, jms) did not exist in 4.4; they were first released in 5.0
     - artifact_id: hibernate-search-analyzers
       summary: Analyzer dependencies from Lucene/Solr
 integration_constraints:

--- a/_data/projects/search/releases/4.5/series.yml
+++ b/_data/projects/search/releases/4.5/series.yml
@@ -22,10 +22,7 @@ maven:
   artifacts:
     - artifact_id: hibernate-search-orm
       summary: Hibernate ORM integration
-    - artifact_id: hibernate-search-backend-jgroups
-      summary: JGroups backend
-    - artifact_id: hibernate-search-backend-jms
-      summary: JMS backend
+    # Note: backend artifacts (jgroups, jms) did not exist in 4.5; they were first released in 5.0
     - artifact_id: hibernate-search-analyzers
       summary: Analyzer dependencies from Lucene/Solr
 integration_constraints:

--- a/_data/projects/search/releases/6.1/series.yml
+++ b/_data/projects/search/releases/6.1/series.yml
@@ -53,7 +53,7 @@ integration_constraints:
   orm:
     version:
       - value: 5.6
-        comment: in the main artifacts
+        comment: main artifacts
       - from: 6.0
         to: '6.2'
         comment: >-

--- a/_data/projects/search/releases/6.2/series.yml
+++ b/_data/projects/search/releases/6.2/series.yml
@@ -50,7 +50,7 @@ integration_constraints:
   orm:
     version:
       - value: 5.6
-        comment: in the main artifacts
+        comment: main artifacts
       - from: 6.2
         to: '6.3'
         comment: >-

--- a/_data/projects/validator/releases/3.0/3.0.0.GA.yml
+++ b/_data/projects/validator/releases/3.0/3.0.0.GA.yml
@@ -1,0 +1,2 @@
+date: 2007-09-21
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/3.0.0.GA/pom

--- a/_data/projects/validator/releases/3.0/3.0.0.ga.yml
+++ b/_data/projects/validator/releases/3.0/3.0.0.ga.yml
@@ -1,2 +1,6 @@
 date: 2007-05-29
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/3.0.0.ga/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/3.0.0.GA/hibernate-validator-3.0.0.GA-dist.zip/download

--- a/_data/projects/validator/releases/3.0/3.0.0.ga.yml
+++ b/_data/projects/validator/releases/3.0/3.0.0.ga.yml
@@ -1,0 +1,2 @@
+date: 2007-05-29
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/3.0.0.ga/pom

--- a/_data/projects/validator/releases/3.0/series.yml
+++ b/_data/projects/validator/releases/3.0/series.yml
@@ -1,0 +1,34 @@
+license:
+  name: Apache License 2.0
+  # Note: 3.0 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-validator
+    artifact_id_pattern: hibernate-validator-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-validator
+      summary: Core implementation
+    - artifact_id: hibernate-validator-annotation-processor
+      summary: Annotation processor
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate-validator/

--- a/_data/projects/validator/releases/3.0/series.yml
+++ b/_data/projects/validator/releases/3.0/series.yml
@@ -17,6 +17,9 @@ links:
   short_guide:
   # Note: Very old series - no documentation links available
     displayed: false
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/validator/releases/3.0/series.yml
+++ b/_data/projects/validator/releases/3.0/series.yml
@@ -27,8 +27,7 @@ maven:
   artifacts:
     - artifact_id: hibernate-validator
       summary: Core implementation
-    - artifact_id: hibernate-validator-annotation-processor
-      summary: Annotation processor
+    # Note: annotation-processor did not exist in 3.0; it was first released in 4.1
 integration_constraints:
   # Integration constraints sourced from Maven Central:
   # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate-validator/

--- a/_data/projects/validator/releases/3.0/series.yml
+++ b/_data/projects/validator/releases/3.0/series.yml
@@ -1,6 +1,6 @@
 license:
   name: Apache License 2.0
-  # Note: 3.0 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate-validator/master/license.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/validator/releases/3.1/3.1.0.CR1.yml
+++ b/_data/projects/validator/releases/3.1/3.1.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2008-05-27
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/3.1.0.CR1/pom

--- a/_data/projects/validator/releases/3.1/3.1.0.CR1.yml
+++ b/_data/projects/validator/releases/3.1/3.1.0.CR1.yml
@@ -1,2 +1,6 @@
 date: 2008-05-27
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/3.1.0.CR1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/3.1.0.CR1/hibernate-validator-3.1.0.CR1-dist.zip/download

--- a/_data/projects/validator/releases/3.1/3.1.0.CR2.yml
+++ b/_data/projects/validator/releases/3.1/3.1.0.CR2.yml
@@ -1,2 +1,6 @@
 date: 2008-08-20
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/3.1.0.CR2/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/3.1.0.CR2/hibernate-validator-3.1.0.CR2-dist.zip/download

--- a/_data/projects/validator/releases/3.1/3.1.0.CR2.yml
+++ b/_data/projects/validator/releases/3.1/3.1.0.CR2.yml
@@ -1,0 +1,2 @@
+date: 2008-08-20
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/3.1.0.CR2/pom

--- a/_data/projects/validator/releases/3.1/3.1.0.GA.yml
+++ b/_data/projects/validator/releases/3.1/3.1.0.GA.yml
@@ -1,0 +1,2 @@
+date: 2008-09-10
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/3.1.0.GA/pom

--- a/_data/projects/validator/releases/3.1/3.1.0.GA.yml
+++ b/_data/projects/validator/releases/3.1/3.1.0.GA.yml
@@ -1,2 +1,6 @@
 date: 2008-09-10
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/3.1.0.GA/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/3.1.0.GA/hibernate-validator-3.1.0.GA-dist.zip/download

--- a/_data/projects/validator/releases/3.1/series.yml
+++ b/_data/projects/validator/releases/3.1/series.yml
@@ -1,0 +1,34 @@
+license:
+  name: Apache License 2.0
+  # Note: 3.1 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-validator
+    artifact_id_pattern: hibernate-validator-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-validator
+      summary: Core implementation
+    - artifact_id: hibernate-validator-annotation-processor
+      summary: Annotation processor
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate-validator/

--- a/_data/projects/validator/releases/3.1/series.yml
+++ b/_data/projects/validator/releases/3.1/series.yml
@@ -17,6 +17,9 @@ links:
   short_guide:
   # Note: Very old series - no documentation links available
     displayed: false
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/validator/releases/3.1/series.yml
+++ b/_data/projects/validator/releases/3.1/series.yml
@@ -1,6 +1,6 @@
 license:
   name: Apache License 2.0
-  # Note: 3.1 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate-validator/master/license.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/validator/releases/3.1/series.yml
+++ b/_data/projects/validator/releases/3.1/series.yml
@@ -27,8 +27,7 @@ maven:
   artifacts:
     - artifact_id: hibernate-validator
       summary: Core implementation
-    - artifact_id: hibernate-validator-annotation-processor
-      summary: Annotation processor
+    # Note: annotation-processor did not exist in 3.1; it was first released in 4.1
 integration_constraints:
   # Integration constraints sourced from Maven Central:
   # - Java: https://repo1.maven.org/maven2/org/hibernate/hibernate-validator/

--- a/_data/projects/validator/releases/4.0/4.0.0.Alpha1.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Alpha1.yml
@@ -1,0 +1,2 @@
+date: 2009-02-12
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Alpha1/pom

--- a/_data/projects/validator/releases/4.0/4.0.0.Alpha2.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Alpha2.yml
@@ -1,0 +1,2 @@
+date: 2009-03-03
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Alpha2/pom

--- a/_data/projects/validator/releases/4.0/4.0.0.Alpha2.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Alpha2.yml
@@ -1,2 +1,6 @@
 date: 2009-03-03
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Alpha2/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/4.0.0.Alpha2/hibernate-validator-4.0.0.Alpha2-dist.zip/download

--- a/_data/projects/validator/releases/4.0/4.0.0.Alpha3.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Alpha3.yml
@@ -1,0 +1,2 @@
+date: 2009-03-20
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Alpha3/pom

--- a/_data/projects/validator/releases/4.0/4.0.0.Alpha3.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Alpha3.yml
@@ -1,2 +1,6 @@
 date: 2009-03-20
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Alpha3/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/4.0.0.Alpha3/hibernate-validator-4.0.0.Alpha3-dist.zip/download

--- a/_data/projects/validator/releases/4.0/4.0.0.Beta1.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2009-04-27
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Beta1/pom

--- a/_data/projects/validator/releases/4.0/4.0.0.Beta1.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Beta1.yml
@@ -1,2 +1,6 @@
 date: 2009-04-27
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Beta1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/4.0.0.Beta1/hibernate-validator-4.0.0.Beta1-dist.zip/download

--- a/_data/projects/validator/releases/4.0/4.0.0.Beta2.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Beta2.yml
@@ -1,2 +1,6 @@
 date: 2009-07-20
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Beta2/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/4.0.0.Beta2/hibernate-validator-4.0.0.Beta2-dist.zip/download

--- a/_data/projects/validator/releases/4.0/4.0.0.Beta2.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2009-07-20
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Beta2/pom

--- a/_data/projects/validator/releases/4.0/4.0.0.Beta3.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.Beta3.yml
@@ -1,0 +1,2 @@
+date: 2009-08-13
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.Beta3/pom

--- a/_data/projects/validator/releases/4.0/4.0.0.CR1.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2009-08-27
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.CR1/pom

--- a/_data/projects/validator/releases/4.0/4.0.0.CR1.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.CR1.yml
@@ -1,2 +1,6 @@
 date: 2009-08-27
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.CR1/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/4.0.0.CR1/hibernate-validator-4.0.0.CR1-dist.zip/download

--- a/_data/projects/validator/releases/4.0/4.0.0.GA.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.GA.yml
@@ -1,2 +1,6 @@
 date: 2009-10-08
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.GA/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/4.0.0.GA/hibernate-validator-4.0.0.GA-dist.zip/download

--- a/_data/projects/validator/releases/4.0/4.0.0.GA.yml
+++ b/_data/projects/validator/releases/4.0/4.0.0.GA.yml
@@ -1,0 +1,2 @@
+date: 2009-10-08
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.0.GA/pom

--- a/_data/projects/validator/releases/4.0/4.0.1.GA.yml
+++ b/_data/projects/validator/releases/4.0/4.0.1.GA.yml
@@ -1,0 +1,2 @@
+date: 2009-10-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.1.GA/pom

--- a/_data/projects/validator/releases/4.0/4.0.1.GA.yml
+++ b/_data/projects/validator/releases/4.0/4.0.1.GA.yml
@@ -1,2 +1,6 @@
 date: 2009-10-28
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.1.GA/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/4.0.1.GA/hibernate-validator-4.0.1.GA-dist.zip/download

--- a/_data/projects/validator/releases/4.0/4.0.2.GA.yml
+++ b/_data/projects/validator/releases/4.0/4.0.2.GA.yml
@@ -1,2 +1,6 @@
 date: 2009-11-06
 # Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.2.GA/pom
+links:
+  dist:
+    sourceforge:
+      zip: https://sourceforge.net/projects/hibernate/files/hibernate-validator/4.0.2.GA/hibernate-validator-4.0.2.GA-dist.zip/download

--- a/_data/projects/validator/releases/4.0/4.0.2.GA.yml
+++ b/_data/projects/validator/releases/4.0/4.0.2.GA.yml
@@ -1,0 +1,2 @@
+date: 2009-11-06
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.0.2.GA/pom

--- a/_data/projects/validator/releases/4.0/series.yml
+++ b/_data/projects/validator/releases/4.0/series.yml
@@ -1,6 +1,6 @@
 license:
   name: Apache License 2.0
-  # Note: 4.0 branch not available in current GitHub repository
+  url: https://raw.githubusercontent.com/hibernate/hibernate-validator/master/license.txt
 links:
   doc:
     displayed: false

--- a/_data/projects/validator/releases/4.0/series.yml
+++ b/_data/projects/validator/releases/4.0/series.yml
@@ -17,6 +17,9 @@ links:
   short_guide:
   # Note: Very old series - no documentation links available
     displayed: false
+  jira_issues:
+  github_issues:
+  # Note: Issue tracker links disabled for very old series
 maven:
   coord:
     group_id: org.hibernate

--- a/_data/projects/validator/releases/4.0/series.yml
+++ b/_data/projects/validator/releases/4.0/series.yml
@@ -27,8 +27,7 @@ maven:
   artifacts:
     - artifact_id: hibernate-validator
       summary: Core implementation
-    - artifact_id: hibernate-validator-annotation-processor
-      summary: Annotation processor
+    # Note: annotation-processor did not exist in 4.0; it was first released in 4.1
 integration_constraints:
   # Integration constraints sourced from Maven Central:
   # - Bean Validation: dependency on javax.validation:validation-api:1.0.0.GA

--- a/_data/projects/validator/releases/4.0/series.yml
+++ b/_data/projects/validator/releases/4.0/series.yml
@@ -1,0 +1,40 @@
+license:
+  name: Apache License 2.0
+  # Note: 4.0 branch not available in current GitHub repository
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-validator
+    artifact_id_pattern: hibernate-validator-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-validator
+      summary: Core implementation
+    - artifact_id: hibernate-validator-annotation-processor
+      summary: Annotation processor
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Bean Validation: dependency on javax.validation:validation-api:1.0.0.GA
+  # - Java EE: derived from Bean Validation version (BV 1.0 → Java EE 6)
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-validator/4.0.2.GA/hibernate-validator-4.0.2.GA.pom
+  java_ee_bv:
+    version: '1.0'
+  java_ee:
+    version: '6'

--- a/_data/projects/validator/releases/4.1/4.1.0.Beta1.yml
+++ b/_data/projects/validator/releases/4.1/4.1.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2010-03-24
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.1.0.Beta1/pom

--- a/_data/projects/validator/releases/4.1/4.1.0.Beta2.yml
+++ b/_data/projects/validator/releases/4.1/4.1.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2010-06-02
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.1.0.Beta2/pom

--- a/_data/projects/validator/releases/4.1/4.1.0.CR1.yml
+++ b/_data/projects/validator/releases/4.1/4.1.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2010-06-17
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.1.0.CR1/pom

--- a/_data/projects/validator/releases/4.1/4.1.0.Final.yml
+++ b/_data/projects/validator/releases/4.1/4.1.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2010-06-28
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.1.0.Final/pom

--- a/_data/projects/validator/releases/4.1/series.yml
+++ b/_data/projects/validator/releases/4.1/series.yml
@@ -1,0 +1,40 @@
+license:
+  name: Apache License 2.0
+  url: https://raw.githubusercontent.com/hibernate/hibernate-validator/4.1/license.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-validator
+    artifact_id_pattern: hibernate-validator-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-validator
+      summary: Core implementation
+    - artifact_id: hibernate-validator-annotation-processor
+      summary: Annotation processor
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Bean Validation: dependency on javax.validation:validation-api:1.0.0.GA
+  # - Java EE: derived from Bean Validation version (BV 1.0 → Java EE 6)
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-validator/4.1.0.Final/hibernate-validator-4.1.0.Final.pom
+  java_ee_bv:
+    version: '1.0'
+  java_ee:
+    version: '6'

--- a/_data/projects/validator/releases/4.2/4.2.0.Beta1.yml
+++ b/_data/projects/validator/releases/4.2/4.2.0.Beta1.yml
@@ -1,0 +1,2 @@
+date: 2011-01-13
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.2.0.Beta1/pom

--- a/_data/projects/validator/releases/4.2/4.2.0.Beta2.yml
+++ b/_data/projects/validator/releases/4.2/4.2.0.Beta2.yml
@@ -1,0 +1,2 @@
+date: 2011-03-07
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.2.0.Beta2/pom

--- a/_data/projects/validator/releases/4.2/4.2.0.CR1.yml
+++ b/_data/projects/validator/releases/4.2/4.2.0.CR1.yml
@@ -1,0 +1,2 @@
+date: 2011-06-09
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.2.0.CR1/pom

--- a/_data/projects/validator/releases/4.2/4.2.0.Final.yml
+++ b/_data/projects/validator/releases/4.2/4.2.0.Final.yml
@@ -1,0 +1,2 @@
+date: 2011-06-20
+# Source: https://search.maven.org/artifact/org.hibernate/hibernate-validator/4.2.0.Final/pom

--- a/_data/projects/validator/releases/4.2/series.yml
+++ b/_data/projects/validator/releases/4.2/series.yml
@@ -1,0 +1,40 @@
+license:
+  name: Apache License 2.0
+  url: https://raw.githubusercontent.com/hibernate/hibernate-validator/4.2/license.txt
+links:
+  doc:
+    displayed: false
+  reference_doc:
+    displayed: false
+  javadoc:
+    displayed: false
+  getting_started_guide:
+    displayed: false
+  whats_new:
+    displayed: false
+  migration_guide:
+    displayed: false
+  short_guide:
+  # Note: Very old series - no documentation links available
+    displayed: false
+maven:
+  coord:
+    group_id: org.hibernate
+    main_artifact_id: hibernate-validator
+    artifact_id_pattern: hibernate-validator-*
+  repo:
+    snapshots: jboss
+  artifacts:
+    - artifact_id: hibernate-validator
+      summary: Core implementation
+    - artifact_id: hibernate-validator-annotation-processor
+      summary: Annotation processor
+integration_constraints:
+  # Integration constraints sourced from Maven Central:
+  # - Bean Validation: dependency on javax.validation:validation-api:1.0.0.GA
+  # - Java EE: derived from Bean Validation version (BV 1.0 → Java EE 6)
+  # Source: https://repo1.maven.org/maven2/org/hibernate/hibernate-validator/4.2.0.Final/hibernate-validator-4.2.0.Final.pom
+  java_ee_bv:
+    version: '1.0'
+  java_ee:
+    version: '6'

--- a/_data/projects/validator/releases/4.3/series.yml
+++ b/_data/projects/validator/releases/4.3/series.yml
@@ -24,3 +24,5 @@ integration_constraints:
     version: '6'
   java_ee_bv:
     version: '1.0'
+  java_ee:
+    version: '6'

--- a/_data/projects/validator/releases/5.0/series.yml
+++ b/_data/projects/validator/releases/5.0/series.yml
@@ -28,3 +28,5 @@ integration_constraints:
       - '7'
   java_ee_bv:
     version: '1.1'
+  java_ee:
+    version: '7'

--- a/_data/projects/validator/releases/5.1/series.yml
+++ b/_data/projects/validator/releases/5.1/series.yml
@@ -28,3 +28,5 @@ integration_constraints:
       - '7'
   java_ee_bv:
     version: '1.1'
+  java_ee:
+    version: '7'

--- a/_data/projects/validator/releases/5.2/series.yml
+++ b/_data/projects/validator/releases/5.2/series.yml
@@ -31,4 +31,6 @@ integration_constraints:
       - '8'
   java_ee_bv:
     version: '1.1'
+  java_ee:
+    version: '7'
 

--- a/_data/projects/validator/releases/5.3/series.yml
+++ b/_data/projects/validator/releases/5.3/series.yml
@@ -31,6 +31,8 @@ integration_constraints:
       - '8'
   java_ee_bv:
     version: '1.1'
+  java_ee:
+    version: '7'
   spring_boot:
     version: '1.5'
   wildfly:

--- a/_data/projects/validator/releases/5.4/series.yml
+++ b/_data/projects/validator/releases/5.4/series.yml
@@ -31,3 +31,5 @@ integration_constraints:
       - '8'
   java_ee_bv:
     version: '1.1'
+  java_ee:
+    version: '7'

--- a/_ext/link_resolver.rb
+++ b/_ext/link_resolver.rb
@@ -16,12 +16,16 @@ module Awestruct
               ['getting_started_guide'].each do |key|
                 links[key] = DocumentRef.from_patterns_multi(project, series, key)
               end
+              links[:jira_issues] = IssueTrackerRef.for_series(project, series)
+              links[:github_issues] = IssueTrackerRef.github_fallback(project, series)
               series[:releases]&.each do |release|
                 links = release['links'] || Hash.new
                 release['links'] = links
                 links[:maven] = MavenRef.from(@site, project, series, release)
                 links[:dist] ||= Hash.new
                 links[:dist][:sourceforge] = DistRef.from(project, series, release, :sourceforge)
+                links[:jira_issues] = IssueTrackerRef.for_release(project, series, release)
+                links[:github_issues] = IssueTrackerRef.github_fallback(project, series)
               end
             end
         end
@@ -225,6 +229,94 @@ module Awestruct
 
         def initialize(zip_url)
           @zip_url = zip_url
+        end
+      end
+
+      class IssueTrackerRef
+        @@logger = Logger.new(STDERR)
+        @@logger.level = Logger::INFO
+
+        def self.for_series(project, series)
+          log_prefix = "#{project['name']}/#{series.version}/jira_issues: "
+
+          # Check if explicitly disabled in series
+          series_jira = series&.[]('links')&.[]('jira_issues')
+          if series_jira == false || series_jira.nil? && series&.[]('links')&.has_key?('jira_issues')
+            @@logger.debug("#{log_prefix}Explicitly disabled")
+            return nil
+          end
+
+          # Check if project has Jira configured
+          if project[:jira].nil? || project[:jira][:key].nil?
+            @@logger.debug("#{log_prefix}No Jira key configured")
+            return nil
+          end
+
+          versions = series.releases.collect{|r| r.version}
+          url = jira_issues_url(project, versions)
+          @@logger.debug("#{log_prefix}URL: #{url}")
+          return IssueTrackerRef.new(url)
+        end
+
+        def self.for_release(project, series, release)
+          log_prefix = "#{project['name']}/#{series.version}/#{release.version}/jira_issues: "
+
+          # Check if explicitly disabled in series (applies to all releases)
+          series_jira = series&.[]('links')&.[]('jira_issues')
+          if series_jira == false || series_jira.nil? && series&.[]('links')&.has_key?('jira_issues')
+            @@logger.debug("#{log_prefix}Explicitly disabled in series")
+            return nil
+          end
+
+          # Check if project has Jira configured
+          if project[:jira].nil? || project[:jira][:key].nil?
+            @@logger.debug("#{log_prefix}No Jira key configured")
+            return nil
+          end
+
+          url = jira_issues_url(project, [release.version])
+          @@logger.debug("#{log_prefix}URL: #{url}")
+          return IssueTrackerRef.new(url)
+        end
+
+        def self.github_fallback(project, series)
+          log_prefix = "#{project['name']}/#{series.version}/github_issues: "
+
+          # Only use GitHub if no Jira
+          if project[:jira] && project[:jira][:key]
+            @@logger.debug("#{log_prefix}Jira available, skipping GitHub")
+            return nil
+          end
+
+          # Check if explicitly disabled in series
+          series_github = series&.[]('links')&.[]('github_issues')
+          if series_github == false || series_github.nil? && series&.[]('links')&.has_key?('github_issues')
+            @@logger.debug("#{log_prefix}Explicitly disabled")
+            return nil
+          end
+
+          if project.github.nil? || project.github['project'].nil?
+            @@logger.debug("#{log_prefix}No GitHub project configured")
+            return nil
+          end
+
+          url = "https://github.com/hibernate/#{project.github['project']}/issues?q=is%3Aissue+is%3Aclosed+"
+          @@logger.debug("#{log_prefix}URL: #{url}")
+          return IssueTrackerRef.new(url)
+        end
+
+        def self.jira_issues_url(project, versions)
+          fix_version_translator = project.jira['key'] == 'HHH' ?
+            lambda {|v| v != '4.2.0.Final' && v != '4.3.0.Final' && v != '5.0.0.Final' && v =~ /^(.*).Final$/ ? $1 : v } :
+            lambda {|v| v}
+          comma_separated_fix_versions = versions.collect{|v| fix_version_translator.call(v)}.join( "%2C%20" )
+          return "https://hibernate.atlassian.net/issues/?jql=project%20%3D%20#{project.jira['key']}%20AND%20fixVersion%20in%20(#{comma_separated_fix_versions})%20ORDER%20BY%20updated"
+        end
+
+        attr_reader :url
+
+        def initialize(url)
+          @url = url
         end
       end
     end

--- a/_ext/link_resolver.rb
+++ b/_ext/link_resolver.rb
@@ -50,7 +50,14 @@ module Awestruct
           project_maven = project['maven'] || {}
           series_maven = series['maven'] || {}
           release_maven = release['maven'] || {}
-          maven_coord = release_maven&.[]('coord') || series_maven&.[]('coord') || project_maven['coord']
+          # Check for explicit nil to prevent fallback to project config
+          maven_coord = if release_maven&.has_key?('coord')
+                          release_maven['coord']
+                        elsif series_maven&.has_key?('coord')
+                          series_maven['coord']
+                        else
+                          project_maven['coord']
+                        end
           @@logger.debug("#{log_prefix}Coord: #{maven_coord}")
           maven_signing = project_maven&.[]('signing')
           maven_repo = {}

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -4,6 +4,7 @@ require 'html_minifier'
 require 'relative'
 require 'releases'
 require 'release_file_parser'
+require 'release_series_index_generator'
 require 'data_file_parser'
 require 'directory_listing'
 require 'links'
@@ -46,6 +47,7 @@ Awestruct::Extensions::Pipeline.new do
   # register extensions and transformers
   extension Awestruct::Extensions::DataFileParser.new
   extension Awestruct::Extensions::ReleaseFileParser.new
+  extension Awestruct::Extensions::ReleaseSeriesIndexGenerator.new
   extension Awestruct::Extensions::LinkResolver.new
   extension Awestruct::Extensions::MetadataPublisher.new
   transformer Awestruct::Extensions::JsMinifier.new

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -136,6 +136,7 @@ module Awestruct
 
         if subproject_id
           # Automatically add the constraint "this subproject is compatible with the same version of the superproject"
+          series[:integration_constraints] ||= Hash.new
           superproject_constraint = Hash.new
           superproject_constraint[:version] = series[:version]
           series[:integration_constraints][project[:superproject_id]] = superproject_constraint

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -166,13 +166,7 @@ module Awestruct
           release[:version_family] = series.version
         end
 
-        if release.version =~ /.*\.(Alpha[0-9]+|Beta[0-9]+|CR[0-9]+)$/
-          release.stable = false
-        elsif release.version =~ /.*\.(Final|SP[0-9]+)/
-          release.stable = true
-        else
-          raise StandardError, "Unsupported version scheme for #{release_file}: #{release.version}"
-        end
+        determineStability(release, release_file)
 
         if release[:scm_tag] == nil
           if project['github']['final_suffix_in_tags']
@@ -643,6 +637,17 @@ module Awestruct
           end
         end
         nil
+      end
+
+      # Determine whether a release is stable or unstable based on version suffix
+      # Uses the Version class to parse and determine stability
+      def determineStability(release, release_file)
+        begin
+          version_obj = Version.new(release.version)
+          release.stable = version_obj.stable?
+        rescue => e
+          raise StandardError, "Unsupported version scheme for #{release_file}: #{release.version} (#{e.message})"
+        end
       end
     end
   end

--- a/_ext/release_series_index_generator.rb
+++ b/_ext/release_series_index_generator.rb
@@ -1,0 +1,58 @@
+require 'fileutils'
+
+module Awestruct
+  module Extensions
+    # Extension that automatically generates index pages for release series
+    # that have a series.yml but no index.adoc in the source tree
+    class ReleaseSeriesIndexGenerator
+
+      def execute(site)
+        # Find all projects and their series that need generated index pages
+        projects = Dir.glob('_data/projects/*/releases/*/series.yml').map do |series_file|
+          project_path = series_file.split('/')[2]
+          series_version = series_file.split('/')[4]
+          index_path = "#{project_path}/releases/#{series_version}/index.adoc"
+
+          # Only create if index.adoc doesn't exist in the source
+          unless File.exist?(index_path)
+            { project: project_path, series: series_version, path: index_path }
+          end
+        end.compact
+
+        # Generate pages using temporary files
+        projects.each do |info|
+          create_page_from_temp(site, info[:project], info[:series], info[:path])
+        end
+
+        site
+      end
+
+      private
+
+      def create_page_from_temp(site, project, series_version, output_path)
+        # Create temporary directory
+        tmp_dir = './_tmp/release_series_indexes'
+        FileUtils.mkdir_p(tmp_dir)
+
+        # Generate the index.adoc content
+        content = <<~ADOC
+          :awestruct-layout: project-releases-series
+          :awestruct-project: #{project}
+          :awestruct-series_version: "#{series_version}"
+        ADOC
+
+        # Create a temporary file
+        tmp_file = File.join(tmp_dir, "#{project}-#{series_version}.adoc")
+        File.write(tmp_file, content)
+
+        # Load the temporary file as an Awestruct page
+        page = site.engine.load_page(tmp_file)
+        # Set output path: orm/releases/3.0/index.adoc -> /orm/releases/3.0/index.html
+        page.output_path = '/' + output_path.sub(/\.adoc$/, '.html')
+
+        # Add to site pages
+        site.pages << page
+      end
+    end
+  end
+end

--- a/_ext/version.rb
+++ b/_ext/version.rb
@@ -15,21 +15,68 @@ module Awestruct
           raise ArgumentError, "Version string '#{version_str}' must not have leading or trailing whitespace"
         end
 
-        v = version_str.split(".")
-        @major = v[0].to_i
-        @minor = v[1].to_i
-        @micro = v[2].to_i
-        @suffix = v[3] == nil ? nil : VersionSuffix.new(v[3])
-        # Track how many components were in the original version string
-        # This helps distinguish "8" (1 component) from "8.0" (2 components)
-        @component_count = v.length
+        # Parse version string, handling multiple formats:
+        # - 3-component: 1.0.0.Final, 3.5.0-Beta-2
+        # - 2-component: 3.0, 3.0beta1, 3.1.ga
+        # - 1-component: 8
+
+        # Try 3-component version first: major.minor.micro[separator][suffix]
+        match = version_str.match(/^(\d+)\.(\d+)\.(\d+)(?:[\.\-]?(.+))?$/)
+        if match
+          @major = match[1].to_i
+          @minor = match[2].to_i
+          @micro = match[3].to_i
+          @suffix = match[4] ? VersionSuffix.new(match[4]) : nil
+          @component_count = match[4] ? 4 : 3
+        else
+          # Try 2-component version: major.minor[separator][suffix]
+          match = version_str.match(/^(\d+)\.(\d+)(?:[\.\-]?(.+))?$/)
+          if match
+            @major = match[1].to_i
+            @minor = match[2].to_i
+            @micro = 0
+            @suffix = match[3] ? VersionSuffix.new(match[3]) : nil
+            @component_count = match[3] ? 3 : 2
+          else
+            # Fallback to old dot-splitting behavior for 1-component versions (e.g., "8")
+            v = version_str.split(".")
+            @major = v[0].to_i
+            @minor = v[1].to_i
+            @micro = v[2].to_i
+            @suffix = v[3] ? VersionSuffix.new(v[3]) : nil
+            @component_count = v.length
+          end
+        end
       end
 
       def <=>(other)
         return @major <=> other.major if ((@major <=> other.major) != 0)
         return @minor <=> other.minor if ((@minor <=> other.minor) != 0)
         return @micro <=> other.micro if ((@micro <=> other.micro) != 0)
+
+        # Handle suffix comparison with nil values
+        # nil suffix = plain version (e.g., "3.0.1")
+        # Ordering: Alpha/Beta/CR < nil (plain) < Final/GA/SP
+        return 0 if @suffix.nil? && other.suffix.nil?
+
+        # If one has nil suffix and other doesn't, compare based on stability
+        if @suffix.nil?
+          # nil < stable suffixes (Final, GA, SP), nil > pre-release suffixes (Alpha, Beta, CR)
+          return other.suffix.stable? ? -1 : 1
+        elsif other.suffix.nil?
+          # stable suffixes > nil, pre-release suffixes < nil
+          return @suffix.stable? ? 1 : -1
+        end
+
         return @suffix <=> other.suffix
+      end
+
+      # Determine if this version represents a stable release
+      # Versions with no suffix (e.g., 3.0, 3.0.1) or stable suffixes (Final, GA, SP) are stable
+      # Versions with unstable suffixes (Alpha, Beta, CR) are unstable
+      def stable?
+        return true if @suffix.nil?
+        @suffix.stable?
       end
 
       def matches?(constraint)
@@ -235,23 +282,65 @@ module Awestruct
 
       attr_reader :prefix, :number
 
-      def initialize(bugfix="")
-        split = bugfix.scan(/^([A-Za-z\-_]+)([0-9]+)?$/)
-        @prefix = split.first[0]
-        @number = split.first[1]&.to_i
+      def initialize(suffix_str="")
+        # Handle multiple formats:
+        # - "Final" -> prefix: "Final", number: nil
+        # - "Alpha1" -> prefix: "Alpha", number: 1
+        # - "Beta-2" -> prefix: "Beta", number: 2
+        # - "CR-1" -> prefix: "CR", number: 1
+        # - "ga" -> prefix: "ga", number: nil
+        # - "sp1" -> prefix: "sp", number: 1
+        # - "beta4b" -> prefix: "beta", number: 4 (letter suffix ignored)
+
+        # Match: prefix, optional hyphen, optional number, optional letter suffix
+        match = suffix_str.match(/^([A-Za-z]+)\-?([0-9]+)?[a-z]?$/)
+        if match
+          @prefix = match[1]
+          @number = match[2]&.to_i
+        else
+          # Fallback for edge cases
+          @prefix = suffix_str
+          @number = nil
+        end
       end
 
       def <=>(other)
-        return @prefix <=> other.prefix if ((@prefix <=> other.prefix) != 0)
-        return @number <=> other.number
+        # Case-insensitive comparison of prefix (so "cr" == "CR")
+        prefix_cmp = @prefix.downcase <=> other.prefix.downcase
+        return prefix_cmp if prefix_cmp != 0
+
+        # Compare numbers second (so cr1 < cr2, CR1 < CR2)
+        number_cmp = @number <=> other.number
+        return number_cmp if number_cmp != 0
+
+        # If prefixes and numbers are equal, compare case as final tiebreaker
+        # This ensures lowercase comes before uppercase (cr1 < CR1)
+        # Note: In ASCII, uppercase < lowercase, so we reverse the comparison
+        return other.prefix <=> @prefix
       end
 
       def self.sort
         self.sort!{|a,b| a <=> b}
       end
 
+      # Determine if this suffix represents a stable release
+      # Stable: Final, GA, SP (service packs)
+      # Unstable: Alpha, Beta, CR (candidate release)
+      def stable?
+        prefix_lower = @prefix.downcase
+        case prefix_lower
+        when 'final', 'ga', 'sp'
+          true
+        when 'alpha', 'beta', 'cr'
+          false
+        else
+          # Unknown suffix - conservative default is unstable
+          false
+        end
+      end
+
       def to_s
-        @bugfix + @number&.to_s
+        @number ? "#{@prefix}#{@number}" : @prefix
       end
     end
   end

--- a/_layouts/project/project-documentation.html.haml
+++ b/_layouts/project/project-documentation.html.haml
@@ -28,10 +28,11 @@ project_buttons_partial: project/documentation-buttons.html.haml
               %strong= release.version
               %span.detail= release.date
             = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "tag" } )
-          %p
-            :asciidoc
-              :doctype: inline
-              #{series.summary.strip}
+          - if series.summary && !series.summary.strip.empty?
+            %p
+              :asciidoc
+                :doctype: inline
+                #{series.summary.strip}
           = partial( 'project/series-documentation.html.haml', { "project" => project_description, "series" => series } )
 - else
   %p There is no reference documentation configured for this project.
@@ -67,8 +68,9 @@ project_buttons_partial: project/documentation-buttons.html.haml
                 %strong= release.version
                 %span.detail= release.date
               = partial( 'project/series-status-label.html.haml', { "series" => series, "classes" => "tag" } )
-            %p
-              = series.summary
+            - if series.summary && !series.summary.strip.empty?
+              %p
+                = series.summary
             = partial( 'project/series-documentation.html.haml', { "project" => project_description, "series" => series } )
 
 ~ content

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -135,90 +135,99 @@ project_hero_partial: project/hero-series.html.haml
   Current series status:
   = partial( 'project/series-status-label.html.haml', { "series" => series } )
 
-.ui.grid.equal.height.stackable.download-options
-  .row
-    - if latest_release_maven.coord
-      - releases_repo = latest_release_maven.repo[:releases]
-      .eleven.wide.column
-        %p
-          Maven artifacts of #{project_description.name} are published to
-          %a{:href => releases_repo.data.web_ui_url}
-            #{releases_repo.data.name}.
-          Most build tools fetch artifacts from Maven Central by default,
-          but if that's not the case for you,
-          see
-          %a{:href => releases_repo.data.help_setup_url}
-            this page
-          to configure your build tool.
-        %p
-          You can find the Maven coordinates of all artifacts through the link below:
-          %p
-            %a.ui.right.labeled.button.small.icon{:href => releases_repo.web_ui_all_artifacts_url(latest_release_maven.coord, latest_release.version)}
-              %i.icon.cloud.cubes
-              Maven artifacts
-        - if latest_release_maven.artifacts
-          %p
-            Below are the Maven coordinates of the main artifacts.
-          %div.ui.relaxed.divided.list
-            - latest_release_maven.artifacts.each do |artifact|
-              - group_id = latest_release_maven.coord['group_id']
-              - artifact_id = artifact.artifact_id
-              - version = latest_release.version
-              %div.item
-                %div.right.floated.content
-                  %a.ui.button.tiny.icon{:href => releases_repo.web_ui_artifact_url(group_id, artifact_id, latest_release.version)}
-                    %i.icon.cloud.cube
-                %div.header
-                  <span class="faded">#{group_id}:</span>#{artifact_id}</strong><span class="faded">:#{version}</span>
-                %div.content
-                  %div.description
-                    :asciidoc
-                      :doctype: inline
-                      #{(artifact[:summary] || artifact.artifact_id).strip}
-        - if latest_release_maven&.signing&.[]('since')
-          %p
-            All Maven artifacts of this project released after #{latest_release_maven.signing['since']} are signed.
-          %p
-            To verify signed Maven artifacts, head to
-            %a{:href => "/community/keys/"}
-              this page.
-    - if dist_sourceforge || latest_release_maven.coord
-      .five.wide.column.divided
-        %h3 Direct download
-        - if dist_sourceforge
-          %p
-            A ZIP archive containing all JAR files, documentation and source is available from SourceForge:
-            %p
-              %a.ui.right.labeled.button.small.icon{:href => dist_sourceforge.zip_url, :title => "Download"}
-                %i.icon.cloud.download
-                Download ZIP archive
-        - if latest_release_maven.coord
-          - releases_repo = latest_release_maven.repo[:releases]
-          %p
-            Individual Maven artifacts may be downloaded directly from the Maven repository:
-            %p
-              %a.ui.right.labeled.button.small.icon{:href => releases_repo.direct_download_url(latest_release_maven.coord)}
-                %i.icon.folder.open
-                #{releases_repo.data.name} subdirectory
-            %p
-              See
-              %a{:href => "https://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-project-dependencies.html"}
-                here
-              for how to download all dependencies of your Maven project to a local directory on your filesystem.
-            %p
-              See
-              %a{:href => "https://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-artifacts.html"}
-                here
-              for how to download an explicitly listed set of artifacts to a local directory on your filesystem.
+- maven_has_content = latest_release_maven.coord
+- dist_has_content = dist_sourceforge || latest_release_maven.coord
 
-%p
-  More information about specific releases (announcements, download links) can be found
-  %a{:href => "#releases"}
-    here.
+- if maven_has_content || dist_has_content
+  .ui.grid.equal.height.stackable.download-options
+    .row
+      - if maven_has_content
+        - releases_repo = latest_release_maven.repo[:releases]
+        .eleven.wide.column
+          %p
+            Maven artifacts of #{project_description.name} are published to
+            %a{:href => releases_repo.data.web_ui_url}
+              #{releases_repo.data.name}.
+            Most build tools fetch artifacts from Maven Central by default,
+            but if that's not the case for you,
+            see
+            %a{:href => releases_repo.data.help_setup_url}
+              this page
+            to configure your build tool.
+          %p
+            You can find the Maven coordinates of all artifacts through the link below:
+            %p
+              %a.ui.right.labeled.button.small.icon{:href => releases_repo.web_ui_all_artifacts_url(latest_release_maven.coord, latest_release.version)}
+                %i.icon.cloud.cubes
+                Maven artifacts
+          - if latest_release_maven.artifacts
+            %p
+              Below are the Maven coordinates of the main artifacts.
+            %div.ui.relaxed.divided.list
+              - latest_release_maven.artifacts.each do |artifact|
+                - group_id = latest_release_maven.coord['group_id']
+                - artifact_id = artifact.artifact_id
+                - version = latest_release.version
+                %div.item
+                  %div.right.floated.content
+                    %a.ui.button.tiny.icon{:href => releases_repo.web_ui_artifact_url(group_id, artifact_id, latest_release.version)}
+                      %i.icon.cloud.cube
+                  %div.header
+                    <span class="faded">#{group_id}:</span>#{artifact_id}</strong><span class="faded">:#{version}</span>
+                  %div.content
+                    %div.description
+                      :asciidoc
+                        :doctype: inline
+                        #{(artifact[:summary] || artifact.artifact_id).strip}
+          - if latest_release_maven&.signing&.[]('since')
+            %p
+              All Maven artifacts of this project released after #{latest_release_maven.signing['since']} are signed.
+            %p
+              To verify signed Maven artifacts, head to
+              %a{:href => "/community/keys/"}
+                this page.
+      - if dist_has_content
+        .column{:class=>"#{maven_has_content ? 'divided five wide' : 'eleven wide'}"}
+          - if maven_has_content
+            %h3 Direct download
+          - if dist_sourceforge
+            %p
+              A ZIP archive containing all JAR files, documentation and source is available from SourceForge:
+              %p
+                %a.ui.right.labeled.button.small.icon{:href => dist_sourceforge.zip_url, :title => "Download"}
+                  %i.icon.cloud.download
+                  Download ZIP archive
+          - if latest_release_maven.coord
+            - releases_repo = latest_release_maven.repo[:releases]
+            %p
+              Individual Maven artifacts may be downloaded directly from the Maven repository:
+              %p
+                %a.ui.right.labeled.button.small.icon{:href => releases_repo.direct_download_url(latest_release_maven.coord)}
+                  %i.icon.folder.open
+                  #{releases_repo.data.name} subdirectory
+              %p
+                See
+                %a{:href => "https://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-project-dependencies.html"}
+                  here
+                for how to download all dependencies of your Maven project to a local directory on your filesystem.
+              %p
+                See
+                %a{:href => "https://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-artifacts.html"}
+                  here
+                for how to download an explicitly listed set of artifacts to a local directory on your filesystem.
+  %p
+    More information about specific releases (announcements, download links) can be found
+    %a{:href => "#releases"}
+      here.
+- else
+  %p
+    Download information is not currently available for this series.
 
 %h2{:id => "whats-new"} What's new
+- whatsnew_has_content = false
 
 - if latest_release[:announcement_url]
+  - whatsnew_has_content = true
   %p
     Latest release announcement (#{latest_release.date}):
     %a{:href => "#{latest_release.announcement_url}"}
@@ -226,6 +235,7 @@ project_hero_partial: project/hero-series.html.haml
 
 - whats_new = whats_new(project_description, series)
 - if !whats_new.nil? && (!whats_new.html_url.nil? && !whats_new.html_url.start_with?(current_path) || !whats_new.pdf_url.nil?)
+  - whatsnew_has_content = true
   %p
     Highlights of new features and enhancements can be found here:
   %p
@@ -241,6 +251,7 @@ project_hero_partial: project/hero-series.html.haml
 - jira_issues_link = series.links[:jira_issues]
 - github_issues_link = series.links[:github_issues]
 - if jira_issues_link || github_issues_link
+  - whatsnew_has_content = true
   %p
     A detailed list of new features, improvements and fixes in this series can be found
     - if jira_issues_link
@@ -250,7 +261,11 @@ project_hero_partial: project/hero-series.html.haml
       %a{:href => github_issues_link.url}
         on our issue tracker.
 
-~ content
+- if !whatsnew_has_content
+  %p
+    This information is not currently available for this series.
+- else
+  ~ content
 
 - if latest_release_maven.repo[:snapshots] && !series.endoflife
   - snapshots_repo = latest_release_maven.repo[:snapshots]
@@ -304,6 +319,7 @@ project_hero_partial: project/hero-series.html.haml
       - dist_sourceforge = dist_sourceforge(project_description, series, release)
       - version = release.version
       - available = release[:available] == nil || release[:available]
+      - release_download_has_content = false
       .ui.row
         .three.wide.column
           %p
@@ -333,7 +349,8 @@ project_hero_partial: project/hero-series.html.haml
               :asciidoc
                 :doctype: inline
                 #{release.summary.strip}
-          - if available && latest_release.version == version
+          - if available && latest_release.version == version && maven_has_content && dist_has_content
+            - release_download_has_content = true
             %p
               %a.ui.small.right.labeled.icon.button{:href => '#get-it'}
                 %i.level.up.alternate.icon
@@ -346,12 +363,14 @@ project_hero_partial: project/hero-series.html.haml
             - if available
               - release_maven = maven(project_description, series, release)
               - if release_maven.coord
+                - release_download_has_content = true
                 - releases_repo = latest_release_maven.repo[:releases]
                 %a.ui.small.right.labeled.button.icon{:href => releases_repo.web_ui_all_artifacts_url(release_maven.coord, version)}
                   %i.icon.cloud.cubes
                   Maven artifacts
 
               - if dist_sourceforge
+                - release_download_has_content = true
                 %a.ui.small.right.labeled.button.icon{:href => dist_sourceforge.zip_url}
                   %i.icon.cloud.download
                   Download
@@ -366,5 +385,9 @@ project_hero_partial: project/hero-series.html.haml
                 %a.ui.small.right.labeled.button.icon{:href => "#{release.announcement_url}"}
                   %i.icon.announcement
                   Release announcement
+
+              - if !release_download_has_content
+                %p
+                  Download information is not currently available for this release.
 - else
   %p There are no releases configured for this series.

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -238,14 +238,17 @@ project_hero_partial: project/hero-series.html.haml
         %i.icon.file.pdf.outline
         PDF
 
-%p
-  A detailed list of new features, improvements and fixes in this series can be found
-  - if project_description[:jira][:key]
-    %a{:href => jira_issues_for_series_url(project_description, series)}
-      on our issue tracker.
-  - else
-    %a{:href => github_issues_url(project_description)}
-      on our issue tracker.
+- jira_issues_link = series.links[:jira_issues]
+- github_issues_link = series.links[:github_issues]
+- if jira_issues_link || github_issues_link
+  %p
+    A detailed list of new features, improvements and fixes in this series can be found
+    - if jira_issues_link
+      %a{:href => jira_issues_link.url}
+        on our issue tracker.
+    - elsif github_issues_link
+      %a{:href => github_issues_link.url}
+        on our issue tracker.
 
 ~ content
 
@@ -353,8 +356,9 @@ project_hero_partial: project/hero-series.html.haml
                   %i.icon.cloud.download
                   Download
 
-              - if project_description[:jira][:key]
-                %a.ui.small.right.labeled.button.icon{:href => jira_issues_for_release_url(project_description, release)}
+              - jira_issues_link = release.links[:jira_issues]
+              - if jira_issues_link
+                %a.ui.small.right.labeled.button.icon{:href => jira_issues_link.url}
                   %i.icon.bug
                   Resolved issues
 

--- a/_layouts/project/project-releases.html.haml
+++ b/_layouts/project/project-releases.html.haml
@@ -35,10 +35,11 @@ project_buttons_partial: project/releases-buttons.html.haml
               = series.version
               %small
                 = release.date
-            %p
-              :asciidoc
-                :doctype: inline
-                #{series.summary.strip}
+            - if series.summary && !series.summary.strip.empty?
+              %p
+                :asciidoc
+                  :doctype: inline
+                  #{series.summary.strip}
             .ui.right.aligned.basic.segment
               %a.ui.right.labeled.icon.button.primary{:href => "./#{series.version}/"}
                 %i.right.arrow.icon
@@ -77,10 +78,11 @@ project_buttons_partial: project/releases-buttons.html.haml
                 = series.version
                 %small
                   = release.date
-              %p
-                :asciidoc
-                  :doctype: inline
-                  #{series.summary.strip}
+              - if series.summary && !series.summary.strip.empty?
+                %p
+                  :asciidoc
+                    :doctype: inline
+                    #{series.summary.strip}
               .ui.right.aligned.basic.segment
                 %a.ui.right.labeled.icon.button.primary{:href => "./#{series.version}/"}
                   %i.right.arrow.icon

--- a/_partials/project/hero-series.html.haml
+++ b/_partials/project/hero-series.html.haml
@@ -1,9 +1,10 @@
 - real_page = page['real_page']
 - project_description = site.projects[real_page.project]
 - series = project_description.release_series[real_page.series_version]
-.page-title.small
-  .ui.container
-    %h4
-      :asciidoc
-        :doctype: inline
-        #{series.summary.strip}
+- if series.summary && !series.summary.strip.empty?
+  .page-title.small
+    .ui.container
+      %h4
+        :asciidoc
+          :doctype: inline
+          #{series.summary.strip}

--- a/_partials/project/series-documentation.html.haml
+++ b/_partials/project/series-documentation.html.haml
@@ -1,12 +1,14 @@
 - project_description = page.project
 - series = page.series
 - anchors = page.anchors
+- doc_content = false
 
 - getting_started_guides = getting_started_guides(project_description, series)
 - if anchors && ! getting_started_guides.empty?
   - # Legacy anchor, kept just so we don't break existing links
   %a{:id => "getting_started"}
 - getting_started_guides.each do |getting_started_guide|
+  - doc_content = true
   %p
     %span.ui.label.basic.horizontal
       Getting started guide
@@ -22,6 +24,7 @@
         PDF
 - whats_new = whats_new(project_description, series)
 - if not whats_new.nil?
+  - doc_content = true
   %p
     %span.ui.label.basic.horizontal
       What's new
@@ -35,6 +38,7 @@
         PDF
 - migration_guide = migration_guide(project_description, series)
 - if not migration_guide.nil?
+  - doc_content = true
   %p
     - if anchors
       - # Legacy anchor, kept just so we don't break existing links
@@ -51,6 +55,7 @@
         PDF
 - short_guide = short_guide(project_description, series)
 - if not short_guide.nil?
+  - doc_content = true
   %p
     %span.ui.label.basic.horizontal
       Short guide
@@ -63,23 +68,30 @@
         %i.icon.file.pdf.outline
         PDF
 - reference_doc = reference_doc(project_description, series)
-%p
-  %span.ui.label.basic.horizontal
-    Reference
-  %a.ui.right.labeled.icon.button.small(href="#{reference_doc.html_url}")
-    %i.icon.file.text.outline
-    HTML
-  - if not reference_doc.pdf_url.nil?
-    %a.ui.right.labeled.icon.button.small(href="#{reference_doc.pdf_url}")
-      %i.icon.file.pdf.outline
-      PDF
-  - javadoc = javadoc(project_description, series)
-  %a.ui.right.labeled.icon.button.small(href="#{javadoc.html_url}")
-    %i.icon.code.outline
-    API (Javadoc)
+- if not reference_doc.nil?
+  - doc_content = true
+  %p
+    %span.ui.label.basic.horizontal
+      Reference
+    %a.ui.right.labeled.icon.button.small(href="#{reference_doc.html_url}")
+      %i.icon.file.text.outline
+      HTML
+    - if not reference_doc.pdf_url.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{reference_doc.pdf_url}")
+        %i.icon.file.pdf.outline
+        PDF
+    - javadoc = javadoc(project_description, series)
+    - if not javadoc.nil?
+      %a.ui.right.labeled.icon.button.small(href="#{javadoc.html_url}")
+        %i.icon.code.outline
+        API (Javadoc)
 - doc = doc(project_description, series)
 - if not doc.nil?
+  - doc_content = true
   %p
     %a.ui.right.labeled.icon.button(href="#{doc.html_url}")
       %i.icon.book
       More documentation for #{series.version}
+- if not doc_content
+  %p
+    Documentation is not currently available for this series.

--- a/_scripts/check-maven-artifacts.py
+++ b/_scripts/check-maven-artifacts.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Extract Maven Central artifact links from built website and verify they exist.
+"""
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs, unquote
+from html.parser import HTMLParser
+import urllib.request
+import urllib.error
+
+class MavenLinkExtractor(HTMLParser):
+    """Extract Maven Central and Maven Repository links from HTML."""
+
+    def __init__(self):
+        super().__init__()
+        self.links = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'a':
+            for attr, value in attrs:
+                if attr == 'href' and value:
+                    # Match Maven Central artifact links
+                    if 'central.sonatype.com/artifact/' in value:
+                        self.links.append(('central', value))
+                    # Match direct Maven repo links
+                    elif 'repo.maven.apache.org/maven2/' in value or 'repo1.maven.org/maven2/' in value:
+                        self.links.append(('repo', value))
+
+def extract_artifact_info_from_central_url(url):
+    """Extract group_id, artifact_id, version from central.sonatype.com URL."""
+    # Example: https://central.sonatype.com/artifact/org.hibernate/hibernate/1.2.5
+    match = re.search(r'/artifact/([^/]+)/([^/]+)/([^/?]+)', url)
+    if match:
+        return {
+            'group_id': match.group(1),
+            'artifact_id': match.group(2),
+            'version': match.group(3),
+            'url': url
+        }
+    return None
+
+def extract_artifact_info_from_repo_url(url):
+    """Extract artifact info from repo.maven.apache.org URL."""
+    # Example: https://repo.maven.apache.org/maven2/org/hibernate/hibernate/1.2.5/
+    # or https://repo1.maven.org/maven2/org/hibernate/hibernate/1.2.5/hibernate-1.2.5.pom
+    parsed = urlparse(url)
+    path = parsed.path
+
+    # Remove /maven2/ prefix
+    path = re.sub(r'.*/maven2/', '', path)
+
+    # Split into parts
+    parts = [p for p in path.split('/') if p]
+
+    if len(parts) >= 3:
+        # Last part might be filename or empty
+        version = parts[-1] if not parts[-1].endswith('.pom') and not parts[-1].endswith('.jar') else parts[-2]
+        artifact_id = parts[-2] if not parts[-1].endswith('.pom') and not parts[-1].endswith('.jar') else parts[-3]
+
+        # Group ID is everything before artifact_id
+        if not parts[-1].endswith('.pom') and not parts[-1].endswith('.jar'):
+            group_parts = parts[:-2]
+        else:
+            group_parts = parts[:-3]
+
+        if group_parts:
+            group_id = '.'.join(group_parts)
+            return {
+                'group_id': group_id,
+                'artifact_id': artifact_id,
+                'version': version,
+                'url': url
+            }
+
+    return None
+
+def check_artifact_exists_on_central(group_id, artifact_id, version):
+    """Check if artifact exists on Maven Central via central.sonatype.com API."""
+    # Use the central.sonatype.com artifact page
+    url = f"https://central.sonatype.com/artifact/{group_id}/{artifact_id}/{version}"
+
+    try:
+        req = urllib.request.Request(url, method='HEAD')
+        req.add_header('User-Agent', 'Mozilla/5.0 (compatible; Maven Artifact Checker/1.0)')
+        with urllib.request.urlopen(req, timeout=10) as response:
+            return response.status == 200
+    except urllib.error.HTTPError as e:
+        return False
+    except Exception as e:
+        print(f"  Warning: Error checking {url}: {e}", file=sys.stderr)
+        return None  # Unknown
+
+def check_artifact_exists_on_repo(group_id, artifact_id, version):
+    """Check if artifact exists on Maven repository by checking for POM file."""
+    # Convert group_id to path
+    group_path = group_id.replace('.', '/')
+
+    # Try repo1.maven.org first (Maven Central's primary CDN)
+    pom_url = f"https://repo1.maven.org/maven2/{group_path}/{artifact_id}/{version}/{artifact_id}-{version}.pom"
+
+    try:
+        req = urllib.request.Request(pom_url, method='HEAD')
+        req.add_header('User-Agent', 'Mozilla/5.0 (compatible; Maven Artifact Checker/1.0)')
+        with urllib.request.urlopen(req, timeout=10) as response:
+            return response.status == 200
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return False
+        return None  # Other error - unknown
+    except Exception as e:
+        print(f"  Warning: Error checking {pom_url}: {e}", file=sys.stderr)
+        return None  # Unknown
+
+def scan_html_files(site_dir):
+    """Scan all HTML files in site directory and extract Maven links."""
+    site_path = Path(site_dir)
+    all_artifacts = {}
+
+    if not site_path.exists():
+        print(f"Error: Directory {site_dir} does not exist", file=sys.stderr)
+        print("Have you built the site? Run the build command first.", file=sys.stderr)
+        return {}
+
+    html_files = list(site_path.rglob('*.html'))
+    print(f"Scanning {len(html_files)} HTML files...\n")
+
+    for html_file in html_files:
+        try:
+            with open(html_file, 'r', encoding='utf-8') as f:
+                content = f.read()
+
+            parser = MavenLinkExtractor()
+            parser.feed(content)
+
+            for link_type, url in parser.links:
+                artifact_info = None
+
+                if link_type == 'central':
+                    artifact_info = extract_artifact_info_from_central_url(url)
+                elif link_type == 'repo':
+                    artifact_info = extract_artifact_info_from_repo_url(url)
+
+                if artifact_info:
+                    key = (artifact_info['group_id'], artifact_info['artifact_id'], artifact_info['version'])
+                    if key not in all_artifacts:
+                        all_artifacts[key] = {
+                            'info': artifact_info,
+                            'files': set()
+                        }
+                    all_artifacts[key]['files'].add(str(html_file.relative_to(site_path)))
+
+        except Exception as e:
+            print(f"Warning: Error processing {html_file}: {e}", file=sys.stderr)
+
+    return all_artifacts
+
+def extract_major_minor(version):
+    """Extract major.minor version from a version string."""
+    # Match patterns like: 1.2.3, 1.2.3.Final, 1.2beta1, etc.
+    match = re.match(r'^(\d+)\.(\d+)', version)
+    if match:
+        return f"{match.group(1)}.{match.group(2)}"
+    return "unknown"
+
+def main():
+    site_dir = '_site'
+
+    if len(sys.argv) > 1:
+        site_dir = sys.argv[1]
+
+    print(f"Maven Central Artifact Checker")
+    print(f"=" * 80)
+    print(f"Site directory: {site_dir}\n")
+
+    # Extract all artifacts
+    artifacts = scan_html_files(site_dir)
+
+    if not artifacts:
+        print("No Maven Central artifact links found.")
+        return 0
+
+    print(f"Found {len(artifacts)} unique artifacts referenced in the site.\n")
+    print("Checking which artifacts exist on Maven Central...")
+    print("(This may take a while...)\n")
+
+    missing_artifacts = []
+    unknown_artifacts = []
+    found_artifacts = []
+    checked = 0
+
+    for key, data in sorted(artifacts.items()):
+        group_id, artifact_id, version = key
+        info = data['info']
+
+        # Check if artifact exists
+        exists = check_artifact_exists_on_repo(group_id, artifact_id, version)
+
+        checked += 1
+        if checked % 10 == 0:
+            print(f"  Checked {checked}/{len(artifacts)} artifacts...", end='\r')
+
+        if exists is False:
+            missing_artifacts.append((key, data))
+        elif exists is None:
+            unknown_artifacts.append((key, data))
+        else:
+            found_artifacts.append((key, data))
+
+        # Be nice to Maven Central - rate limit
+        time.sleep(0.2)
+
+    print(f"  Checked {checked}/{len(artifacts)} artifacts... Done!      \n")
+
+    # Organize data by artifact
+    artifacts_data = {}
+
+    # Collect all versions (found and missing) for each artifact
+    for key, data in found_artifacts + missing_artifacts:
+        group_id, artifact_id, version = key
+        artifact_key = f"{group_id}:{artifact_id}"
+
+        if artifact_key not in artifacts_data:
+            artifacts_data[artifact_key] = {
+                'versions_by_series': {},  # major.minor -> {'found': count, 'total': count}
+                'missing_versions': []
+            }
+
+        major_minor = extract_major_minor(version)
+
+        if major_minor not in artifacts_data[artifact_key]['versions_by_series']:
+            artifacts_data[artifact_key]['versions_by_series'][major_minor] = {
+                'found': 0,
+                'total': 0
+            }
+
+        artifacts_data[artifact_key]['versions_by_series'][major_minor]['total'] += 1
+
+        # Check if this version was found
+        if (key, data) in found_artifacts:
+            artifacts_data[artifact_key]['versions_by_series'][major_minor]['found'] += 1
+        else:
+            artifacts_data[artifact_key]['missing_versions'].append(version)
+
+    # Report results
+    print("=" * 80)
+    print("ARTIFACTS REPORT")
+    print("=" * 80)
+    print()
+
+    for artifact_key in sorted(artifacts_data.keys()):
+        data = artifacts_data[artifact_key]
+
+        # Determine status
+        has_missing = len(data['missing_versions']) > 0
+        status = "❌" if has_missing else "✅"
+
+        print(f"{status} {artifact_key}")
+
+        # Print versions found line
+        version_parts = []
+        for series in sorted(data['versions_by_series'].keys()):
+            stats = data['versions_by_series'][series]
+            version_parts.append(f"{series} ({stats['found']}/{stats['total']})")
+
+        print(f"  Versions: {', '.join(version_parts)}")
+
+        # Print missing versions line
+        if data['missing_versions']:
+            missing_str = ', '.join(sorted(data['missing_versions']))
+            print(f"  Missing: {missing_str}")
+        else:
+            print(f"  Missing: (none)")
+
+        print()
+
+    # Detailed missing artifacts listing with file references
+    if missing_artifacts:
+        print("=" * 80)
+        print(f"DETAILED MISSING ARTIFACTS ({len(missing_artifacts)}):")
+        print("=" * 80)
+        for key, data in missing_artifacts:
+            group_id, artifact_id, version = key
+            print(f"\n❌ {group_id}:{artifact_id}:{version}")
+            print(f"   URL: {data['info']['url']}")
+            print(f"   Referenced in:")
+            for file_path in sorted(data['files']):
+                print(f"     - {file_path}")
+        print()
+
+    if unknown_artifacts:
+        print(f"UNKNOWN STATUS ({len(unknown_artifacts)}):")
+        print("-" * 80)
+        print("(Network errors or other issues prevented verification)")
+        for key, data in unknown_artifacts:
+            group_id, artifact_id, version = key
+            print(f"\n⚠️  {group_id}:{artifact_id}:{version}")
+            print(f"   URL: {data['info']['url']}")
+        print()
+
+    # Summary
+    print("=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+    print(f"Total artifacts checked: {len(artifacts)}")
+    print(f"Existing artifacts: {len(found_artifacts)}")
+    print(f"Missing artifacts: {len(missing_artifacts)}")
+    print(f"Unknown status: {len(unknown_artifacts)}")
+    print()
+
+    # Return exit code based on results
+    return 1 if missing_artifacts else 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/_spec/release_file_parser_spec.rb
+++ b/_spec/release_file_parser_spec.rb
@@ -77,6 +77,85 @@ describe Awestruct::Extensions::ReleaseFileParser do
         expect(@site.projects[:foo].releases.length).to eql 1
     end
 
+    describe "legacy version format support" do
+        before :each do
+            @parser = Awestruct::Extensions::ReleaseFileParser.new
+            @release = OpenStruct.new
+        end
+
+        it "accepts 2-component plain versions" do
+            @release.version = "3.0"
+            expect {
+                @parser.send(:determineStability, @release, "3.0.yml")
+            }.not_to raise_error
+            expect(@release.stable).to be true
+        end
+
+        it "accepts 3-component plain versions" do
+            @release.version = "3.0.1"
+            expect {
+                @parser.send(:determineStability, @release, "3.0.1.yml")
+            }.not_to raise_error
+            expect(@release.stable).to be true
+        end
+
+        it "accepts 2-component versions with lowercase beta suffix (no separator)" do
+            @release.version = "3.0beta1"
+            expect {
+                @parser.send(:determineStability, @release, "3.0beta1.yml")
+            }.not_to raise_error
+            expect(@release.stable).to be false
+        end
+
+        it "accepts 2-component versions with lowercase alpha suffix (no separator)" do
+            @release.version = "3.0alpha"
+            expect {
+                @parser.send(:determineStability, @release, "3.0alpha.yml")
+            }.not_to raise_error
+            expect(@release.stable).to be false
+        end
+
+        it "accepts versions with letter suffix after number" do
+            @release.version = "3.0beta4b"
+            expect {
+                @parser.send(:determineStability, @release, "3.0beta4b.yml")
+            }.not_to raise_error
+            expect(@release.stable).to be false
+        end
+
+        it "accepts lowercase cr versions" do
+            @release.version = "3.2.0.cr1"
+            expect {
+                @parser.send(:determineStability, @release, "3.2.0.cr1.yml")
+            }.not_to raise_error
+            expect(@release.stable).to be false
+        end
+
+        it "accepts uppercase CR versions" do
+            @release.version = "3.2.0.CR1"
+            expect {
+                @parser.send(:determineStability, @release, "3.2.0.CR1.yml")
+            }.not_to raise_error
+            expect(@release.stable).to be false
+        end
+
+        it "accepts lowercase ga versions" do
+            @release.version = "3.2.0.ga"
+            expect {
+                @parser.send(:determineStability, @release, "3.2.0.ga.yml")
+            }.not_to raise_error
+            expect(@release.stable).to be true
+        end
+
+        it "accepts uppercase GA versions" do
+            @release.version = "3.2.0.GA"
+            expect {
+                @parser.send(:determineStability, @release, "3.2.0.GA.yml")
+            }.not_to raise_error
+            expect(@release.stable).to be true
+        end
+    end
+
     describe "#extractCommentFromConstraint" do
         before :each do
             @parser = Awestruct::Extensions::ReleaseFileParser.new

--- a/_spec/version_spec.rb
+++ b/_spec/version_spec.rb
@@ -149,4 +149,297 @@ describe Awestruct::Extensions::Version do
 			expect(versions).to eq(['16', '15', '14', '13'])
 		end
 	end
+
+	describe "legacy version formats" do
+		describe "2-component versions" do
+			it "parses plain 2-component versions" do
+				version = Awestruct::Extensions::Version.new("3.0")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(0)
+				expect(version.micro).to eq(0)
+				expect(version.suffix).to be_nil
+				expect(version.stable?).to be true
+			end
+
+			it "parses 2-component versions with lowercase suffix (no separator)" do
+				version = Awestruct::Extensions::Version.new("3.0beta1")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(0)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("beta")
+				expect(version.suffix.number).to eq(1)
+				expect(version.stable?).to be false
+			end
+
+			it "parses 2-component versions with letter suffix after number" do
+				version = Awestruct::Extensions::Version.new("3.0beta4b")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(0)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("beta")
+				expect(version.suffix.number).to eq(4)
+				expect(version.stable?).to be false
+			end
+
+			it "parses 2-component versions with alpha suffix" do
+				version = Awestruct::Extensions::Version.new("3.0alpha")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(0)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("alpha")
+				expect(version.suffix.number).to be_nil
+				expect(version.stable?).to be false
+			end
+		end
+
+		describe "hyphenated versions" do
+			it "parses hyphenated Beta versions" do
+				version = Awestruct::Extensions::Version.new("3.5.0-Beta-2")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(5)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("Beta")
+				expect(version.suffix.number).to eq(2)
+			end
+
+			it "parses hyphenated CR versions" do
+				version = Awestruct::Extensions::Version.new("3.5.0-CR-1")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(5)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("CR")
+				expect(version.suffix.number).to eq(1)
+			end
+
+			it "parses hyphenated Final versions" do
+				version = Awestruct::Extensions::Version.new("3.5.0-Final")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(5)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("Final")
+				expect(version.suffix.number).to be_nil
+			end
+
+			it "parses mixed dot-hyphen versions" do
+				version = Awestruct::Extensions::Version.new("3.5.0.Beta-1")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(5)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("Beta")
+				expect(version.suffix.number).to eq(1)
+			end
+		end
+
+		describe "lowercase legacy versions" do
+			it "parses lowercase ga versions" do
+				version = Awestruct::Extensions::Version.new("3.2.0.ga")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(2)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("ga")
+				expect(version.suffix.number).to be_nil
+			end
+
+			it "parses lowercase cr versions" do
+				version = Awestruct::Extensions::Version.new("3.2.0.cr1")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(2)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("cr")
+				expect(version.suffix.number).to eq(1)
+			end
+
+			it "parses lowercase sp versions" do
+				version = Awestruct::Extensions::Version.new("3.2.4.sp1")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(2)
+				expect(version.micro).to eq(4)
+				expect(version.suffix.prefix).to eq("sp")
+				expect(version.suffix.number).to eq(1)
+			end
+		end
+
+		describe "uppercase legacy versions" do
+			it "parses uppercase GA versions" do
+				version = Awestruct::Extensions::Version.new("3.3.0.GA")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(3)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("GA")
+				expect(version.suffix.number).to be_nil
+			end
+
+			it "parses uppercase CR versions" do
+				version = Awestruct::Extensions::Version.new("3.3.0.CR1")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(3)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("CR")
+				expect(version.suffix.number).to eq(1)
+			end
+
+			it "parses uppercase SP versions" do
+				version = Awestruct::Extensions::Version.new("3.3.0.SP1")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(3)
+				expect(version.micro).to eq(0)
+				expect(version.suffix.prefix).to eq("SP")
+				expect(version.suffix.number).to eq(1)
+			end
+		end
+
+		describe "plain versions without suffix" do
+			it "parses plain version numbers" do
+				version = Awestruct::Extensions::Version.new("3.0.1")
+				expect(version.major).to eq(3)
+				expect(version.minor).to eq(0)
+				expect(version.micro).to eq(1)
+				expect(version.suffix).to be_nil
+			end
+		end
+
+		describe "version comparison with legacy formats" do
+			it "correctly orders mixed version formats" do
+				versions = [
+					Awestruct::Extensions::Version.new("3.2.0.cr1"),
+					Awestruct::Extensions::Version.new("3.2.0.ga"),
+					Awestruct::Extensions::Version.new("3.2.1.ga"),
+					Awestruct::Extensions::Version.new("3.5.0-Beta-2"),
+					Awestruct::Extensions::Version.new("3.5.0-CR-1"),
+					Awestruct::Extensions::Version.new("3.5.0-Final"),
+					Awestruct::Extensions::Version.new("3.5.1-Final"),
+				]
+
+				# Verify versions are in ascending order
+				versions.each_with_index do |version, index|
+					break if index == (versions.length - 1)
+					expect(version <=> versions[index + 1]).to eq(-1),
+						"Expected #{version} < #{versions[index + 1]}"
+				end
+			end
+
+			it "treats GA as stable release equivalent to Final" do
+				ga_version = Awestruct::Extensions::Version.new("3.2.0.ga")
+				cr_version = Awestruct::Extensions::Version.new("3.2.0.cr1")
+				expect(ga_version > cr_version).to be true
+			end
+
+			it "treats plain versions as stable releases" do
+				plain_version = Awestruct::Extensions::Version.new("3.0.1")
+				expect(plain_version.suffix).to be_nil
+			end
+		end
+
+		describe "nil suffix comparison" do
+			it "treats nil suffix as greater than pre-release suffixes" do
+				plain = Awestruct::Extensions::Version.new("3.0.1")
+				alpha = Awestruct::Extensions::Version.new("3.0.1.Alpha1")
+				beta = Awestruct::Extensions::Version.new("3.0.1.Beta1")
+				cr = Awestruct::Extensions::Version.new("3.0.1.CR1")
+
+				expect(plain > alpha).to be true
+				expect(plain > beta).to be true
+				expect(plain > cr).to be true
+			end
+
+			it "compares two nil suffixes as equal" do
+				v1 = Awestruct::Extensions::Version.new("3.0.1")
+				v2 = Awestruct::Extensions::Version.new("3.0.1")
+				expect(v1 <=> v2).to eq(0)
+			end
+
+			it "orders versions with mixed nil and non-nil suffixes correctly" do
+				versions = [
+					Awestruct::Extensions::Version.new("3.0.1.Alpha1"),
+					Awestruct::Extensions::Version.new("3.0.1.Beta1"),
+					Awestruct::Extensions::Version.new("3.0.1.CR1"),
+					Awestruct::Extensions::Version.new("3.0.1"),  # nil suffix (stable)
+					Awestruct::Extensions::Version.new("3.0.1.Final"),
+					Awestruct::Extensions::Version.new("3.0.2"),  # nil suffix (stable, next micro)
+				]
+
+				# Verify they're in ascending order
+				versions.each_with_index do |version, index|
+					break if index == (versions.length - 1)
+					result = version <=> versions[index + 1]
+					expect(result).to eq(-1),
+						"Expected #{version} < #{versions[index + 1]}, but got #{result}"
+				end
+			end
+
+			describe "stability determination" do
+				it "treats plain versions as stable" do
+					expect(Awestruct::Extensions::Version.new("3.0").stable?).to be true
+					expect(Awestruct::Extensions::Version.new("3.0.1").stable?).to be true
+				end
+
+				it "treats alpha versions as unstable" do
+					expect(Awestruct::Extensions::Version.new("3.0alpha").stable?).to be false
+					expect(Awestruct::Extensions::Version.new("3.0.1.Alpha1").stable?).to be false
+				end
+
+				it "treats beta versions as unstable" do
+					expect(Awestruct::Extensions::Version.new("3.0beta1").stable?).to be false
+					expect(Awestruct::Extensions::Version.new("3.0.1.Beta1").stable?).to be false
+				end
+
+				it "treats CR versions as unstable" do
+					expect(Awestruct::Extensions::Version.new("3.0.1.CR1").stable?).to be false
+					expect(Awestruct::Extensions::Version.new("3.0.1.cr1").stable?).to be false
+				end
+
+				it "treats Final versions as stable" do
+					expect(Awestruct::Extensions::Version.new("3.0.1.Final").stable?).to be true
+				end
+
+				it "treats GA versions as stable" do
+					expect(Awestruct::Extensions::Version.new("3.0.1.GA").stable?).to be true
+					expect(Awestruct::Extensions::Version.new("3.0.1.ga").stable?).to be true
+				end
+
+				it "treats SP versions as stable" do
+					expect(Awestruct::Extensions::Version.new("3.0.1.SP1").stable?).to be true
+				end
+			end
+
+			describe "case-sensitive suffix ordering" do
+				it "orders lowercase before uppercase for same suffix and number" do
+					lowercase = Awestruct::Extensions::Version.new("3.2.0.cr1")
+					uppercase = Awestruct::Extensions::Version.new("3.2.0.CR1")
+					expect(lowercase < uppercase).to be true
+				end
+
+				it "orders by number before case" do
+					# cr1 < CR1 < cr2 < CR2
+					v1 = Awestruct::Extensions::Version.new("3.2.0.cr1")
+					v2 = Awestruct::Extensions::Version.new("3.2.0.CR1")
+					v3 = Awestruct::Extensions::Version.new("3.2.0.cr2")
+					v4 = Awestruct::Extensions::Version.new("3.2.0.CR2")
+
+					expect(v1 < v2).to be true
+					expect(v2 < v3).to be true
+					expect(v3 < v4).to be true
+				end
+
+				it "orders mixed-case versions correctly" do
+					versions = [
+						Awestruct::Extensions::Version.new("3.2.0.cr1"),
+						Awestruct::Extensions::Version.new("3.2.0.CR1"),
+						Awestruct::Extensions::Version.new("3.2.0.cr2"),
+						Awestruct::Extensions::Version.new("3.2.0.CR2"),
+						Awestruct::Extensions::Version.new("3.2.0.ga"),
+						Awestruct::Extensions::Version.new("3.2.0.GA"),
+					]
+
+					# Verify they're in ascending order
+					versions.each_with_index do |version, index|
+						break if index == (versions.length - 1)
+						result = version <=> versions[index + 1]
+						expect(result).to eq(-1),
+							"Expected #{version} < #{versions[index + 1]}, but got #{result}"
+					end
+				end
+			end
+		end
+	end
 end

--- a/orm/releases/4.2/index.adoc
+++ b/orm/releases/4.2/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "4.2"

--- a/orm/releases/4.3/index.adoc
+++ b/orm/releases/4.3/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "4.3"

--- a/orm/releases/5.0/index.adoc
+++ b/orm/releases/5.0/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "5.0"

--- a/orm/releases/5.1/index.adoc
+++ b/orm/releases/5.1/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "5.1"

--- a/orm/releases/5.2/index.adoc
+++ b/orm/releases/5.2/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "5.2"

--- a/orm/releases/5.3/index.adoc
+++ b/orm/releases/5.3/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "5.3"

--- a/orm/releases/7.0/index.adoc
+++ b/orm/releases/7.0/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "7.0"

--- a/orm/releases/7.1/index.adoc
+++ b/orm/releases/7.1/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "7.1"

--- a/orm/releases/7.2/index.adoc
+++ b/orm/releases/7.2/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "7.2"

--- a/orm/releases/7.3/index.adoc
+++ b/orm/releases/7.3/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "7.3"

--- a/orm/releases/8.0/index.adoc
+++ b/orm/releases/8.0/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: orm
-:awestruct-series_version: "8.0"

--- a/search/releases/4.4/index.adoc
+++ b/search/releases/4.4/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: search
-:awestruct-series_version: "4.4"

--- a/search/releases/4.5/index.adoc
+++ b/search/releases/4.5/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: search
-:awestruct-series_version: "4.5"

--- a/search/releases/5.0/index.adoc
+++ b/search/releases/5.0/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: search
-:awestruct-series_version: "5.0"

--- a/search/releases/5.1/index.adoc
+++ b/search/releases/5.1/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: search
-:awestruct-series_version: "5.1"

--- a/search/releases/5.2/index.adoc
+++ b/search/releases/5.2/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: search
-:awestruct-series_version: "5.2"

--- a/search/releases/5.3/index.adoc
+++ b/search/releases/5.3/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: search
-:awestruct-series_version: "5.3"

--- a/search/releases/5.4/index.adoc
+++ b/search/releases/5.4/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: search
-:awestruct-series_version: "5.4"

--- a/survival-guide.adoc
+++ b/survival-guide.adoc
@@ -269,6 +269,35 @@ to set the `displayed` attribute to `false` (just add the attribute if it is mis
 To only hide download links and Maven coordinates,
 set the `available` attribute to `false` (just add the attribute if it is missing).
 
+== Verify Maven Central artifacts
+
+After building the site, you can verify that all Maven Central artifact links point to actual artifacts
+using the `_scripts/check-maven-artifacts.py` script.
+
+This is particularly useful when adding older series to ensure the artifacts are actually available on Maven Central.
+
+[source,bash]
+----
+# First build the site
+podman run --rm -t --userns=keep-id -u $UID:$GID \
+  -v $PWD:/home/dev/website:rw,Z \
+  quay.io/hibernate/awestruct-build-env:latest \
+  rake clean gen
+
+# Then run the artifact checker
+python3 _scripts/check-maven-artifacts.py
+----
+
+The script will:
+
+* Scan all HTML files in `_site/`
+* Extract Maven Central artifact links from the pages
+* Verify each artifact exists by checking Maven Central
+* Report which artifacts are missing with details about which pages reference them
+
+If artifacts are missing for an older series, you should update the `series.yml` file
+to note that the artifacts are not available on Maven Central.
+
 == Data
 
 === `_config/site.yml`

--- a/survival-guide.adoc
+++ b/survival-guide.adoc
@@ -201,6 +201,11 @@ they are used to generate links to all JIRA tickets of a given series, for insta
 If your release is the first one of a new series, you will also have to create a new `series.yml` file
 in the `_data/<project ID>/releases/<series version>` directory.
 
+NOTE: The `index.adoc` file for each series page (e.g., `orm/releases/5.0/index.adoc`) is automatically
+generated as a virtual page during the build process. You do not need to create this file in the source
+tree. The `ReleaseSeriesIndexGenerator` extension will detect any series with a `series.yml` file and
+generate the corresponding page in `_site` if no source `index.adoc` exists.
+
 For information about the content of each file, see <<data_directory,here>>.
 
 === Series status

--- a/validator/releases/4.3/index.adoc
+++ b/validator/releases/4.3/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: validator
-:awestruct-series_version: "4.3"

--- a/validator/releases/5.0/index.adoc
+++ b/validator/releases/5.0/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: validator
-:awestruct-series_version: "5.0"

--- a/validator/releases/5.1/index.adoc
+++ b/validator/releases/5.1/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: validator
-:awestruct-series_version: "5.1"

--- a/validator/releases/5.2/index.adoc
+++ b/validator/releases/5.2/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: validator
-:awestruct-series_version: "5.2"

--- a/validator/releases/9.1/index.adoc
+++ b/validator/releases/9.1/index.adoc
@@ -1,3 +1,0 @@
-:awestruct-layout: project-releases-series
-:awestruct-project: validator
-:awestruct-series_version: "9.1"


### PR DESCRIPTION
Have you ever needed to know when Hibernate ORM 1.0 was released? Which version of ORM targeted JPA 1.0? Etc.?

I have, rarely but definitely more than once, and I've been asked, too, and it's always been a pain to find out. No more:

* https://staging.hibernate.org/orm/releases/1.0/ => Okay, that one is close to useless.
* https://staging.hibernate.org/orm/releases/3.3/ => Ah, more useful!
   
* https://staging.hibernate.org/community/integrations/#java_ee_jpa => :heart_eyes: 
   <img width="942" height="374" alt="image" src="https://github.com/user-attachments/assets/03121401-eb2f-443e-9a90-bf3962ca8cf8" />
   <img width="942" height="374" alt="image" src="https://github.com/user-attachments/assets/4f51f9cf-b569-4b35-ab0f-fbe0144483d4" />

Of course this was automated and there will be mistakes, but from what I could see it's not too bad.

Of course a lot of the information is missing, but what's there is still useful.
