### PR TITLE
Add backticks around technical terms in series.yml summaries

### DIFF
--- a/_data/projects/orm/releases/5.4/series.yml
+++ b/_data/projects/orm/releases/5.4/series.yml
@@ -1,4 +1,4 @@
-summary: EntityGraph improvements, JDK 11 support
+summary: "`EntityGraph` improvements, JDK 11 support"
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/5.4/lgpl.txt

--- a/_data/projects/orm/releases/6.5/series.yml
+++ b/_data/projects/orm/releases/6.5/series.yml
@@ -1,4 +1,4 @@
-summary: Java Time Handling, Configurable Query Cache Layout, records as @IdClass, auto-enabled Filters, Key-based Pagination, Jakarta Data (tech preview)
+summary: "Java Time Handling, Configurable Query Cache Layout, records as `@IdClass`, auto-enabled Filters, Key-based Pagination, Jakarta Data (tech preview)"
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/6.5/lgpl.txt

--- a/_data/projects/orm/releases/6.6/series.yml
+++ b/_data/projects/orm/releases/6.6/series.yml
@@ -1,4 +1,4 @@
-summary: Jakarta Data, @ConcreteProxy, Extended Array Support, Embeddable Inheritance
+summary: "Jakarta Data, `@ConcreteProxy`, Extended Array Support, Embeddable Inheritance"
 license:
   name: LGPL v2.1
   url: https://raw.githubusercontent.com/hibernate/hibernate-orm/6.6/lgpl.txt

--- a/_data/projects/orm/releases/7.0/series.yml
+++ b/_data/projects/orm/releases/7.0/series.yml
@@ -1,4 +1,4 @@
-summary: Apache License, Jakarta Persistence 3.2, Java 17, QuerySpecification, mapping.xsd, Hibernate Models
+summary: "Apache License, Jakarta Persistence 3.2, Java 17, `QuerySpecification`, `mapping.xsd`, Hibernate Models"
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/7.2/series.yml
+++ b/_data/projects/orm/releases/7.2/series.yml
@@ -1,7 +1,7 @@
 summary: >-
   Pessimistic Locking Improvements,
-  @EmbeddedTable,
-  FindMultipleOptions, 
+  `@EmbeddedTable`,
+  `FindMultipleOptions`,
   Vector Support for SQL Server
 status: limited-support
 maven:

--- a/_data/projects/orm/releases/7.3/series.yml
+++ b/_data/projects/orm/releases/7.3/series.yml
@@ -1,8 +1,8 @@
 summary: >-
-  @NaturalIdClass,
+  `@NaturalIdClass`,
   tenant-specific credentials,
   entities and embeddables with no default constructor,
-  check constraints on List order columns
+  check constraints on `List` order columns
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/orm/releases/7.4/series.yml
+++ b/_data/projects/orm/releases/7.4/series.yml
@@ -1,9 +1,9 @@
 summary: >-
-  @Temporal,
-  @Audited,
+  `@Temporal`,
+  `@Audited`,
   Limits & fetch joins,
-  hbm.xml transformation,
-  CacheMode.REFRESH_SESSION
+  `hbm.xml` transformation,
+  `CacheMode.REFRESH_SESSION`
 maven:
   artifacts:
     - artifact_id: hibernate-core

--- a/_data/projects/validator/releases/6.2/series.yml
+++ b/_data/projects/validator/releases/6.2/series.yml
@@ -1,4 +1,4 @@
-summary: Keep javax.* packages, Expression Language overhaul, @SafeHtml removal
+summary: "Keep `javax.*` packages, Expression Language overhaul, `@SafeHtml` removal"
 # Not actually included in any downstream integration we care about, but Marko wants to continue supporting it as the last version using javax. package names.
 status: limited-support
 links:

--- a/_data/projects/validator/releases/7.0/series.yml
+++ b/_data/projects/validator/releases/7.0/series.yml
@@ -1,4 +1,4 @@
-summary: Jakarta Bean Validation 3.0, jakarta.* packages
+summary: "Jakarta Bean Validation 3.0, `jakarta.*` packages"
 links:
   whats_new:
     html: "/validator/releases/{series.version}/#whats-new"

--- a/_data/projects/validator/releases/8.0/series.yml
+++ b/_data/projects/validator/releases/8.0/series.yml
@@ -1,4 +1,4 @@
-summary: Jakarta EE 10, @UUID constraint
+summary: "Jakarta EE 10, `@UUID` constraint"
 links:
   whats_new:
     html: "/validator/releases/{series.version}/#whats-new"

--- a/_data/projects/validator/releases/9.0/series.yml
+++ b/_data/projects/validator/releases/9.0/series.yml
@@ -1,7 +1,7 @@
 summary: >-
   This series targets Jakarta EE 11.
   It implements Jakarta Validation 3.1.
-  New constraints: @KorRRN, @BitcoinAddress,
+  New constraints: `@KorRRN`, `@BitcoinAddress`,
   removal of the Security Manager integration,
   BOM for simpler dependency management,
   dependency updates,


### PR DESCRIPTION
## Summary

- Added backticks around `@`-prefixed annotations (`@ConcreteProxy`, `@IdClass`, `@SafeHtml`, `@UUID`, `@EmbeddedTable`, `@NaturalIdClass`, `@Temporal`, `@Audited`, `@KorRRN`, `@BitcoinAddress`)
- Added backticks around class/interface names (`EntityGraph`, `QuerySpecification`, `FindMultipleOptions`, `CacheMode.REFRESH_SESSION`, `List`)
- Added backticks around file names (`mapping.xsd`, `hbm.xml`)
- Added backticks around package patterns (`jakarta.*`, `javax.*`)

Files already using backticks (search 6.2's `` `@IndexedEmbedded` ``/`` `excludePaths` ``, search 7.0's `` `-orm6` ``, ORM 6.2's `` `MERGE` ``) were left as-is.

## Test plan

- [x] All 113 `series.yml` files parse successfully with a YAML parser
- [x] Backticks are preserved in the parsed string values