### PR TITLE
List inactive Java and Spring Boot series explicitly 

### DIFF
--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -19,6 +19,14 @@
 java:
   name: Java
   url: https://www.oracle.com/java/technologies/downloads/
+  inactive_series:
+    # Only EOL'd Java versions mentioned in still-supported project series need to be here.
+    # They are generally the more recent non-LTS versions (except *the* most recent one, of course).
+    - "20"
+    - "21"
+    - "22"
+    - "23"
+    - "24"
 orm:
   name: Hibernate ORM
   url: /orm/
@@ -101,3 +109,15 @@ spring_boot:
   name: Spring Boot
   url: https://spring.io/projects/spring-boot
   downstream: true
+  inactive_series:
+    # Maintained on a best-effort basis.
+    - "1.5"
+    - "2.0"
+    - "2.2"
+    - "2.3"
+    - "2.4"
+    - "2.5"
+    - "2.6"
+    - "3.0"
+    - "3.1"
+    - "3.2"

--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -8,6 +8,13 @@
 # because then this member provides at least "limited support" for the corresponding Hibernate project series,
 # even if this series is not the latest stable.
 #
+# You can control which integration series are displayed using one of two approaches:
+# - active_series: List the series to show; all others are hidden
+# - inactive_series: List the series to hide; all others are shown according to default rules
+#
+# Note: active_series and inactive_series are mutually exclusive approaches.
+# If you specify inactive_series, active_series is ignored.
+#
 # IMPORTANT: The order of entries in this file is the order they are displayed in compatibility matrices on the website.
 java:
   name: Java

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -195,6 +195,8 @@ module Awestruct
           integration = @site.integrations[integration_key]
           integration_constraint[:active] = false
           next unless integration[:downstream] && integration[:hibernate_involvement]
+
+          # Check if this series is in the active_series list
           integration[:active_series]&.each do |active_version_string|
             if Version.new(active_version_string).matches?(integration_constraint[:version])
               integration_constraint[:status] = 'active'
@@ -202,6 +204,18 @@ module Awestruct
               break
             end
           end
+
+          # Check if this series is in the inactive_series list (only if not already marked active)
+          unless integration_constraint[:status]
+            integration[:inactive_series]&.each do |inactive_version_string|
+              if Version.new(inactive_version_string).matches?(integration_constraint[:version])
+                integration_constraint[:status] = 'inactive'
+                break
+              end
+            end
+          end
+
+          # Check if this series is in the els_series list (only if not already marked)
           unless integration_constraint[:status]
             integration[:els_series]&.each do |active_version_string|
               if Version.new(active_version_string).matches?(integration_constraint[:version])
@@ -576,14 +590,18 @@ module Awestruct
       # Compute whether a version should be displayed based on integration settings and compatibility
       def computeVersionDisplayed(integration_version, compatibility, integration, projects_hash)
         has_active_or_els = integration[:active_series]&.any? || integration[:els_series]&.any?
+        has_inactive = integration[:inactive_series]&.any?
 
-        if has_active_or_els
-          # If there are active or els series, check if this integration version is in those lists
-          return true if integration[:active_series]&.include?(integration_version)
-          return true if integration[:els_series]&.include?(integration_version)
+        if has_inactive && integration[:inactive_series]&.include?(integration_version)
+          # If there are inactive series, hide those and display others by default
           false
+        elsif has_active_or_els
+          # If there are active or els series, check if this integration version is in those lists
+          integration[:active_series]&.include?(integration_version) ||
+            integration[:els_series]&.include?(integration_version)
         else
-          # If there are no active or els series, check if compatible with at least one non-EOL project series
+          # If the series is not explicitly inactive, and there is no explicitly active or els series,
+          # check if compatible with at least one non-EOL project series
           isCompatibleWithNonEolSeries(compatibility, projects_hash)
         end
       end

--- a/_spec/inactive_series_test.rb
+++ b/_spec/inactive_series_test.rb
@@ -1,0 +1,107 @@
+require_relative '../_ext/release_file_parser'
+
+# Simple test to verify inactive_series logic
+describe "Inactive Series Logic" do
+  it "inactive_series hides specified versions" do
+    parser = Awestruct::Extensions::ReleaseFileParser.new
+
+    # Mock integration with inactive_series
+    integration = {
+      inactive_series: ['1.0', '1.1']
+    }
+
+    # Mock compatibility that would normally display the version
+    compatibility = {}
+
+    # Mock projects_hash
+    projects_hash = {}
+
+    # Test that inactive series are hidden
+    displayed = parser.send(:computeVersionDisplayed, '1.0', compatibility, integration, projects_hash)
+    expect(displayed).to be false
+
+    displayed = parser.send(:computeVersionDisplayed, '1.1', compatibility, integration, projects_hash)
+    expect(displayed).to be false
+  end
+
+  it "inactive_series shows non-listed versions based on default rules" do
+    parser = Awestruct::Extensions::ReleaseFileParser.new
+
+    # Mock integration with inactive_series
+    integration = {
+      inactive_series: ['1.0', '1.1']
+    }
+
+    # Mock compatibility - empty means no displayed series, so should be false
+    compatibility = {}
+
+    # Mock projects_hash
+    projects_hash = {}
+
+    # Non-inactive versions should use default display logic
+    # (in this case, false because no compatible displayed series)
+    displayed = parser.send(:computeVersionDisplayed, '2.0', compatibility, integration, projects_hash)
+    expect(displayed).to be false
+  end
+
+  it "active_series takes precedence when both are specified" do
+    parser = Awestruct::Extensions::ReleaseFileParser.new
+
+    # Mock integration with both active and inactive series
+    # inactive_series should take precedence
+    integration = {
+      active_series: ['1.0', '1.1'],
+      inactive_series: ['2.0']
+    }
+
+    # Mock compatibility
+    compatibility = {}
+
+    # Mock projects_hash
+    projects_hash = {}
+
+    # When inactive_series is present, it should be used instead of active_series
+    # So 2.0 should be hidden
+    displayed = parser.send(:computeVersionDisplayed, '2.0', compatibility, integration, projects_hash)
+    expect(displayed).to be false
+
+    # And 1.0 should depend on default rules (not active_series)
+    displayed = parser.send(:computeVersionDisplayed, '1.0', compatibility, integration, projects_hash)
+    expect(displayed).to be false
+  end
+
+  it "integration status is set to inactive for inactive_series" do
+    # This tests the markIntegrationStatuses method
+    # We need a more complex mock setup for this
+
+    # Mock site integrations
+    site_integrations = {
+      quarkus: {
+        downstream: true,
+        hibernate_involvement: true,
+        inactive_series: ['3.30', '3.31']
+      }
+    }
+
+    # Mock series with integration constraints
+    series = {
+      integration_constraints: {
+        quarkus: {
+          version: '3.30'
+        }
+      }
+    }
+
+    # Create parser and set @site.integrations
+    parser = Awestruct::Extensions::ReleaseFileParser.new
+    mock_site = double('site')
+    allow(mock_site).to receive(:integrations).and_return(site_integrations)
+    parser.instance_variable_set(:@site, mock_site)
+
+    # Call markIntegrationStatuses
+    parser.send(:markIntegrationStatuses, series)
+
+    # Verify the status is set to 'inactive'
+    expect(series[:integration_constraints][:quarkus][:status]).to eq('inactive')
+  end
+end


### PR DESCRIPTION
So that we hide them by default in hibernate.org/community/integrations/