### PR TITLE
Mark EAP 8.0 as EOL

### DIFF
--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -99,7 +99,6 @@ rheap:
   downstream: true
   hibernate_involvement: true
   active_series:
-    - "8.0"
     - "8.1"
   els_series:
     - "6.4"


### PR DESCRIPTION
And consequently ORM 6.2 and others.

EAP 8.1 replaced it.