### PR TITLE
Update integration versions and add lifecycle comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,51 @@ podman run --rm -t --userns=keep-id -u $UID:$GID \
 - The workspace directory must be mounted to `/home/dev/website`
 - Use `--rm` to clean up the container after execution
 - The `Z` flag on the volume mount handles SELinux contexts
+
+## Updating Integration Versions
+
+`_data/integrations.yml` controls which integration versions are shown in the compatibility matrix and which downstream integrations keep Hibernate project series in "limited-support" status. It needs periodic updates as upstream projects release new versions or end support.
+
+### How it works
+
+Each integration can define three lists:
+- `active_series`: versions currently in active support (shown in matrix; gives series "limited-support" status for downstream integrations with `hibernate_involvement: true`)
+- `els_series`: versions in extended life support (shown in matrix; gives series "els" status)
+- `inactive_series`: versions to hide from the matrix (opposite approach — everything else is shown)
+
+The `active_series`/`els_series` status marking only applies to integrations with `downstream: true` AND `hibernate_involvement: true` (Quarkus, WildFly, Red Hat EAP). For other integrations (Java, Spring Boot), these lists only affect matrix display.
+
+### Integrations to check
+
+Check each integration against its upstream source:
+
+1. **Quarkus** (`active_series`)
+   - Release planning: https://github.com/quarkusio/quarkus/wiki/Release-Planning
+   - Red Hat support policy: https://access.redhat.com/support/policy/updates/red_hat_build_of_quarkus_notes
+   - Keep current LTS versions (an LTS stays active ~6 months after the next LTS ships) and the latest non-LTS
+   - When a new non-LTS releases, replace the old non-LTS entry; when an LTS expires, remove it
+
+2. **WildFly** (`active_series`)
+   - Releases: https://www.wildfly.org/news/
+   - Included versions: https://github.com/wildfly/wildfly/blob/main/pom.xml
+   - Typically only the latest release is active (no LTS model)
+
+3. **Red Hat EAP** (`active_series` + `els_series`)
+   - Lifecycle: https://endoflife.date/red-hat-jboss-eap or https://access.redhat.com/support/policy/updates/jboss_notes/
+   - Move versions from `active_series` to `els_series` when they enter Extended Life Support
+   - Remove from `els_series` when ELS ends (no more fixes)
+
+4. **Java** (`inactive_series`)
+   - Lifecycle: https://endoflife.date/oracle-jdk
+   - Add non-LTS versions when they reach EOL (every 6 months after release)
+   - Never add LTS versions (11, 17, 21, 25, ...) — they are not EOL'd
+   - Don't add the most recent non-LTS (it's still current)
+
+5. **Spring Boot** (`inactive_series`)
+   - Lifecycle: https://endoflife.date/spring-boot
+   - Add versions when both OSS and commercial support end
+   - The Hibernate team maintains Spring Boot compatibility on a best-effort basis
+
+### After updating
+
+Run `rake test` to verify (see "Running Tests" above). Check that no project series unexpectedly changed lifecycle status by reviewing which series reference the integration versions you changed (grep for the integration key in `_data/projects/*/releases/*/series.yml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ podman run --rm -t --userns=keep-id -u $UID:$GID \
 - The workspace directory must be mounted to `/home/dev/website`
 - Use `--rm` to clean up the container after execution
 - The `Z` flag on the volume mount handles SELinux contexts
+- If rootless podman fails with `newuidmap: write to uid_map failed: Operation not permitted`, fall back to `sudo podman --storage-driver=vfs` (drop the `--userns=keep-id -u $UID:$GID` flags). Run `sudo podman system reset --force` once first to switch storage drivers.
 
 ## Updating Integration Versions
 
@@ -104,6 +105,15 @@ Check each integration against its upstream source:
    - Add versions when both OSS and commercial support end
    - The Hibernate team maintains Spring Boot compatibility on a best-effort basis
 
+### Checking for missing series.yml constraints
+
+When a new version of Quarkus or Spring Boot is released, the corresponding Hibernate project series should already reference it in their `integration_constraints`. To verify nothing is missing:
+
+1. Build the site with `rake clean gen` (see "Running the Build" above)
+2. Read `_site/community/integrations/index.html` and inspect the Quarkus and Spring Boot tables
+3. The latest upstream version should appear as a row — if it's missing, a `series.yml` file needs a constraint update
+4. Check for gaps: every version between the oldest and newest should have a row (versions are collapsed into ranges like "3.35 → 3.36" when consecutive versions map to the same Hibernate series)
+
 ### After updating
 
-Run `rake test` to verify (see "Running Tests" above). Check that no project series unexpectedly changed lifecycle status by reviewing which series reference the integration versions you changed (grep for the integration key in `_data/projects/*/releases/*/series.yml`).
+Run `rake test` to verify (see "Running Tests" above). Then build the site and inspect the integrations page as described above. Check that no project series unexpectedly changed lifecycle status by reviewing which series reference the integration versions you changed (grep for the integration key in `_data/projects/*/releases/*/series.yml`).

--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -22,11 +22,12 @@ java:
   inactive_series:
     # Only EOL'd Java versions mentioned in still-supported project series need to be here.
     # They are generally the more recent non-LTS versions (except *the* most recent one, of course).
-    - "20"
-    - "21"
-    - "22"
-    - "23"
-    - "24"
+    # Do NOT add LTS versions (17, 21, 25, ...): they have years of support.
+    # For EOL dates, see https://endoflife.date/oracle-jdk
+    - "20" # non-LTS, EOL Sep 2023
+    - "22" # non-LTS, EOL Sep 2024
+    - "23" # non-LTS, EOL Mar 2025
+    - "24" # non-LTS, EOL Sep 2025
 orm:
   name: Hibernate ORM
   url: /orm/
@@ -91,23 +92,25 @@ wildfly:
     # For release dates, see https://www.wildfly.org/events/
     # For included versions, see https://github.com/wildfly/wildfly/blob/main/pom.xml
     # For included versions in preview (EE 11), see https://github.com/wildfly/wildfly/blob/main/boms/preview-ee/pom.xml
-    - "41" # Planned
+    - "41" # Released Jul 16th 2026
 rheap:
   name: Red Hat EAP
   url: https://www.redhat.com/en/technologies/jboss-middleware/application-platform
   downstream: true
   hibernate_involvement: true
   active_series:
-    - "8.1"
+    # For lifecycle dates, see https://endoflife.date/red-hat-jboss-eap
+    - "8.1" # Full Support until Feb 2028
   els_series:
-    - "6.4"
-    - "7.4"
+    - "6.4" # ELS-2 (guidance only, no fixes) until Dec 2028
+    - "7.4" # ELS-1 until Oct 2027
 spring_boot:
   name: Spring Boot
   url: https://spring.io/projects/spring-boot
   downstream: true
   inactive_series:
     # Maintained on a best-effort basis.
+    # For lifecycle dates, see https://endoflife.date/spring-boot
     - "1.5"
     - "2.0"
     - "2.2"

--- a/_data/projects/orm/releases/4.2/series.yml
+++ b/_data/projects/orm/releases/4.2/series.yml
@@ -62,3 +62,5 @@ integration_constraints:
     version: '2.0'
   java_ee:
     version: '6'  # Derived from JPA 2.0 → Java EE 6
+  rheap:
+    version: '6.4'

--- a/_data/projects/search/releases/4.4/series.yml
+++ b/_data/projects/search/releases/4.4/series.yml
@@ -40,5 +40,7 @@ integration_constraints:
       - '8'
   orm:
     version: '4.2'
+  rheap:
+    version: '6.4'
   lucene:
     version: '3.6'

--- a/_data/projects/validator/releases/4.3/series.yml
+++ b/_data/projects/validator/releases/4.3/series.yml
@@ -40,3 +40,5 @@ integration_constraints:
     version: '1.0'
   java_ee:
     version: '6'
+  rheap:
+    version: '6.4'


### PR DESCRIPTION
## Summary

- Remove Java 21 from `inactive_series` — it's LTS (premier support until 2028), not EOL'd, contradicting the comment's own criteria
- Update WildFly 41 comment from "Planned" to released date (Jul 16th 2026)
- Add lifecycle reference URLs and EOL date comments for Java, Red Hat EAP, and Spring Boot entries
- Add missing `rheap: '6.4'` constraints to ORM 4.2, Search 4.4, Validator 4.3 (EAP 6.4 ships these versions but the constraint was absent)
- Document the integration version update procedure and version checking workflow in CLAUDE.md
- Document podman fallback for environments where rootless podman fails

## Test plan

- [x] `rake test` passes (66 examples, 0 failures)
- [x] Built site and inspected `/community/integrations/` — Quarkus and Spring Boot matrices are complete with no gaps
- [ ] Verify Java 21 row now appears in the Java compatibility matrix on the integrations page