### PR TITLE
Consistently present corporate contributors' exact contribution before their full description

### DIFF
--- a/community/corporate-contributors.html.haml
+++ b/community/corporate-contributors.html.haml
@@ -44,8 +44,8 @@ title: Corporate contributors
       .header
         %a(href='https://www.mongodb.com/') MongoDB
       .description
-        %p MongoDB is the world’s most popular document database, giving developers a flexible, intuitive way to work with data. With MongoDB Atlas, teams get a fully managed cloud DBaaS platform that combines the flexible document model with a suite of data services, best-in-class security, and enterprise scalability, empowering developers to build any type of application.
         %p MongoDB proudly contributes to the Hibernate ORM project through the MongoDB Extension for Hibernate ORM, bringing first-class support for MongoDB’s document model to the Hibernate ecosystem.
+        %p MongoDB is the world’s most popular document database, giving developers a flexible, intuitive way to work with data. With MongoDB Atlas, teams get a fully managed cloud DBaaS platform that combines the flexible document model with a suite of data services, best-in-class security, and enterprise scalability, empowering developers to build any type of application.
     .extra.content
       = partial( 'project/project-labels.html.haml', {'projects' => [:orm]} )
   .ui.card.fluid.contributor
@@ -56,8 +56,8 @@ title: Corporate contributors
       .header
         %a(href='https://www.oracle.com/') Oracle
       .description
-        %p Oracle offers integrated suites of applications plus secure, autonomous infrastructure in the Oracle Cloud.
         %p Oracle contributes to the Hibernate ORM project to ensure the best support for the Oracle Database.
+        %p Oracle offers integrated suites of applications plus secure, autonomous infrastructure in the Oracle Cloud.
     .extra.content
       = partial( 'project/project-labels.html.haml', {'projects' => [:orm]} )
   .ui.card.fluid.contributor
@@ -68,11 +68,11 @@ title: Corporate contributors
       .header
         %a(href='https://www.sap.com/') SAP
       .description
+        %p SAP contributes to the Hibernate ORM and Search projects to ensure the best support for SAP HANA Cloud in your application.
         %p
           SAP is the market leader in enterprise application software, and announced
           %a(href='https://www.sap.com/hanacloud') SAP HANA Cloud,
           a cloud-native in-memory database which provides advanced analytics on multi-modal data (e.g. vector, time-series, graph, or geo-spatial data).
-        %p SAP contributes to the Hibernate ORM and Search projects to ensure the best support for SAP HANA Cloud in your application.
     .extra.content
       = partial( 'project/project-labels.html.haml', {'projects' => [:orm, :search, :ogm]} )
 


### PR DESCRIPTION
I think that makes more sense given the purpose of that page, and we're already doing it for IBM/RH as well as financial contributors and infrastructure providers.