### PR TITLE
WEBSITE-688 Filter "Other versions" dropdown to only list versions with a documentation page

### DIFF
--- a/_partials/project/orm/documentation-selector.html.haml
+++ b/_partials/project/orm/documentation-selector.html.haml
@@ -1,6 +1,6 @@
 - real_page = page["real_page"]
 - project_description = site.projects[real_page.project]
-- displayed_series = project_description.release_series.values
+- displayed_series = project_description.release_series.values.select { |series| !doc(project_description, series).nil? }
 .jumbotron-button
   .ui.segment.raised#documentation-version-selector-container
     %form.ui.form


### PR DESCRIPTION
## Summary
- The "Other versions" dropdown on ORM documentation pages (e.g. `/orm/documentation/7.0/`) listed all release series (1.0–8.0), including many that don't have a corresponding documentation page, leading to broken links.
- Filter the dropdown to only show versions where `orm/documentation/{version}/index.adoc` exists.

https://hibernate.atlassian.net/browse/WEBSITE-688

## Test plan
- [x] Verified the fix locally by building the site and checking the dropdown