### PR TITLE
Upgrade to Semantic UI 2.5.0

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -36,9 +36,9 @@ maven:
 # Various resources
 jquery_js_url: https://code.jquery.com/jquery-3.1.1
 jquery_js_url_integrity: "sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7"
-semantic_ui_js_url: https://cdn.jsdelivr.net/npm/semantic-ui@2.2.14/dist/semantic
-semantic_ui_js_url_integrity: "sha384-KfrAxmzWxzKdfquWGNOhm/N9kEjIgoP2yBPMQmAjQ+Is0hp+3BlcWT6PcI7NuKEP"
-semantic_ui_css_url: https://cdn.jsdelivr.net/npm/semantic-ui@2.2.14/dist/semantic
+semantic_ui_js_url: https://cdn.jsdelivr.net/npm/semantic-ui@2.5.0/dist/semantic
+semantic_ui_js_url_integrity: "sha384-J90C/4H4FEvN97dzFx745RBJDfRe8Lt+DQaL3uLYunPE2dagUsllBeEn5aZa4w8M"
+semantic_ui_css_url: https://cdn.jsdelivr.net/npm/semantic-ui@2.5.0/dist/semantic
 slick_js_url: https://cdn.jsdelivr.net/npm/slick-carousel@1.7.1/slick/slick
 slick_js_url_integrity: "sha384-wBo76R9TGH6DxuCcambHkpxJKY96xJq59OwZONC0A2v0rlNK9Kb75uRdSgxK5j9+"
 slick_css_url: https://cdn.jsdelivr.net/npm/slick-carousel@1.7.1/slick/slick
@@ -650,7 +650,7 @@ profiles:
     css_minifier: disabled
     # Different checksums because we're not using the minified files
     jquery_js_url_integrity: "sha384-VC7EHu0lDzZyFfmjTPJq+DFyIn8TUGAJbEtpXquazFVr00Q/OOx//RjiZ9yU9+9m"
-    semantic_ui_js_url_integrity: "sha384-/OCHdyuUZjDPStDj7ti/VaVeGQ4U9HxuJhh0FNfMTf0eO1VeBLAam8EiKCIK+jso"
+    semantic_ui_js_url_integrity: "sha384-kIFKUWK+wdxfV8cJfSr4f3jPQNEOyf4LlPwR3ugvNq4nYKOrZnu1rTlVLzvo6eu9"
     slick_js_url_integrity: "sha384-vIgLoBvIiHAJ0ttXa/pf/vpP9JgaN/9dCH6zbhDPEF3H8fvQXE0wHjS/LauoTNF1"
     clipboard_js_url_integrity: "sha256-ul94Jn0MBOijGuvXhgx/1/wjaJHN3Ud6TH/cGaDrF24="
     base_url: http://0.0.0.0:4242
@@ -661,7 +661,7 @@ profiles:
     css_minifier: disabled
     # Different checksums because we're not using the minified files
     jquery_js_url_integrity: "sha384-VC7EHu0lDzZyFfmjTPJq+DFyIn8TUGAJbEtpXquazFVr00Q/OOx//RjiZ9yU9+9m"
-    semantic_ui_js_url_integrity: "sha384-/OCHdyuUZjDPStDj7ti/VaVeGQ4U9HxuJhh0FNfMTf0eO1VeBLAam8EiKCIK+jso"
+    semantic_ui_js_url_integrity: "sha384-kIFKUWK+wdxfV8cJfSr4f3jPQNEOyf4LlPwR3ugvNq4nYKOrZnu1rTlVLzvo6eu9"
     slick_js_url_integrity: "sha384-vIgLoBvIiHAJ0ttXa/pf/vpP9JgaN/9dCH6zbhDPEF3H8fvQXE0wHjS/LauoTNF1"
     clipboard_js_url_integrity: "sha256-ul94Jn0MBOijGuvXhgx/1/wjaJHN3Ud6TH/cGaDrF24="
     base_url: http://0.0.0.0:4242

--- a/_layouts/project/project-getting-started.html.haml
+++ b/_layouts/project/project-getting-started.html.haml
@@ -35,7 +35,7 @@ layout: project-standard
                   = guide.name
                 - if not guide.html_url.nil?
                   %a.ui.right.labeled.icon.button.small(href="#{guide.html_url}")
-                    %i.icon.file.text.outline
+                    %i.icon.file.alternate.outline
                     HTML
                 - if not guide.pdf_url.nil?
                   %a.ui.right.labeled.icon.button.small(href="#{guide.pdf_url}")

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -242,7 +242,7 @@ project_hero_partial: project/hero-series.html.haml
   %p
     - if not whats_new.html_url.nil?
       %a.ui.right.labeled.icon.button.small(href="#{whats_new.html_url}")
-        %i.icon.file.text.outline
+        %i.icon.file.alternate.outline
         HTML
     - if not whats_new.pdf_url.nil?
       %a.ui.right.labeled.icon.button.small(href="#{whats_new.pdf_url}")

--- a/_partials/project/series-documentation.html.haml
+++ b/_partials/project/series-documentation.html.haml
@@ -30,7 +30,7 @@
             - if entry.html_url
               %a.ui.button{:href => entry.html_url}
                 HTML&nbsp;
-                %i.icon.file.text.outline<>
+                %i.icon.file.alternate.outline<>
             - if entry.pdf_url
               %a.ui.button{:href => entry.pdf_url}
                 PDF&nbsp;

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -655,29 +655,16 @@ code, kbd, samp {
 		background: rgba(0, 0, 0, 0) none repeat scroll 0 0;
 	}
 
-	.fa.icon-note {
-		font-family: outline-icons;
+	@mixin admonition-icon($codepoint, $font: 'Icons') {
+		font-family: $font;
+		&::before { content: $codepoint; }
 	}
-
-	.fa.icon-note::before {
-		content: "\f249";
-	}
-
-	.fa.icon-tip::before {
-		content: "";
-	}
-
-	.fa.icon-warning::before {
-		content: "";
-	}
-
-	.fa.icon-caution::before {
-		content: "";
-	}
-
-	.fa.icon-important::before {
-		content: "";
-	}
+	// Semantic UI 2.5 icon codepoints for Asciidoc admonition blocks
+	.fa.icon-note      { @include admonition-icon("\f249", 'outline-icons'); } // sticky note outline
+	.fa.icon-tip       { @include admonition-icon("\f0eb", 'outline-icons'); } // lightbulb outline
+	.fa.icon-warning   { @include admonition-icon("\f071"); }                  // exclamation triangle
+	.fa.icon-caution   { @include admonition-icon("\f06d"); }                  // fire
+	.fa.icon-important { @include admonition-icon("\f071"); }                  // exclamation circle
 }
 
 .quoteblock {

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -655,8 +655,12 @@ code, kbd, samp {
 		background: rgba(0, 0, 0, 0) none repeat scroll 0 0;
 	}
 
+	.fa.icon-note {
+		font-family: outline-icons;
+	}
+
 	.fa.icon-note::before {
-		content: "";
+		content: "\f249";
 	}
 
 	.fa.icon-tip::before {


### PR DESCRIPTION
## Summary
- Upgrade Semantic UI from 2.2.14 to 2.5.0 (CDN URLs and integrity hashes)
- Fix icon compatibility for the Font Awesome 4 → 5 transition in SUI 2.5:
  - Replace `file.text.outline` with `file.alternate.outline` in templates to fix a CSS specificity collision
  - Refactor Asciidoc admonition icon overrides into an SCSS mixin with correct codepoints and font families
  - Switch `icon-tip` to `outline-icons` font for consistent outline style

## Context
SUI 2.5 switched its underlying icon font from Font Awesome 4 to Font Awesome 5. FA5 uses three separate font files (`Icons`, `outline-icons`, `brand-icons`) instead of different codepoints for outline variants. This broke several icons on the site.

## Test plan
- [x] Verify documentation page icons (HTML file icon, PDF file icon) render correctly
- [x] Verify Asciidoc admonition icons (note, tip, warning, caution, important) render correctly
- [x] Verify clipboard copy icon works on code blocks
- [x] Spot-check other icons across the site (menu, project pages, 404)