### PR TITLE
Remove WildFly 40 from active series

### DIFF
--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -91,7 +91,6 @@ wildfly:
     # For release dates, see https://www.wildfly.org/events/
     # For included versions, see https://github.com/wildfly/wildfly/blob/main/pom.xml
     # For included versions in preview (EE 11), see https://github.com/wildfly/wildfly/blob/main/boms/preview-ee/pom.xml
-    - "40"
     - "41" # Planned
 rheap:
   name: Red Hat EAP


### PR DESCRIPTION
## Summary
- Remove WildFly 40 from the active series in `integrations.yml` since it is no longer active

## Consequences on projects

Series that will change from `limited-support` to `end-of-life`:
- **Hibernate ORM 7.3** — WildFly 40 was its only active downstream integration (Quarkus 3.35–3.36 are not active)
- **Hibernate Search 8.3** — same situation (Quarkus 3.35–3.36, WildFly 40 only)

Series unaffected (they still have other active integrations):
- **ORM 6.6** — still has WildFly 41 (range 40–41) and EAP 8.1
- **Search 7.2** — still has WildFly 41 (range 40–41) and EAP 8.1
- **Validator 8.0** — still has WildFly 41 (range 40–41) and EAP 8.0–8.1
- **Validator 9.1** — still has WildFly 41 (range 40–41) and Quarkus 3.30–3.38

## Test plan
- [ ] Verify ORM 7.3 and Search 8.3 now show as end-of-life
- [ ] Verify ORM 6.6, Search 7.2, Validator 8.0, and Validator 9.1 remain limited-support