### PR TITLE
Show cross-project compatibility in release pages

### DIFF
--- a/_data/integrations.yml
+++ b/_data/integrations.yml
@@ -28,12 +28,6 @@ java:
     - "22" # non-LTS, EOL Sep 2024
     - "23" # non-LTS, EOL Mar 2025
     - "24" # non-LTS, EOL Sep 2025
-orm:
-  name: Hibernate ORM
-  url: /orm/
-search:
-  name: Hibernate Search
-  url: /search/
 java_ee_jpa:
   name: JPA
   url: https://www.oracle.com/technetwork/java/javaee/tech/persistence-jsp-140049.html

--- a/_ext/release_file_parser.rb
+++ b/_ext/release_file_parser.rb
@@ -45,6 +45,8 @@ module Awestruct
 
         # After parsing all projects, compute integration compatibility tables
         computeIntegrationCompatibility()
+        computeIntegrationDisplayOrder()
+        computeSeriesIntegrations()
       end
 
       def findReleaseFiles(project)
@@ -189,6 +191,7 @@ module Awestruct
         series[:integration_constraints]&.each do |integration_key,integration_constraint|
           integration = @site.integrations[integration_key]
           integration_constraint[:active] = false
+          next if integration.nil?
           next unless integration[:downstream] && integration[:hibernate_involvement]
 
           # Check if this series is in the active_series list
@@ -431,6 +434,91 @@ module Awestruct
           # Mark if there are any older series
           integration[:has_older_series] = integration[:version_ranges].any? { |vr| !vr[:displayed] }
         end
+      end
+
+      # Compute the canonical display order for integrations and projects:
+      # non-downstream integrations, then Hibernate projects, then downstream integrations.
+      # Stored as site.integration_display_order for use by templates and other methods.
+      def computeIntegrationDisplayOrder()
+        order = []
+        @site.integrations&.each do |id, integration|
+          order << id unless integration[:downstream]
+        end
+        @projects_hash.each do |id, _|
+          order << id
+        end
+        @site.integrations&.each do |id, integration|
+          order << id if integration[:downstream]
+        end
+        @site[:integration_display_order] = order
+      end
+
+      # Build series[:integrations] by merging forward constraints (from
+      # integration_constraints) with reverse constraints (other projects
+      # that reference this series), using site.integration_display_order.
+      def computeSeriesIntegrations()
+        @projects_hash.each do |project_id, project|
+          next if project[:release_series].nil?
+
+          project[:release_series].each do |series_version, series|
+            integrations = {}
+
+            @site[:integration_display_order].each do |id|
+              forward = series[:integration_constraints]&.[](id)
+              if forward
+                integrations[id] = forward
+              elsif @projects_hash.key?(id)
+                reverse = reverseProjectConstraint(project_id, series_version, id)
+                integrations[id] = reverse if reverse
+              end
+            end
+
+            series[:integrations] = integrations unless integrations.empty?
+          end
+        end
+      end
+
+      # For a given project series, find all series of another project that
+      # reference it in their integration_constraints. Returns a constraint
+      # hash ({:version => ...}) or nil.
+      def reverseProjectConstraint(project_id, series_version, other_project_id)
+        other_project = @projects_hash[other_project_id]
+        return nil if other_project[:release_series].nil?
+        return nil if other_project[:superproject_id] == project_id
+
+        matching_series = []
+        other_project[:release_series].each do |other_series_version, other_series|
+          next if other_series[:integration_constraints].nil?
+          constraint = other_series[:integration_constraints][project_id]
+          next if constraint.nil? || constraint[:version].nil?
+
+          if Version.new(series_version).matches?(constraint[:version])
+            comment = extractCommentFromConstraint(constraint[:version], series_version)
+            matching_series << { :version => other_series_version, :comment => comment, :status => nil }
+          end
+        end
+
+        return nil if matching_series.empty?
+
+        matching_series.sort_by! { |m| Version.new(m[:version]) }
+        packed = packProjectVersionsIntoRanges(matching_series)
+
+        constraint_versions = packed.map do |match|
+          version = match[:version]
+          comment = match[:comment]
+          if comment
+            if version.is_a?(Hash) && version.key?(:from)
+              { :from => version[:from], :to => version[:to], :comment => comment }
+            else
+              { :value => version, :comment => comment }
+            end
+          else
+            version
+          end
+        end
+
+        constraint_version = constraint_versions.length == 1 ? constraint_versions.first : constraint_versions
+        { :version => constraint_version }
       end
 
       # Pack consecutive integration versions with identical project compatibility into ranges

--- a/_ext/releases.rb
+++ b/_ext/releases.rb
@@ -32,13 +32,13 @@ module Awestruct
         return project.release_series[version]
       end
 
-      def integration_constraint(constraint)
+      def integration_constraint(constraint, link_prefix = nil)
         version = constraint[:version]
         if version.nil?
           return nil
         end
         if version.is_a?(Array)
-          rendered = version.map { |v| integration_constraint_version(v) }
+          rendered = version.map { |v| integration_constraint_version(v, true, link_prefix) }
           if rendered.length <= 1
             rendered.join
           elsif rendered.length == 2
@@ -47,20 +47,23 @@ module Awestruct
             rendered[0..-2].join(", ") + " or " + rendered[-1]
           end
         else
-          integration_constraint_version(version)
+          integration_constraint_version(version, true, link_prefix)
         end
       end
 
-      def integration_constraint_version(version, includeComment = true)
+      def integration_constraint_version(version, includeComment = true, link_prefix = nil)
         if version.is_a?(Hash)
           if version.key?(:from)
-            "#{integration_constraint_version(version.from, includeComment)}&nbsp;&rarr;&nbsp;#{integration_constraint_version(version.to, includeComment)}" +
-              (includeComment && version.key?(:comment) ? " (#{version.comment})" : "")
+            "#{integration_constraint_version(version[:from], includeComment, link_prefix)}&nbsp;&rarr;&nbsp;#{integration_constraint_version(version[:to], includeComment, link_prefix)}" +
+              (includeComment && version.key?(:comment) ? " (#{version[:comment]})" : "")
           else
-            version.value.to_s + (includeComment && version.key?(:comment) ? " (#{version.comment})" : "")
+            val = version[:value].to_s
+            rendered_val = link_prefix ? "link:#{link_prefix}#{val}/[#{val}]" : val
+            rendered_val + (includeComment && version.key?(:comment) ? " (#{version[:comment]})" : "")
           end
         else
-          version.to_s
+          val = version.to_s
+          link_prefix ? "link:#{link_prefix}#{val}/[#{val}]" : val
         end
       end
     end

--- a/_layouts/project/project-releases-series.html.haml
+++ b/_layouts/project/project-releases-series.html.haml
@@ -23,7 +23,7 @@ project_hero_partial: project/hero-series.html.haml
   #toctitle
     Quick links
   %ul
-    - unless series.integration_constraints.nil? || series.integration_constraints.empty?
+    - unless series[:integrations].nil? || series[:integrations].empty?
       %li
         %a.item(href="#compatibility")
           Compatibility
@@ -89,24 +89,27 @@ project_hero_partial: project/hero-series.html.haml
     of any bugs or problems you encounter.
     ====
 
-- unless series.integration_constraints.nil? || series.integration_constraints.empty?
+- unless series[:integrations].nil? || series[:integrations].empty?
   %h2{:id => "compatibility"} Compatibility
   %table.ui.collapsing.definition.table.striped.celled.unstackable.center.aligned
-    - # Integration constraints must be in the same order as in integrations.yml
-    - site.integrations.each do |integration_id, integration|
-      - constraint = series.integration_constraints[integration_id]
-      - if constraint
-        - integration = site.integrations[integration_id]
-        %tr
-          %td.left.aligned
-            %a{:href => "#{integration&.url}"}
-              = integration&.name
+    - series[:integrations].each do |integration_id, constraint|
+      - integration = site.integrations[integration_id]
+      - project = site.projects[integration_id]
+      - link_prefix = project ? "/#{integration_id}/releases/" : nil
+      %tr
+        %td.left.aligned
+          %a{:href => integration&.url || "/#{integration_id}/"}
+            = integration&.name || project&.name
+          - if project
+            %a.ui.mini.icon.button{:href => "/#{integration_id}/releases/#compatibility-matrix", :title => "See all compatible versions"}
+              %i.icon.list
+          - elsif integration
             %a.ui.mini.icon.button{:href => "/community/integrations/##{integration_id}", :title => "See all compatible versions"}
               %i.icon.list
-          %td
-            :asciidoc
-              :doctype: inline
-              #{integration_constraint(constraint)}
+        %td
+          :asciidoc
+            :doctype: inline
+            #{integration_constraint(constraint, link_prefix)}
   %p
     Not compatible with your requirements? Have a look at the
     %a{:href => "../"}

--- a/_layouts/project/project-releases.html.haml
+++ b/_layouts/project/project-releases.html.haml
@@ -90,7 +90,8 @@ project_buttons_partial: project/releases-buttons.html.haml
                   %i.right.arrow.icon
                   More info
 
-- if project_description.active_release_series.any? { |series| !series.integration_constraints.nil? }
+- if project_description.active_release_series.any? { |series| !series[:integrations].nil? && !series[:integrations].empty? }
+  - all_integration_ids = site.integration_display_order.select { |id| project_description.active_release_series.any? { |s| s[:integrations]&.key?(id) } }
   %h2#compatibility-matrix Compatibility matrix
   %table.ui.definition.table.unstackable.celled.striped.center.aligned
     %thead
@@ -104,28 +105,30 @@ project_buttons_partial: project/releases-buttons.html.haml
           %th
             = series.version
     %tbody
-      - site.integrations.each do |integration_id, integration|
-        - has_constraint = false
-        - project_description.active_release_series.each do |series|
-          - if series.integration_constraints[integration_id]
-            - has_constraint = true
-        - if has_constraint
-          %tr
-            %td.left.aligned
-              %a{:href => "#{integration['url']}"}
-                = integration["name"]
+      - all_integration_ids.each do |integration_id|
+        - integration = site.integrations[integration_id]
+        - project = site.projects[integration_id]
+        - link_prefix = project ? "/#{integration_id}/releases/" : nil
+        %tr
+          %td.left.aligned
+            %a{:href => integration&.url || "/#{integration_id}/"}
+              = integration&.name || project&.name
+            - if project
+              %a.ui.mini.icon.button{:href => "/#{integration_id}/releases/#compatibility-matrix", :title => "See all compatible versions"}
+                %i.icon.list
+            - elsif integration
               %a.ui.mini.icon.button{:href => "/community/integrations/##{integration_id}", :title => "See all compatible versions"}
                 %i.icon.list
-              - project_description.active_release_series.each do |series|
-                - constraint = series.integration_constraints[integration_id]
-                - if constraint == nil
-                  %td.disabled
-                    N/A
-                - else
-                  %td
-                    :asciidoc
-                      :doctype: inline
-                      #{integration_constraint(constraint)}
+            - project_description.active_release_series.each do |series|
+              - constraint = series[:integrations]&.[](integration_id)
+              - if constraint == nil
+                %td.disabled
+                  N/A
+              - else
+                %td
+                  :asciidoc
+                    :doctype: inline
+                    #{integration_constraint(constraint, link_prefix)}
   %p
     See also
     %a{:href => "/support/"}


### PR DESCRIPTION
## Summary

- For every project series, automatically display which other Hibernate projects reference it in their `integration_constraints` — e.g. ORM release pages now show compatible Search, Reactive, and NoSQL versions
- Ordering is centralized in a single `site.integration_display_order` array: libraries/specs, then Hibernate projects, then downstream frameworks
- Project version numbers in compatibility matrices are clickable links to their release pages, with a "See all compatible versions" button linking to `/<project>/releases/#compatibility-matrix`
- Removes `orm`/`search` from `integrations.yml` since reverse compatibility is now computed automatically for all projects

## Test plan

- [x] Verify `rake test` passes (66 specs)
- [x] Build the site with `rake clean gen` and inspect `/orm/releases/` — matrix should show Java, Jakarta Persistence, Jakarta Data, Jakarta EE, MongoDB Extension, Hibernate Search, Hibernate Reactive, Hibernate NoSQL, Quarkus, WildFly, Red Hat EAP, Spring Boot (in that order)
- [x] Inspect `/search/releases/` — matrix should show Hibernate ORM in the projects section
- [x] Inspect a series page like `/orm/releases/7.0/` — compatibility table should include reverse references with clickable version links
- [x] Verify `/community/integrations/` is unchanged (no project entries leaked in)