### PR TITLE
Add Quarkus 3.38 to series integration constraints

### DIFF
--- a/_data/projects/orm/releases/7.4/series.yml
+++ b/_data/projects/orm/releases/7.4/series.yml
@@ -46,7 +46,9 @@ integration_constraints:
   jakarta_ee:
     version: '11'
   quarkus:
-    version: '3.37'
+    version:
+      from: '3.37'
+      to: '3.38'
   wildfly:
     version: '41'
   spring_boot:

--- a/_data/projects/reactive/releases/3.4/series.yml
+++ b/_data/projects/reactive/releases/3.4/series.yml
@@ -28,4 +28,6 @@ integration_constraints:
   vertx:
     version: '4.5'
   quarkus:
-    version: '3.37'
+    version:
+      from: '3.37'
+      to: '3.38'

--- a/_data/projects/search/releases/8.4/series.yml
+++ b/_data/projects/search/releases/8.4/series.yml
@@ -87,6 +87,8 @@ integration_constraints:
         comment: >-
           https://docs.hibernate.org/search/8.4/reference/en-US/html_single/#other-integrations-lucene-next[through `*-backend-lucene-next`]
   quarkus:
-    version: '3.37'
+    version:
+      from: '3.37'
+      to: '3.38'
   wildfly:
     version: '41'

--- a/_data/projects/validator/releases/9.1/series.yml
+++ b/_data/projects/validator/releases/9.1/series.yml
@@ -51,7 +51,7 @@ integration_constraints:
   quarkus:
     version:
       from: '3.30'
-      to: '3.37'
+      to: '3.38'
   wildfly:
     version:
       - value: '39'


### PR DESCRIPTION
## Summary
- Add Quarkus 3.38 to the integration constraints of ORM 7.4, Reactive 3.4, Search 8.4, and Validator 9.1 series
- Without this, those Hibernate series don't appear under Quarkus on the community integrations page for any active Quarkus version (since 3.37 was replaced by 3.38 in integrations.yml)

## Test plan
- [ ] Verify the integrations page at /community/integrations/ shows ORM 7.4, Reactive 3.4, Search 8.4, and Validator 9.1 under both Quarkus 3.37 and 3.38