### PR TITLE
Left-align documentation category headers on stacked grid

### DIFF
--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -490,6 +490,11 @@ code, kbd, samp {
 		.row {
 			padding: 0;
 		}
+		@media only screen and (max-width: 767px) {
+			.right.aligned.column {
+				text-align: left !important;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- On smaller devices, the Semantic UI stackable grid in the series-documentation partial stacks columns vertically. The category headers ("Introduction", "Migration", "Reference", "API", "Reports") were staying right-aligned from their `.right.aligned` class, which looks wrong in a single-column layout.
- Added a responsive override at `<=767px` to left-align these headers when stacked.

## Test plan

- [x] Resize browser to mobile width on a documentation page (e.g. ORM 7.0) and verify "Introduction", "Migration", etc. are left-aligned
- [x] Verify desktop layout still has right-aligned headers